### PR TITLE
Allow overriding news permalink directory via config strings

### DIFF
--- a/src/_data/strings-base.json
+++ b/src/_data/strings-base.json
@@ -2,5 +2,6 @@
 	"product_name": "Products",
 	"product_permalink_dir": "products",
 	"event_name": "Events",
-	"event_permalink_dir": "events"
+	"event_permalink_dir": "events",
+	"news_permalink_dir": "news"
 }

--- a/src/_data/strings.json
+++ b/src/_data/strings.json
@@ -3,5 +3,6 @@
 	"product_permalink_dir": "products",
 	"menus_name": "Menus",
 	"event_name": "Events",
-	"event_permalink_dir": "events"
+	"event_permalink_dir": "events",
+	"news_permalink_dir": "news"
 }

--- a/src/news/news.11tydata.mjs
+++ b/src/news/news.11tydata.mjs
@@ -1,7 +1,12 @@
 import { buildPostMeta } from '../_lib/schema-helper.mjs';
+import strings from '../_data/strings.js';
 
 export default {
   eleventyComputed: {
-    meta: data => buildPostMeta(data)
+    meta: data => buildPostMeta(data),
+    permalink: (data) => {
+      const dir = strings.news_permalink_dir || "news";
+      return `/${dir}/${data.page.fileSlug}/`;
+    }
   }
 };

--- a/src/news/news.json
+++ b/src/news/news.json
@@ -1,6 +1,5 @@
 {
 	"layout": "news-post.html",
-	"permalink": "/news/{{ page.fileSlug }}/index.html",
 	"tags": "news",
 	"navigationParent": "News"
 }


### PR DESCRIPTION
## Summary
- Adds support for customizing the news permalink directory through configuration
- Introduces `news_permalink_dir` in base and main strings data files
- Updates news template to compute permalinks dynamically using the configured directory
- Removes static permalink declaration from `news.json` to allow dynamic control

## Changes

### Configuration
- Added `news_permalink_dir` key with default value "news" in `strings-base.json` and `strings.json` to centralize path configuration

### News Template
- Modified `news.11tydata.mjs` to compute permalinks using the configured directory from strings data
- Permalink format updated to `/${dir}/${data.page.fileSlug}/`, where `dir` is configurable

### Content
- Removed static `permalink` field from `news.json` to enable dynamic permalink generation

## Test plan
- [x] Verified that news posts have permalinks reflecting the default `news` directory
- [x] Tested changing `news_permalink_dir` to custom values to confirm permalinks update accordingly
- [x] Confirmed no build or runtime errors after removing static permalink field
- [x] Validated URLs resolve correctly with new permalink structure

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/88569add-50f4-4809-8f2a-ff46521c841c