### PR TITLE
Add autoHeaderImage config option for automatic header image selection

### DIFF
--- a/src/_data/config.json
+++ b/src/_data/config.json
@@ -5,6 +5,7 @@
 	"sticky_mobile_nav": true,
 	"horizontal_nav": true,
 	"enable_theme_switcher": true,
+	"autoHeaderImage": true,
 	"template_repo_url": "https://github.com/chobbledotcom/chobble-template",
 	"chobble_link": "https://chobble.com/services/chobble-template/",
 	"stripe_publishable_key": null,

--- a/src/_data/config.mjs
+++ b/src/_data/config.mjs
@@ -6,6 +6,7 @@ const DEFAULTS = {
 	horizontal_nav: true,
 	homepage_news: true,
 	homepage_products: true,
+	autoHeaderImage: true,
 	formspark_id: null,
 	botpoison_public_key: null,
 	stripe_publishable_key: null,

--- a/src/_lib/schema-helper.mjs
+++ b/src/_lib/schema-helper.mjs
@@ -22,9 +22,12 @@ function buildBaseMeta(data) {
 		description: data.meta_description || data.short_description,
 	};
 
+	const autoHeaderImage = data.config?.autoHeaderImage ?? true;
+	const galleryFallback = autoHeaderImage && data.gallery?.[0];
+
 	let imageSource =
 		data.header_image ||
-		(data.gallery && data.gallery[0]) ||
+		galleryFallback ||
 		data.image ||
 		null;
 


### PR DESCRIPTION
## Summary
- Introduces a new configuration option `autoHeaderImage` to enable or disable automatic selection of a header image
- Defaults this option to `true` in both JSON and MJS config files
- Updates meta-data image source logic to respect `autoHeaderImage` setting and use gallery fallback accordingly

## Changes

### Configuration Updates
- Added `autoHeaderImage` flag in `src/_data/config.json` with default value `true`
- Added `autoHeaderImage` flag in `src/_data/config.mjs` defaults

### Logic Updates
- Modified `buildBaseMeta` function in `src/_lib/schema-helper.mjs`:
  - Reads `autoHeaderImage` from config with a default of `true`
  - Uses this flag to decide if the first gallery image should be used as fallback for header image

## Test plan
- [x] Verify that `autoHeaderImage` config is properly loaded and defaults to `true`
- [x] Confirm that when enabled, meta image uses gallery fallback if no explicit header image is set
- [x] Confirm that when disabled, gallery fallback is ignored and header image is not automatically set
- [x] Check that no breaking changes occur in metadata image resolution

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8ae56e97-f37a-4a12-838b-ed298f916187