### PR TITLE
Add support for news item images on homepage news list

### DIFF
--- a/src/_includes/news-list-item.html
+++ b/src/_includes/news-list-item.html
@@ -1,0 +1,12 @@
+<li>
+  {% assign item = post %}
+  {% assign widths = config.products.product_thumb_widths %}
+  {% assign sizes = config.products.product_thumb_sizes %}
+  {% include "thumbnail-image-link.html" %}
+
+  <p><strong>{{ post.date | date: "%b %-d, %Y" }}</strong></p>
+
+  {%- if post.data.subtitle -%}
+    <p>{{- post.data.subtitle -}}</p>
+  {%- endif -%}
+</li>

--- a/src/_layouts/home.html
+++ b/src/_layouts/home.html
@@ -14,7 +14,28 @@ layout: base
 {%- if homepage.show_news and collections.news.size > 0 -%}
   <hr />
   {%- render_snippet "homepage-news-header", "<h3>Latest Posts</h3>" -%}
-  {% include "news-post-list.html", limit: 2 %}
+
+  {%- comment -%} Check if all news posts have images {%- endcomment -%}
+  {%- assign all_have_images = true -%}
+  {%- for post in collections.news -%}
+    {%- unless post.data.header_image -%}
+      {%- assign all_have_images = false -%}
+      {%- break -%}
+    {%- endunless -%}
+  {%- endfor -%}
+
+  {%- if all_have_images -%}
+    {%- comment -%} Use item layout when all posts have images {%- endcomment -%}
+    {%- assign posts = collections.news | reverse -%}
+    <ul class="items-list">
+      {%- for post in posts limit: 2 -%}
+        {% include "news-list-item.html" %}
+      {%- endfor -%}
+    </ul>
+  {%- else -%}
+    {%- comment -%} Use text list when some posts lack images {%- endcomment -%}
+    {% include "news-post-list.html", limit: 2 %}
+  {%- endif -%}
 {%- endif -%}
 
 {%- assign categories = collections.categories | getFeaturedCategories -%}

--- a/src/news/1970-01-01-first.md
+++ b/src/news/1970-01-01-first.md
@@ -1,5 +1,5 @@
 ---
-header_image: placeholder.jpg
+header_image: placeholder-wide-1.jpg
 header_text: "New Blog Revitalises Jaded Internet"
 meta_description:
 meta_title: New Blog System | Chobble Template

--- a/src/news/1980-01-01-second.md
+++ b/src/news/1980-01-01-second.md
@@ -1,5 +1,5 @@
 ---
-header_image: placeholder.jpg
+header_image: placeholder-wide-2.jpg
 header_text: Second Blog Post Fails To Excite
 meta_description:
 meta_title: Second Blog Post | Chobble Template


### PR DESCRIPTION
## Summary
- Introduces image support for news items on the homepage news section
- Displays news items with thumbnail images when all posts have header images
- Falls back to simple text list display if any news post lacks an image
- Updates two example news posts with widescreen header images

## Changes

### New Features
- Created `news-list-item.html` include to render individual news posts with image thumbnails, dates, and optional subtitles
- Modified `home.html` layout to conditionally render either the new image-based news list or the existing text-based list
  - Checks if all news posts contain `header_image` data before choosing layout

### Content Updates
- Updated `1970-01-01-first.md` and `1980-01-01-second.md` news posts with new widescreen image references (`header_image` field)

## Test plan
- Verified homepage shows image thumbnails when all news items have header images
- Confirmed homepage falls back to text-only list if any news post lacks an image
- Checked that the date and subtitle appear correctly beneath the image in the news list
- Ensured no layout regressions on homepage news section after changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d3ceb815-c8b8-4e99-a70d-d36371ce1356