### PR TITLE
Notify build failures via ntfy in GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,12 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          curl -d "Build failed: ${{ github.repository }} @ ${{ github.ref_name }}" \
+               -H "Title: Build Failure" \
+               -H "Priority: high" \
+               -H "Tags: warning,github" \
+               "${{ secrets.NTFY_URL }}"


### PR DESCRIPTION
## Summary
- Adds ntfy-based notification for failed builds in GitHub Actions
- Keeps ntfy endpoint secure via repository secrets (NTFY_URL)

## Changes

### CI Workflow
- **Notify on failure**: New step in .github/workflows/test.yml that runs only when tests fail
- Sends a curl request to the ntfy endpoint with build details
- Payload includes repository name and branch reference
- Headers: Title: Build Failure, Priority: high, Tags: warning,github

### Security
- Uses secrets.NTFY_URL to securely store the ntfy endpoint

## Test plan
- [x] Trigger a failing test to verify that a notification is sent
- [x] Confirm the notification payload includes repository and branch information
- [x] Ensure no notification is sent on successful runs
- [x] Verify NTFY_URL secret is configured in the repository


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/14c13d73-3745-474d-9b9f-8033f0c65cd4