### PR TITLE
Add externalLinksTargetBlank flag with tests

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 import { configureCacheBuster } from "./src/_lib/cache-buster.js";
 import { configureCategories } from "./src/_lib/categories.js";
+import { configureExternalLinks } from "./src/_lib/external-links.js";
 import { configureFeed } from "./src/_lib/feed.js";
 import { configureFileUtils } from "./src/_lib/file-utils.js";
 import { configureICal } from "./src/_lib/ical.mjs";
@@ -31,6 +32,7 @@ export default async function (eleventyConfig) {
 
 	configureCacheBuster(eleventyConfig);
 	configureCategories(eleventyConfig);
+	configureExternalLinks(eleventyConfig);
 	await configureFeed(eleventyConfig);
 	configureFileUtils(eleventyConfig);
 	configureICal(eleventyConfig);

--- a/src/_data/config.json
+++ b/src/_data/config.json
@@ -6,6 +6,7 @@
 	"horizontal_nav": true,
 	"enable_theme_switcher": true,
 	"autoHeaderImage": true,
+	"externalLinksTargetBlank": false,
 	"template_repo_url": "https://github.com/chobbledotcom/chobble-template",
 	"chobble_link": "https://chobble.com/services/chobble-template/",
 	"stripe_publishable_key": null,

--- a/src/_data/config.mjs
+++ b/src/_data/config.mjs
@@ -7,6 +7,7 @@ const DEFAULTS = {
 	homepage_news: true,
 	homepage_products: true,
 	autoHeaderImage: true,
+	externalLinksTargetBlank: false,
 	formspark_id: null,
 	botpoison_public_key: null,
 	stripe_publishable_key: null,

--- a/src/_includes/footer-socials.html
+++ b/src/_includes/footer-socials.html
@@ -3,9 +3,10 @@
     {%- if social[1] -%}
       <li>
         <a
-          target="_blank"
           href="{{ social[1] }}"
           title="{{ site.name }} on {{ social[0] }}"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           <img
             width="48"

--- a/src/_lib/external-links.js
+++ b/src/_lib/external-links.js
@@ -1,0 +1,88 @@
+import {JSDOM} from "jsdom";
+
+const isExternalUrl = (url) => {
+	if (!url || typeof url !== "string") {
+		return false;
+	}
+	return url.startsWith("http://") || url.startsWith("https://");
+};
+
+const getExternalLinkAttributes = (url, config) => {
+	if (!isExternalUrl(url)) {
+		return "";
+	}
+
+	const attrs = [];
+	if (config?.externalLinksTargetBlank) {
+		attrs.push('target="_blank"');
+		attrs.push('rel="noopener noreferrer"');
+	}
+
+	return attrs.length > 0 ? " " + attrs.join(" ") : "";
+};
+
+const externalLinkFilter = (url, config) => {
+	return getExternalLinkAttributes(url, config);
+};
+
+const transformExternalLinks = (content, config) => {
+	if (!content || !content.includes("<a")) {
+		return content;
+	}
+
+	if (!config?.externalLinksTargetBlank) {
+		return content;
+	}
+
+	const {
+		window: {document},
+	} = new JSDOM(content);
+
+	const links = document.querySelectorAll("a[href]");
+
+	links.forEach((link) => {
+		const href = link.getAttribute("href");
+		if (isExternalUrl(href)) {
+			link.setAttribute("target", "_blank");
+			link.setAttribute("rel", "noopener noreferrer");
+		}
+	});
+
+	return new JSDOM(document.documentElement.outerHTML).serialize();
+};
+
+const createExternalLinksTransform = (eleventyConfig) => {
+	return (content, outputPath) => {
+		if (!outputPath || !outputPath.endsWith(".html")) {
+			return content;
+		}
+
+		if (outputPath.includes("/feed.")) {
+			return content;
+		}
+
+		const config = eleventyConfig.globalData?.config;
+		return transformExternalLinks(content, config);
+	};
+};
+
+const configureExternalLinks = (eleventyConfig) => {
+	eleventyConfig.addFilter("externalLinkAttrs", (url) => {
+		const config = eleventyConfig.globalData?.config;
+		return externalLinkFilter(url, config);
+	});
+
+	eleventyConfig.addTransform(
+		"externalLinks",
+		createExternalLinksTransform(eleventyConfig),
+	);
+};
+
+export {
+	isExternalUrl,
+	getExternalLinkAttributes,
+	externalLinkFilter,
+	transformExternalLinks,
+	createExternalLinksTransform,
+	configureExternalLinks,
+};

--- a/test/external-links.test.js
+++ b/test/external-links.test.js
@@ -1,0 +1,556 @@
+import {
+	createMockEleventyConfig,
+	createTestRunner,
+	expectStrictEqual,
+	expectFunctionType,
+	expectTrue,
+	expectFalse,
+} from "./test-utils.js";
+
+import {
+	isExternalUrl,
+	getExternalLinkAttributes,
+	externalLinkFilter,
+	transformExternalLinks,
+	createExternalLinksTransform,
+	configureExternalLinks,
+} from "../src/_lib/external-links.js";
+
+const testCases = [
+	{
+		name: "isExternalUrl-http",
+		description: "Detects HTTP URLs as external",
+		test: () => {
+			const result = isExternalUrl("http://example.com");
+			expectTrue(result, "Should return true for HTTP URLs");
+		},
+	},
+	{
+		name: "isExternalUrl-https",
+		description: "Detects HTTPS URLs as external",
+		test: () => {
+			const result = isExternalUrl("https://example.com");
+			expectTrue(result, "Should return true for HTTPS URLs");
+		},
+	},
+	{
+		name: "isExternalUrl-relative",
+		description: "Detects relative URLs as internal",
+		test: () => {
+			const result = isExternalUrl("/about");
+			expectFalse(result, "Should return false for relative URLs");
+		},
+	},
+	{
+		name: "isExternalUrl-absolute-path",
+		description: "Detects absolute paths as internal",
+		test: () => {
+			const result = isExternalUrl("/pages/about");
+			expectFalse(result, "Should return false for absolute paths");
+		},
+	},
+	{
+		name: "isExternalUrl-hash",
+		description: "Detects hash links as internal",
+		test: () => {
+			const result = isExternalUrl("#section");
+			expectFalse(result, "Should return false for hash links");
+		},
+	},
+	{
+		name: "isExternalUrl-mailto",
+		description: "Detects mailto links as internal",
+		test: () => {
+			const result = isExternalUrl("mailto:test@example.com");
+			expectFalse(result, "Should return false for mailto links");
+		},
+	},
+	{
+		name: "isExternalUrl-null",
+		description: "Handles null input gracefully",
+		test: () => {
+			const result = isExternalUrl(null);
+			expectFalse(result, "Should return false for null");
+		},
+	},
+	{
+		name: "isExternalUrl-undefined",
+		description: "Handles undefined input gracefully",
+		test: () => {
+			const result = isExternalUrl(undefined);
+			expectFalse(result, "Should return false for undefined");
+		},
+	},
+	{
+		name: "isExternalUrl-empty-string",
+		description: "Handles empty string gracefully",
+		test: () => {
+			const result = isExternalUrl("");
+			expectFalse(result, "Should return false for empty string");
+		},
+	},
+	{
+		name: "isExternalUrl-non-string",
+		description: "Handles non-string input gracefully",
+		test: () => {
+			const result1 = isExternalUrl(123);
+			expectFalse(result1, "Should return false for number");
+
+			const result2 = isExternalUrl({url: "http://example.com"});
+			expectFalse(result2, "Should return false for object");
+
+			const result3 = isExternalUrl(["http://example.com"]);
+			expectFalse(result3, "Should return false for array");
+		},
+	},
+	{
+		name: "getExternalLinkAttributes-disabled",
+		description: "Returns empty string when config flag is false",
+		test: () => {
+			const config = {externalLinksTargetBlank: false};
+			const result = getExternalLinkAttributes("https://example.com", config);
+			expectStrictEqual(result, "", "Should return empty string when flag is false");
+		},
+	},
+	{
+		name: "getExternalLinkAttributes-enabled",
+		description: "Returns target and rel attributes when config flag is true",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = getExternalLinkAttributes("https://example.com", config);
+			expectStrictEqual(
+				result,
+				' target="_blank" rel="noopener noreferrer"',
+				"Should return target and rel attributes when flag is true",
+			);
+		},
+	},
+	{
+		name: "getExternalLinkAttributes-internal-link",
+		description: "Returns empty string for internal links regardless of config",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = getExternalLinkAttributes("/about", config);
+			expectStrictEqual(
+				result,
+				"",
+				"Should return empty string for internal links",
+			);
+		},
+	},
+	{
+		name: "getExternalLinkAttributes-no-config",
+		description: "Handles missing config gracefully",
+		test: () => {
+			const result = getExternalLinkAttributes("https://example.com", null);
+			expectStrictEqual(
+				result,
+				"",
+				"Should return empty string when config is null",
+			);
+		},
+	},
+	{
+		name: "getExternalLinkAttributes-undefined-config",
+		description: "Handles undefined config gracefully",
+		test: () => {
+			const result = getExternalLinkAttributes(
+				"https://example.com",
+				undefined,
+			);
+			expectStrictEqual(
+				result,
+				"",
+				"Should return empty string when config is undefined",
+			);
+		},
+	},
+	{
+		name: "getExternalLinkAttributes-http-enabled",
+		description: "Works with HTTP URLs when enabled",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = getExternalLinkAttributes("http://example.com", config);
+			expectStrictEqual(
+				result,
+				' target="_blank" rel="noopener noreferrer"',
+				"Should work with HTTP URLs",
+			);
+		},
+	},
+	{
+		name: "externalLinkFilter-basic",
+		description: "externalLinkFilter delegates to getExternalLinkAttributes",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = externalLinkFilter("https://example.com", config);
+			expectStrictEqual(
+				result,
+				' target="_blank" rel="noopener noreferrer"',
+				"Should delegate to getExternalLinkAttributes",
+			);
+		},
+	},
+	{
+		name: "transformExternalLinks-disabled",
+		description: "Returns content unchanged when config flag is false",
+		test: () => {
+			const config = {externalLinksTargetBlank: false};
+			const html = '<a href="https://example.com">Link</a>';
+			const result = transformExternalLinks(html, config);
+			expectStrictEqual(
+				result,
+				html,
+				"Should return unchanged HTML when disabled",
+			);
+		},
+	},
+	{
+		name: "transformExternalLinks-no-links",
+		description: "Returns content unchanged when no links present",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const html = "<p>No links here</p>";
+			const result = transformExternalLinks(html, config);
+			expectStrictEqual(
+				result,
+				html,
+				"Should return unchanged HTML when no links",
+			);
+		},
+	},
+	{
+		name: "transformExternalLinks-external-link",
+		description: "Adds target and rel to external links",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const html = '<html><body><a href="https://example.com">Link</a></body></html>';
+			const result = transformExternalLinks(html, config);
+
+			expectTrue(
+				result.includes('target="_blank"'),
+				"Should add target attribute",
+			);
+			expectTrue(
+				result.includes('rel="noopener noreferrer"'),
+				"Should add rel attribute",
+			);
+		},
+	},
+	{
+		name: "transformExternalLinks-internal-link",
+		description: "Does not modify internal links",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const html = '<html><body><a href="/about">About</a></body></html>';
+			const result = transformExternalLinks(html, config);
+
+			expectFalse(
+				result.includes('target="_blank"'),
+				"Should not add target to internal links",
+			);
+		},
+	},
+	{
+		name: "transformExternalLinks-mixed-links",
+		description: "Handles mix of external and internal links",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const html =
+				'<html><body><a href="https://example.com">External</a><a href="/about">Internal</a></body></html>';
+			const result = transformExternalLinks(html, config);
+
+			expectTrue(
+				result.includes('href="https://example.com"'),
+				"Should preserve external URL",
+			);
+			expectTrue(result.includes('href="/about"'), "Should preserve internal URL");
+			expectTrue(
+				result.includes('target="_blank"'),
+				"Should add target to external link",
+			);
+		},
+	},
+	{
+		name: "transformExternalLinks-preserves-existing-attributes",
+		description: "Preserves other link attributes",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const html =
+				'<html><body><a href="https://example.com" class="button" id="link1">Link</a></body></html>';
+			const result = transformExternalLinks(html, config);
+
+			expectTrue(result.includes('class="button"'), "Should preserve class");
+			expectTrue(result.includes('id="link1"'), "Should preserve id");
+		},
+	},
+	{
+		name: "transformExternalLinks-http-and-https",
+		description: "Handles both HTTP and HTTPS URLs",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const html =
+				'<html><body><a href="http://example.com">HTTP</a><a href="https://example.com">HTTPS</a></body></html>';
+			const result = transformExternalLinks(html, config);
+
+			const targetCount = (result.match(/target="_blank"/g) || []).length;
+			expectStrictEqual(
+				targetCount,
+				2,
+				"Should add target to both HTTP and HTTPS links",
+			);
+		},
+	},
+	{
+		name: "transformExternalLinks-null-content",
+		description: "Handles null content gracefully",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = transformExternalLinks(null, config);
+			expectStrictEqual(result, null, "Should return null for null content");
+		},
+	},
+	{
+		name: "transformExternalLinks-empty-content",
+		description: "Handles empty content gracefully",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = transformExternalLinks("", config);
+			expectStrictEqual(result, "", "Should return empty string");
+		},
+	},
+	{
+		name: "createExternalLinksTransform-basic",
+		description: "Creates transform function",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			const transform = createExternalLinksTransform(mockConfig);
+
+			expectFunctionType(
+				transform,
+				undefined,
+				"Should return a transform function",
+			);
+		},
+	},
+	{
+		name: "createExternalLinksTransform-html-only",
+		description: "Only processes HTML files",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			mockConfig.globalData = {config: {externalLinksTargetBlank: true}};
+			const transform = createExternalLinksTransform(mockConfig);
+
+			const cssContent = "body { color: red; }";
+			const result = transform(cssContent, "style.css");
+			expectStrictEqual(
+				result,
+				cssContent,
+				"Should not process non-HTML files",
+			);
+		},
+	},
+	{
+		name: "createExternalLinksTransform-skip-feeds",
+		description: "Skips feed files",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			mockConfig.globalData = {config: {externalLinksTargetBlank: true}};
+			const transform = createExternalLinksTransform(mockConfig);
+
+			const feedContent = '<a href="https://example.com">Link</a>';
+			const result = transform(feedContent, "feed.xml");
+			expectStrictEqual(result, feedContent, "Should skip feed files");
+		},
+	},
+	{
+		name: "createExternalLinksTransform-processes-html",
+		description: "Processes HTML files",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			mockConfig.globalData = {config: {externalLinksTargetBlank: true}};
+			const transform = createExternalLinksTransform(mockConfig);
+
+			const html =
+				'<html><body><a href="https://example.com">Link</a></body></html>';
+			const result = transform(html, "index.html");
+
+			expectTrue(
+				result.includes('target="_blank"'),
+				"Should process HTML files",
+			);
+		},
+	},
+	{
+		name: "configureExternalLinks-basic",
+		description: "Adds externalLinkAttrs filter to Eleventy config",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			configureExternalLinks(mockConfig);
+
+			expectFunctionType(
+				mockConfig.filters,
+				"externalLinkAttrs",
+				"Should add externalLinkAttrs filter",
+			);
+		},
+	},
+	{
+		name: "configureExternalLinks-adds-transform",
+		description: "Adds HTML transform to Eleventy config",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			configureExternalLinks(mockConfig);
+
+			expectFunctionType(
+				mockConfig.transforms,
+				"externalLinks",
+				"Should add externalLinks transform",
+			);
+		},
+	},
+	{
+		name: "configureExternalLinks-filter-works-enabled",
+		description: "Configured filter works correctly when enabled",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			mockConfig.globalData = {
+				config: {externalLinksTargetBlank: true},
+			};
+
+			configureExternalLinks(mockConfig);
+
+			const result = mockConfig.filters.externalLinkAttrs("https://example.com");
+			expectStrictEqual(
+				result,
+				' target="_blank" rel="noopener noreferrer"',
+				"Filter should return attributes when enabled",
+			);
+		},
+	},
+	{
+		name: "configureExternalLinks-filter-works-disabled",
+		description: "Configured filter works correctly when disabled",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			mockConfig.globalData = {
+				config: {externalLinksTargetBlank: false},
+			};
+
+			configureExternalLinks(mockConfig);
+
+			const result = mockConfig.filters.externalLinkAttrs("https://example.com");
+			expectStrictEqual(
+				result,
+				"",
+				"Filter should return empty string when disabled",
+			);
+		},
+	},
+	{
+		name: "configureExternalLinks-filter-internal-link",
+		description: "Configured filter handles internal links",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+			mockConfig.globalData = {
+				config: {externalLinksTargetBlank: true},
+			};
+
+			configureExternalLinks(mockConfig);
+
+			const result = mockConfig.filters.externalLinkAttrs("/about");
+			expectStrictEqual(
+				result,
+				"",
+				"Filter should return empty string for internal links",
+			);
+		},
+	},
+	{
+		name: "configureExternalLinks-filter-no-global-data",
+		description: "Configured filter handles missing global data",
+		test: () => {
+			const mockConfig = createMockEleventyConfig();
+
+			configureExternalLinks(mockConfig);
+
+			const result = mockConfig.filters.externalLinkAttrs("https://example.com");
+			expectStrictEqual(
+				result,
+				"",
+				"Filter should return empty string when global data is missing",
+			);
+		},
+	},
+	{
+		name: "edge-case-url-with-spaces",
+		description: "Handles URLs with spaces",
+		test: () => {
+			const result = isExternalUrl("https://example.com/path with spaces");
+			expectTrue(result, "Should still detect as external URL");
+		},
+	},
+	{
+		name: "edge-case-url-with-query-params",
+		description: "Handles URLs with query parameters",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = getExternalLinkAttributes(
+				"https://example.com?foo=bar&baz=qux",
+				config,
+			);
+			expectStrictEqual(
+				result,
+				' target="_blank" rel="noopener noreferrer"',
+				"Should work with query parameters",
+			);
+		},
+	},
+	{
+		name: "edge-case-url-with-fragment",
+		description: "Handles external URLs with fragments",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = getExternalLinkAttributes(
+				"https://example.com#section",
+				config,
+			);
+			expectStrictEqual(
+				result,
+				' target="_blank" rel="noopener noreferrer"',
+				"Should work with fragments",
+			);
+		},
+	},
+	{
+		name: "security-rel-attribute",
+		description: "Always includes rel attribute with noopener and noreferrer",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const result = getExternalLinkAttributes("https://example.com", config);
+
+			expectTrue(
+				result.includes('rel="noopener noreferrer"'),
+				"Should include rel attribute with noopener and noreferrer",
+			);
+		},
+	},
+	{
+		name: "pure-function-test",
+		description: "Functions should be pure and not modify inputs",
+		test: () => {
+			const config = {externalLinksTargetBlank: true};
+			const configCopy = JSON.parse(JSON.stringify(config));
+
+			getExternalLinkAttributes("https://example.com", config);
+
+			expectStrictEqual(
+				JSON.stringify(config),
+				JSON.stringify(configCopy),
+				"Should not modify config object",
+			);
+		},
+	},
+];
+
+export default createTestRunner("external-links", testCases);

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -36,6 +36,10 @@ const createMockEleventyConfig = () => ({
     this.extensions = this.extensions || {};
     this.extensions[ext] = config;
   },
+  addTransform: function(name, fn) {
+    this.transforms = this.transforms || {};
+    this.transforms[name] = fn;
+  },
   setLayoutsDirectory: function(dir) {
     this.layoutsDirectory = dir;
   },


### PR DESCRIPTION
## Summary
- Introduces the externalLinksTargetBlank config flag (default false) to control adding target/rel attributes to external links
- Automatically processes external links in HTML via a new Eleventy transform when enabled
- Provides a filter to generate external link attributes and a robust test suite to validate behavior

## Changes
### Core functionality
- Added src/_lib/external-links.js containing:
  - isExternalUrl(url): detects external HTTP/HTTPS URLs
  - getExternalLinkAttributes(url, config): returns appropriate attrs or empty string
  - externalLinkFilter(url, config): filter wrapper for external link attributes
  - transformExternalLinks(content, config): DOM-based transformation to add target and rel to external links
  - createExternalLinksTransform(eleventyConfig): Eleventy transform factory that processes HTML files (skips feeds) using the config
  - configureExternalLinks(eleventyConfig): registers the externalLinkAttrs filter and externalLinks transform

### Eleventy configuration
- Updated .eleventy.js to import and configureExternalLinks, wiring it into the Eleventy setup

### Data/config defaults
- Added default flag to disable external link targeting by default:
  - src/_data/config.json: "externalLinksTargetBlank": false
  - src/_data/config.mjs: externalLinksTargetBlank: false

### UI/HTML tweaks
- Updated src/_includes/footer-socials.html to ensure external social links include target="_blank" and rel="noopener noreferrer" where appropriate

### Tests
- Added test/external-links.test.js with comprehensive test coverage for:
  - isExternalUrl behavior across HTTP/HTTPS, relative paths, hashes, mailto, null/undefined inputs, spaces in URLs
  - getExternalLinkAttributes behavior for enabled/disabled configurations, internal links, and query/fragment parameters
  - externalLinkFilter delegates to getExternalLinkAttributes
  - transformExternalLinks behavior:
    - disabled mode leaves content unchanged
    - no-links scenario
    - adds target and rel for external links
    - does not modify internal links
    - handles mixed external/internal links
    - preserves existing link attributes (class, id, etc.)
    - handles HTTP and HTTPS URLs
  - createExternalLinksTransform:
    - basic creation, HTML-only processing, feed skipping, and HTML processing validation
  - configureExternalLinks:
    - adds externalLinkAttrs filter and externalLinks transform
    - filter behavior when enabled/disabled
    - filter behavior for internal links and missing global data
- Updated test/test-utils.js to support addTransform in the mock Eleventy config (needed for tests)

## Test plan
- Run the test suite (e.g., npm test or the project’s test runner)
- Verify:
  - With externalLinksTargetBlank: true, external links get target="_blank" and rel="noopener noreferrer"
  - Internal links are not modified
  - The externalLinkAttrs filter returns correct strings based on config
  - The transform handles HTML files and skips feeds
  - The Eleventy config exposes both filter and transform as expected

## Notes
- The default remains non-breaking (flag off) until explicitly enabled
- Tests emphasize purity (no mutation of input config objects)
- Footer tweaks ensure external links are semantically correct and secure


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e6a74eba-11f7-467d-b1a9-4afca338df7d