### PR TITLE
Add PayPal order complete page with cart clearing

### DIFF
--- a/src/assets/js/cart.js
+++ b/src/assets/js/cart.js
@@ -412,6 +412,10 @@ class PayPalCart {
       params.append(`quantity_${itemNum}`, item.quantity);
     });
 
+    // Add return URL for after payment completion
+    const returnUrl = `${window.location.origin}/order-complete/`;
+    params.append("return", returnUrl);
+
     // Redirect to PayPal
     window.location.href = `${baseUrl}?${params.toString()}`;
   }

--- a/src/pages/order-complete.md
+++ b/src/pages/order-complete.md
@@ -1,0 +1,18 @@
+---
+title: Order Complete
+header_text: Thank You for Your Order
+meta_description: Thank you for your order
+meta_title: Order Complete
+no_index: true
+---
+
+Your payment has been received. Thank you for your order!
+
+We'll be in touch with you soon regarding your purchase.
+
+<script>
+  // Clear the shopping cart after successful PayPal payment
+  (function() {
+    localStorage.removeItem('paypal_cart');
+  })();
+</script>


### PR DESCRIPTION
- Create order-complete page that displays after PayPal payment
- Add return URL to PayPal checkout to redirect users back to site
- Clear cart from localStorage when landing on order-complete page