### PR TITLE
Create checkout complete page layout

### DIFF
--- a/src/_layouts/checkout-complete.html
+++ b/src/_layouts/checkout-complete.html
@@ -1,0 +1,15 @@
+---
+layout: page
+---
+
+{{ content }}
+
+<script>
+  (function() {
+    localStorage.removeItem('shopping_cart');
+    var cartIcon = document.getElementById('cart-icon');
+    if (cartIcon) {
+      cartIcon.style.display = 'none';
+    }
+  })();
+</script>

--- a/src/pages/order-complete.md
+++ b/src/pages/order-complete.md
@@ -5,14 +5,8 @@ meta_description: Thank you for your order
 meta_title: Order Complete
 no_index: true
 permalink: /checkout-success/
-layout: page.html
+layout: checkout-complete.html
 ---
 Your payment has been received. Thank you for your order!
 
 We'll be in touch with you soon regarding your purchase.
-
-<script>
-  (function() {
-    localStorage.removeItem('shopping_cart');
-  })();
-</script>


### PR DESCRIPTION
- Create new checkout-complete.html layout that inherits from page
- Move cart-clearing script from order-complete.md into the layout
- Add script to hide #cart-icon on checkout complete page
- Update order-complete.md to use the new layout