### PR TITLE
Show only root level locations in layout

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,6 +12,7 @@ import { configureImages } from "./src/_lib/image.js";
 import { configureInlineAsset } from "./src/_lib/inline-asset.js";
 import { configureLayoutAliases } from "./src/_lib/layout-aliases.js";
 import { configureLimitCollections } from "./src/_lib/limit-collections.js";
+import { configureLocations } from "./src/_lib/locations.js";
 import { configureMenus } from "./src/_lib/menus.js";
 import { configureNavigation } from "./src/_lib/navigation.js";
 import { configureOpeningTimes } from "./src/_lib/opening-times.js";
@@ -48,6 +49,7 @@ export default async function (eleventyConfig) {
   configureICal(eleventyConfig);
   configureImages(eleventyConfig);
   configureInlineAsset(eleventyConfig);
+  configureLocations(eleventyConfig);
   configureMenus(eleventyConfig);
   await configureNavigation(eleventyConfig);
   configureOpeningTimes(eleventyConfig);

--- a/src/_layouts/locations.html
+++ b/src/_layouts/locations.html
@@ -4,5 +4,5 @@ layout: base
 
 {{- content -}}
 
-{%- assign locations = collections.location -%}
+{%- assign locations = collections.location | getRootLocations -%}
 {%- include "items.html", items: locations -%}

--- a/src/_lib/locations.js
+++ b/src/_lib/locations.js
@@ -1,0 +1,8 @@
+const getRootLocations = (locations) =>
+  locations?.filter((loc) => !loc.data.parentLocation) || [];
+
+const configureLocations = (eleventyConfig) => {
+  eleventyConfig.addFilter("getRootLocations", getRootLocations);
+};
+
+export { getRootLocations, configureLocations };


### PR DESCRIPTION
Services within subdirectories (e.g., fulchester/gizmo-cleaning) are now excluded from the main locations listing page, as these represent services at a location rather than locations themselves.