### PR TITLE
Fix autosizes script to ignore remote images

### DIFF
--- a/src/assets/js/autosizes.js
+++ b/src/assets/js/autosizes.js
@@ -92,6 +92,11 @@
       ) {
         continue;
       }
+      // Skip remote images (http/https URLs) - only process local images
+      const src = img.getAttribute("src") || "";
+      if (src.startsWith("http://") || src.startsWith("https://")) {
+        continue;
+      }
       if (!didFirstContentfulPaintRun) {
         for (const attribute of attributes) {
           if (img.hasAttribute(attribute)) {


### PR DESCRIPTION
Images with http:// or https:// URLs are now ignored by the autosizes script to prevent issues with remote image handling.