### PR TITLE
Fix precommit script modifying package.json

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,8 +4,7 @@
 		".eleventy.js",
 		"test/**/*.js",
 		"src/_data/**/*.{js,mjs}",
-		"src/**/*.11tydata.mjs",
-		"src/_js/**/*.js"
+		"src/**/*.11tydata.js"
 	],
 	"project": ["**/*.{js,mjs}"],
 	"ignore": [
@@ -14,9 +13,11 @@
 		"_site/**"
 	],
 	"ignoreDependencies": [
-		"@zachleat/heading-anchors"
+		"@zachleat/heading-anchors",
+		"@botpoison/browser",
+		"@hotwired/turbo"
 	],
-	"ignoreBinaries": ["biome"],
+	"ignoreBinaries": [],
 	"ignoreExportsUsedInFile": true,
 	"rules": {
 		"exports": "off"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 		"cpd": "jscpd",
 		"knip": "knip",
 		"knip:fix": "knip --fix",
-		"lint": "biome check .",
-		"lint:fix": "biome check --write .",
+		"lint": "npx @biomejs/biome check .",
+		"lint:fix": "npx @biomejs/biome check --write .",
 		"precommit": "run-s lint:fix cpd knip:fix test"
 	},
 	"devDependencies": {

--- a/src/_lib/properties.js
+++ b/src/_lib/properties.js
@@ -1,5 +1,5 @@
-import { sortByOrderThenTitle } from "./sorting.js";
 import { addGallery } from "./products.js";
+import { sortByOrderThenTitle } from "./sorting.js";
 
 const createPropertiesCollection = (collectionApi) => {
   const properties = collectionApi.getFilteredByTag("property") || [];

--- a/src/assets/js/_bundle.js
+++ b/src/assets/js/_bundle.js
@@ -3,6 +3,7 @@
 // NPM dependencies
 import "@hotwired/turbo";
 import Botpoison from "@botpoison/browser";
+
 window.Botpoison = Botpoison;
 
 // Site JS

--- a/test/strings.test.js
+++ b/test/strings.test.js
@@ -1,7 +1,7 @@
+import fg from "fast-glob";
 import fs from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
-import fg from "fast-glob";
 import strings from "../src/_data/strings.js";
 import baseStrings from "../src/_data/strings-base.json" with { type: "json" };
 import {


### PR DESCRIPTION
- Add @botpoison/browser and @hotwired/turbo to knip ignoreDependencies so knip --fix doesn't remove them (they're browser-side deps that static analysis can't detect as used)
- Update lint scripts to use npx @biomejs/biome instead of bare biome
- Fix knip entry patterns: .11tydata.mjs -> .11tydata.js, remove non-existent src/_js directory
- Remove biome from ignoreBinaries since it now runs via npx