### PR TITLE
Fix mobile availability calendar overlay being too small

### DIFF
--- a/src/css/availability-calendar.scss
+++ b/src/css/availability-calendar.scss
@@ -130,6 +130,7 @@ html:has(dialog.availability-calendar[open]) {
   dialog.availability-calendar {
     width: 100%;
     max-width: 100%;
+    height: 100vh;
     max-height: 100vh;
     border-radius: 0;
   }


### PR DESCRIPTION
Add explicit height: 100vh to the mobile dialog so it expands to fill
the viewport instead of shrinking to content size.