### PR TITLE
Only render popovers on pages that use them

### DIFF
--- a/src/_includes/availability-calendar.html
+++ b/src/_includes/availability-calendar.html
@@ -1,3 +1,4 @@
+{%- if unavailability_api_url -%}
 <dialog id="availability-calendar" class="availability-calendar">
   <header class="availability-header">
     <h2>Availability</h2>
@@ -9,3 +10,4 @@
     <p class="calendar-loading">Loading...</p>
   </div>
 </dialog>
+{%- endif -%}

--- a/src/_includes/image-popup.html
+++ b/src/_includes/image-popup.html
@@ -1,1 +1,3 @@
+{%- if gallery.size > 0 -%}
 <dialog id="image-popup" class="image-popup"></dialog>
+{%- endif -%}


### PR DESCRIPTION
Add conditionals to availability-calendar.html and image-popup.html
so they only render when their functionality is needed:
- availability-calendar: only when page has unavailability_api_url
- image-popup: only when page has a gallery