### PR TITLE
Replace lorem ipsum placeholder text with explanatory content

### DIFF
--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -16,8 +16,8 @@ eleventyNavigation:
 
 ## Get in Touch
 
-The contact form on this page is configured through contact-form.json, which defines the fields, labels, and validation rules. Form submissions are sent to Formspark when a formspark_id is set in config.json, or to a custom endpoint if contact_form_target is specified. Spam protection is handled by Botpoison when a public key is configured.
+The contact form is set up in contact-form.json. This file says what fields to show and what labels to use. When someone fills in the form, it gets sent to Formspark or to another address you choose. You can turn on Botpoison to stop spam.
 
-Form fields can be set to appear only on certain page types using the showOn property. This allows product pages to show a product-specific message field while event pages show an event enquiry field. The opening hours displayed above are pulled from site.json and rendered using the opening_times shortcode.
+Some fields can show only on some pages. For example, you can have one message box on product pages and a different one on event pages. The opening hours above come from site.json.
 
 **If you're looking for my real contact details check out my site at [chobble.com/contact](https://chobble.com/contact/)**

--- a/src/pages/products.md
+++ b/src/pages/products.md
@@ -12,8 +12,8 @@ eleventyNavigation:
 
 # Our Products
 
-This page uses the categories layout to display product categories. Each category is defined as a markdown file in the categories folder and can have a parent category to create a hierarchy. Categories marked as featured appear here on the main products page.
+This page shows product categories. Categories are files in the categories folder. You can put categories inside other categories to group them. Categories with featured set to true show up here.
 
-Products are stored as markdown files in the products folder. Each product can belong to multiple categories by listing category slugs in its frontmatter. Products support options with pricing and SKUs for e-commerce, specifications displayed as a table, features shown as a list, tabs for organising content, FAQs, and a gallery of images. Reviews from the reviews collection can be linked to products and will display with star ratings.
+Products are files in the products folder. A product can be in more than one category. You can add prices, a list of features, a table of specs, questions and answers, and photos. You can also link reviews to products. The reviews will show with star ratings.
 
-When filtering is enabled in the config, products can define filter attributes that generate a filter interface on listing pages. The system pre-generates filtered result pages to maintain a static site architecture.
+You can let people filter products. To do this, turn on filtering in the config file. Then add filter options to your products. The site makes a page for each filter choice.

--- a/src/pages/reviews.md
+++ b/src/pages/reviews.md
@@ -11,6 +11,6 @@ eleventyNavigation:
 
 ## Customer Feedback
 
-Reviews are stored as markdown files in the reviews folder with a date prefix in the filename for sorting. Each review has a name field for the reviewer and can include a URL to link their name, a rating from one to five stars, a thumbnail for their avatar, and a list of product slugs to associate the review with products.
+Reviews are files in the reviews folder. The filename starts with a date so they sort by time. Each review has the person's name. You can also add a link to their website, a star rating from one to five, a photo of them, and which products the review is about.
 
-Reviews do not generate their own pages. They appear here on the reviews listing and on the product pages they are linked to. The system calculates an average rating for each product from its linked reviews and displays this as stars. Reviews with hidden set to true in their frontmatter are excluded from the collection.
+Reviews do not get their own pages. They show up here and on product pages. The site works out the average star rating for each product. If you set hidden to true on a review, it will not show up anywhere.

--- a/src/pages/team.md
+++ b/src/pages/team.md
@@ -11,6 +11,6 @@ eleventyNavigation:
 
 ## Meet the Team
 
-Team members are stored as markdown files in the team folder. Each file generates its own page at /team/filename/ and appears in this listing. The frontmatter includes a title for the person's name, an image for their photo, a header_image for the banner on their page, and a snippet for the summary text shown in listings.
+Team members are files in the team folder. Each file makes its own page and shows up in this list. The file has a title for the name, an image for the photo, a header_image for the banner, and a snippet for the short text shown here.
 
-The listing displays each member's photo as a link to their page, their name, and their snippet. Photos are rendered at multiple sizes for responsive display. The markdown content of each file becomes the biography on their page, where it appears below a breadcrumb linking back to this team listing.
+This list shows each person's photo, name, and snippet. Click the photo to go to their page. The text you write in the file becomes their story on their page. Their page has a link back to this list.

--- a/src/team/jane-doe.md
+++ b/src/team/jane-doe.md
@@ -7,6 +7,6 @@ header_image: src/images/placeholder-wide-3.jpg
 
 > "You can add a quote from the team member here."
 
-This is another team member page showing how multiple members appear in the collection. The team folder can contain any number of markdown files and each one generates a page. Files are processed alphabetically by filename so you can prefix filenames with numbers to control the order.
+This is another team member page. You can add as many team members as you want. Just put more files in the team folder. Each file makes a page. The files show in order by filename. You can put numbers at the start of filenames to change the order.
 
-The layout renders the profile image at multiple widths for responsive display on different screen sizes. When viewed on the team listing page, the image links to this page. The collection is defined in team.json which sets the default layout and adds the team tag used by Eleventy to group these files together.
+The photo shows in different sizes for different screens. In the team list, you can click the photo to come to this page. The team.json file tells the site how to build these pages.

--- a/src/team/john-doe.md
+++ b/src/team/john-doe.md
@@ -7,6 +7,6 @@ header_image: src/images/placeholder-wide-2.jpg
 
 > "You can add a quote from the team member here."
 
-This page demonstrates the team member layout. The title field in the frontmatter sets the name displayed in the heading and listings. The image field references a file in the images folder and appears on both this page and the team listing. The header_image provides the banner at the top of this page. The snippet appears below the name in the team listing.
+This is a team member page. The title at the top of the file sets the name. The image field sets the photo. This photo shows here and in the team list. The header_image sets the banner at the top. The snippet is the short text that shows in the team list.
 
-The markdown content below the frontmatter becomes the biography. You can use any markdown formatting here including headings, lists, links, and blockquotes like the one above. The page includes a breadcrumb linking back to the team listing and uses the same header and footer as the rest of the site.
+The text you write in the file shows up here as the person's story. You can use headings, lists, links, and quotes like the one above. There is a link at the top to go back to the team list.


### PR DESCRIPTION
Replace Latin placeholder text in pages and team member files with
concise British English explanations of how each feature works.