### PR TITLE
Add missing descriptions to collection pages

### DIFF
--- a/src/pages/locations.md
+++ b/src/pages/locations.md
@@ -1,7 +1,7 @@
 ---
 header_image: src/images/placeholder.jpg
-header_text: Our Locations
-meta_description: Find us in your area. We serve multiple locations across the region.
+header_text: Locations
+meta_description:
 meta_title: Locations
 layout: locations.html
 permalink: "/locations/"
@@ -10,6 +10,10 @@ eleventyNavigation:
   order: 5
 ---
 
-# Our Service Areas
+# Locations
 
-We're proud to serve communities across the region. Find your nearest location below.
+This page shows locations. Locations are files in the locations folder. Each location can have a list of product categories. The location page will show products from those categories.
+
+Locations can have sub-pages for services. Put a markdown file in a folder with the same name as the location. The sub-page will appear under that location and link to sibling services.
+
+Properties can link to locations. When a property lists a location slug, it shows up on that location page. Each location page also shows links to other locations in the area list.

--- a/src/pages/menus.md
+++ b/src/pages/menus.md
@@ -9,6 +9,10 @@ eleventyNavigation:
 layout: menus.html
 permalink: /menus/
 ---
-# Our Menus
+# Menus
 
-Fresh vegan food for every occasion. Browse our menus below.
+This page shows menus. Menus are files in the menus folder. The system uses a three-level structure. Menus contain categories, and categories contain items.
+
+Menu categories are files in the menu-categories folder. Each category says which menus it belongs to. Menu items are files in the menu-items folder. Each item says which categories it belongs to. This lets you put the same item in more than one category or menu.
+
+You can mark items as vegan or gluten-free. The menu page shows a key with symbols for these. You can add more dietary indicators in the config.

--- a/src/pages/properties.md
+++ b/src/pages/properties.md
@@ -10,6 +10,10 @@ eleventyNavigation:
   order: 4
 ---
 
-# Our Properties
+# Properties
 
-Browse our selection of holiday let properties.
+This page shows properties. Properties are files in the properties folder. You can add bedrooms, bathrooms, how many people it sleeps, and a price per night. You can also add a list of features and questions with answers.
+
+Properties can link to locations. When you add location slugs to a property, it shows up on those location pages. You can also add filter attributes like number of bedrooms or whether pets are allowed. If you turn on filtering in the config, visitors can search by these attributes.
+
+If you use the Chobble booking system, you can add an availability calendar. Properties with featured set to true show on the homepage.


### PR DESCRIPTION
…ages

Replace placeholder content with explanatory text that describes how each collection works and connects to other parts of the template.