### PR TITLE
Refactor cart to use explicit mode option

### DIFF
--- a/src/_data/config.js
+++ b/src/_data/config.js
@@ -15,9 +15,47 @@ const DEFAULTS = {
   template_repo_url: "https://github.com/chobbledotcom/chobble-template",
   chobble_link: null,
   map_embed_src: null,
-  has_cart_enquiry_form: false,
+  cart_mode: null,
   has_products_filter: false,
 };
+
+const VALID_CART_MODES = ["paypal", "stripe", "quote"];
+
+function validateCartConfig(config) {
+  const { cart_mode, paypal_email, stripe_publishable_key, checkout_api_url, form_target } = config;
+
+  if (!cart_mode) return;
+
+  if (!VALID_CART_MODES.includes(cart_mode)) {
+    throw new Error(
+      `Invalid cart_mode: "${cart_mode}". Must be one of: ${VALID_CART_MODES.join(", ")}, or null/omitted for no cart.`
+    );
+  }
+
+  if (cart_mode === "paypal") {
+    if (!paypal_email) {
+      throw new Error('cart_mode is "paypal" but paypal_email is not set in config.json');
+    }
+    if (!checkout_api_url) {
+      throw new Error('cart_mode is "paypal" but checkout_api_url is not set in config.json');
+    }
+  }
+
+  if (cart_mode === "stripe") {
+    if (!stripe_publishable_key) {
+      throw new Error('cart_mode is "stripe" but stripe_publishable_key is not set in config.json');
+    }
+    if (!checkout_api_url) {
+      throw new Error('cart_mode is "stripe" but checkout_api_url is not set in config.json');
+    }
+  }
+
+  if (cart_mode === "quote") {
+    if (!form_target) {
+      throw new Error('cart_mode is "quote" but neither formspark_id nor contact_form_target is set in config.json');
+    }
+  }
+}
 
 const DEFAULT_PRODUCT_DATA = {
   item_widths: "240,480,640",
@@ -59,6 +97,8 @@ export default function () {
     products: products,
   });
   merged.form_target = getFormTarget(merged);
+
+  validateCartConfig(merged);
 
   cachedConfig = merged;
   return merged;

--- a/src/_data/config.json
+++ b/src/_data/config.json
@@ -11,9 +11,10 @@
 	"externalLinksTargetBlank": false,
 	"template_repo_url": "https://github.com/chobbledotcom/chobble-template",
 	"chobble_link": "https://chobble.com/services/chobble-template/",
+	"cart_mode": null,
 	"checkout_api_url": null,
 	"stripe_publishable_key": null,
-	"paypal_email": "example@chobble.com",
+	"paypal_email": null,
 	"products": {
 		"item_widths": "240,480,640",
 		"gallery_thumb_widths": "240,480",

--- a/src/_includes/cart-overlay.html
+++ b/src/_includes/cart-overlay.html
@@ -1,7 +1,6 @@
 <dialog
   id="cart-overlay"
   class="cart-overlay"
-  data-paypal-email="{{ config.paypal_email }}"
   data-stripe-key="{{ config.stripe_publishable_key }}"
   data-checkout-api-url="{{ config.checkout_api_url }}"
 >
@@ -28,7 +27,7 @@
         You must spend at least 30p to check out
       </p>
       <div class="cart-checkout-buttons">
-        {%- if config.paypal_email -%}
+        {%- if config.cart_mode == "paypal" -%}
           <button class="cart-checkout cart-checkout-paypal" disabled>
             <svg class="payment-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M7.076 21.337H2.47a.641.641 0 0 1-.633-.74L4.944 2.296A.776.776 0 0 1 5.71 1.6h6.957c2.624 0 4.484.516 5.53 1.533.976.95 1.35 2.324 1.114 4.083-.028.21-.064.434-.108.672-.586 3.43-2.7 5.256-5.96 5.742a8.88 8.88 0 0 1-1.494.114H9.85a.776.776 0 0 0-.766.664l-.782 4.929z"/>
@@ -37,7 +36,7 @@
             PayPal
           </button>
         {%- endif -%}
-        {%- if config.stripe_publishable_key -%}
+        {%- if config.cart_mode == "stripe" -%}
           <button class="cart-checkout cart-checkout-stripe" disabled>
             <svg class="payment-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/>

--- a/src/_includes/product-options.html
+++ b/src/_includes/product-options.html
@@ -1,5 +1,5 @@
 {%- if options and options.size > 0 -%}
-  {%- if config.paypal_email or config.stripe_publishable_key or config.has_cart_enquiry_form -%}
+  {%- if config.cart_mode -%}
   <h2>Buy Now</h2>
   {%- if options.size == 1 -%}
     {%- assign option = options.first -%}

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -32,9 +32,9 @@
   </main>
   {%- include "footer.html" -%}
   {%- include "theme-switcher.html" -%}
-  {%- if config.has_cart_enquiry_form -%}
+  {%- if config.cart_mode == "quote" -%}
     {%- include "cart-icon-enquiry.html" -%}
-  {%- elsif config.paypal_email or config.stripe_publishable_key -%}
+  {%- elsif config.cart_mode == "paypal" or config.cart_mode == "stripe" -%}
     {%- include "cart-icon.html" -%}
     {%- include "cart-overlay.html" -%}
   {%- endif -%}

--- a/src/assets/js/cart.js
+++ b/src/assets/js/cart.js
@@ -405,14 +405,7 @@ class ShoppingCart {
     if (cart.length === 0) return;
 
     const checkoutApiUrl = this.getCheckoutApiUrl();
-
-    // If backend is configured, use PayPal Orders API
-    if (checkoutApiUrl) {
-      await this.checkoutWithPayPalBackend(checkoutApiUrl);
-    } else {
-      // Fall back to static URL redirect (no backend needed)
-      this.checkoutWithPayPalStatic();
-    }
+    await this.checkoutWithPayPalBackend(checkoutApiUrl);
   }
 
   // Helper to POST cart data to an API endpoint
@@ -462,41 +455,6 @@ class ShoppingCart {
       console.error("PayPal checkout failed:", error);
       alert("Failed to start checkout. Please try again.");
     }
-  }
-
-  // PayPal checkout via static URL redirect (no backend)
-  checkoutWithPayPalStatic() {
-    const cart = getCart();
-    const paypalEmail = this.cartOverlay.dataset.paypalEmail;
-
-    if (!paypalEmail) {
-      alert("PayPal is not configured");
-      return;
-    }
-
-    // Build PayPal checkout URL
-    const baseUrl = "https://www.paypal.com/cgi-bin/webscr";
-    const params = new URLSearchParams();
-
-    params.append("cmd", "_cart");
-    params.append("upload", "1");
-    params.append("business", paypalEmail);
-    params.append("currency_code", "GBP");
-
-    // Add each cart item
-    cart.forEach((item, index) => {
-      const itemNum = index + 1;
-      params.append(`item_name_${itemNum}`, item.item_name);
-      params.append(`amount_${itemNum}`, item.unit_price.toFixed(2));
-      params.append(`quantity_${itemNum}`, item.quantity);
-    });
-
-    // Add return URL for after payment completion
-    const returnUrl = `${window.location.origin}/order-complete/`;
-    params.append("return", returnUrl);
-
-    // Redirect to PayPal
-    window.location.href = `${baseUrl}?${params.toString()}`;
   }
 
   // Checkout with Stripe - redirects to dedicated checkout page


### PR DESCRIPTION
Replace implicit cart mode detection (based on payment credentials) with an explicit cart_mode option. This provides clearer configuration and removes the insecure static PayPal URL redirect.

Changes:
- Add cart_mode option: "paypal", "stripe", "quote", or null
- Add validateCartConfig() to enforce cart_mode requirements
- Remove has_cart_enquiry_form (replaced by cart_mode: "quote")
- Remove checkoutWithPayPalStatic() - all payments now require backend
- Remove data-paypal-email attribute from cart overlay
- Update templates to use cart_mode conditionals
- Update tests for new configuration model