### PR TITLE
Refactor canonical URL utility function

### DIFF
--- a/src/_lib/eleventy/canonical-url.js
+++ b/src/_lib/eleventy/canonical-url.js
@@ -1,30 +1,5 @@
-import site from "#data/site.json" with { type: "json" };
 import { canonicalUrl } from "#utils/canonical-url.js";
 
-function validateSiteUrl(url) {
-  if (!url) {
-    throw new Error("site.json is missing the 'url' field");
-  }
-
-  try {
-    const parsed = new URL(url);
-    if (!["http:", "https:"].includes(parsed.protocol)) {
-      throw new Error(
-        `site.json 'url' must use http or https protocol, got: ${url}`,
-      );
-    }
-  } catch (e) {
-    if (e.code === "ERR_INVALID_URL") {
-      throw new Error(`site.json 'url' is not a valid URL: ${url}`);
-    }
-    throw e;
-  }
-}
-
 export function configureCanonicalUrl(eleventyConfig) {
-  validateSiteUrl(site.url);
-
-  eleventyConfig.addFilter("canonicalUrl", (pageUrl) =>
-    canonicalUrl(site.url, pageUrl),
-  );
+  eleventyConfig.addFilter("canonicalUrl", canonicalUrl);
 }

--- a/src/_lib/eleventy/ical.js
+++ b/src/_lib/eleventy/ical.js
@@ -29,7 +29,7 @@ export function generateICalForEvent(event) {
     summary: event.data.title,
     description: event.data.subtitle || event.data.meta_description || "",
     location: event.data.event_location || "",
-    url: canonicalUrl(site.url, event.url),
+    url: canonicalUrl(event.url),
   });
 
   return calendar.toString();

--- a/src/_lib/utils/canonical-url.js
+++ b/src/_lib/utils/canonical-url.js
@@ -1,21 +1,49 @@
+import site from "#data/site.json" with { type: "json" };
+
 /**
- * Generates a canonical URL by properly joining a site URL and page path.
+ * Validates that site.url is a proper HTTP/HTTPS URL.
+ * @param {string} url - The URL to validate
+ * @throws {Error} If URL is missing or invalid
+ */
+function validateSiteUrl(url) {
+  if (!url) {
+    throw new Error("site.json is missing the 'url' field");
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      throw new Error(
+        `site.json 'url' must use http or https protocol, got: ${url}`,
+      );
+    }
+  } catch (e) {
+    if (e.code === "ERR_INVALID_URL") {
+      throw new Error(`site.json 'url' is not a valid URL: ${url}`);
+    }
+    throw e;
+  }
+}
+
+// Validate on module load
+validateSiteUrl(site.url);
+
+/**
+ * Generates a canonical URL by properly joining the site URL with a page path.
  * Prevents double slashes that occur when site.url ends with "/" and
  * page.url starts with "/".
  *
  * Root page "/" returns site URL without trailing slash.
  * All other pages preserve their trailing slashes.
  *
- * @param {string} siteUrl - The base site URL (e.g., "https://example.com" or "https://example.com/")
  * @param {string} pageUrl - The page path (e.g., "/quote/" or "quote")
  * @returns {string} The properly joined canonical URL
  */
-export function canonicalUrl(siteUrl, pageUrl) {
-  if (!siteUrl) return pageUrl || "/";
-  if (!pageUrl) return siteUrl.replace(/\/+$/, "");
+export function canonicalUrl(pageUrl) {
+  if (!pageUrl) return site.url.replace(/\/+$/, "");
 
   // Remove trailing slashes from site URL
-  const cleanSiteUrl = siteUrl.replace(/\/+$/, "");
+  const cleanSiteUrl = site.url.replace(/\/+$/, "");
 
   // Normalize page URL to start with a single slash
   const cleanPageUrl = "/" + pageUrl.replace(/^\/+/, "");

--- a/src/_lib/utils/schema-helper.js
+++ b/src/_lib/utils/schema-helper.js
@@ -20,7 +20,7 @@ function buildBaseMeta(data) {
 
   const meta = {
     ...baseMeta,
-    url: canonicalUrl(data.site.url, data.page.url),
+    url: canonicalUrl(data.page.url),
     title: data.title || data.meta_title || "Untitled",
     description: data.meta_description || data.subtitle,
   };

--- a/test/canonical-url.test.js
+++ b/test/canonical-url.test.js
@@ -2,78 +2,32 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import { canonicalUrl } from "#utils/canonical-url.js";
 
+// Site URL from site.json is https://example.chobble.com
+const SITE_URL = "https://example.chobble.com";
+
 describe("canonicalUrl", () => {
   it("joins site URL and page URL correctly", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com", "/quote/"),
-      "https://example.com/quote/",
-    );
-  });
-
-  it("handles site URL with trailing slash", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com/", "/quote/"),
-      "https://example.com/quote/",
-    );
-  });
-
-  it("handles site URL with multiple trailing slashes", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com///", "/quote/"),
-      "https://example.com/quote/",
-    );
+    assert.strictEqual(canonicalUrl("/quote/"), `${SITE_URL}/quote/`);
   });
 
   it("handles page URL without leading slash", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com", "quote/"),
-      "https://example.com/quote/",
-    );
+    assert.strictEqual(canonicalUrl("quote/"), `${SITE_URL}/quote/`);
   });
 
   it("handles page URL with multiple leading slashes", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com", "///quote/"),
-      "https://example.com/quote/",
-    );
+    assert.strictEqual(canonicalUrl("///quote/"), `${SITE_URL}/quote/`);
   });
 
-  it("handles both trailing and leading slashes", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com/", "/quote/"),
-      "https://example.com/quote/",
-    );
-  });
-
-  it("handles root page URL without trailing slash", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com", "/"),
-      "https://example.com",
-    );
-  });
-
-  it("handles root page URL even with trailing slash on site", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com/", "/"),
-      "https://example.com",
-    );
+  it("handles root page URL", () => {
+    assert.strictEqual(canonicalUrl("/"), SITE_URL);
   });
 
   it("handles empty page URL", () => {
-    assert.strictEqual(
-      canonicalUrl("https://example.com/", ""),
-      "https://example.com",
-    );
-  });
-
-  it("handles empty site URL", () => {
-    assert.strictEqual(canonicalUrl("", "/quote/"), "/quote/");
+    assert.strictEqual(canonicalUrl(""), SITE_URL);
   });
 
   it("handles null/undefined inputs", () => {
-    assert.strictEqual(canonicalUrl(null, "/quote/"), "/quote/");
-    assert.strictEqual(canonicalUrl(undefined, "/quote/"), "/quote/");
-    assert.strictEqual(canonicalUrl("https://example.com", null), "https://example.com");
-    assert.strictEqual(canonicalUrl("https://example.com", undefined), "https://example.com");
+    assert.strictEqual(canonicalUrl(null), SITE_URL);
+    assert.strictEqual(canonicalUrl(undefined), SITE_URL);
   });
 });


### PR DESCRIPTION
Move site.json import and URL validation into the utility module so callers no longer need to pass the site URL - they just provide the page path and the canonical URL is computed automatically.