### PR TITLE
Prevent duplicate product names in cart display

### DIFF
--- a/src/assets/js/cart.js
+++ b/src/assets/js/cart.js
@@ -196,8 +196,8 @@ class ShoppingCart {
           rawPrice: button.dataset.price,
         });
 
-        // Build full item name including option if present
-        const fullItemName = optionName
+        // Build full item name including option if present (avoid "Name - Name" duplication)
+        const fullItemName = optionName && optionName !== itemName
           ? `${itemName} - ${optionName}`
           : itemName;
 


### PR DESCRIPTION
When a product option has the same name as the product itself, now displays just the name once instead of "Name - Name".