### PR TITLE
Add see all reviews link for products

### DIFF
--- a/src/_data/config.json
+++ b/src/_data/config.json
@@ -19,5 +19,6 @@
 		"gallery_image_widths": "900,1300,1800",
 		"header_image_widths": "640,900,1300"
 	},
-	"timezone": "Europe/London"
+	"timezone": "Europe/London",
+	"reviews_truncate_limit": 10
 }

--- a/src/_includes/item-reviews-section.html
+++ b/src/_includes/item-reviews-section.html
@@ -2,7 +2,14 @@
   {% assign reviews = collections.reviews | getReviewsByProduct: page.fileSlug %}
   {%- if reviews.size > 0 -%}
     <h2 id="reviews">Reviews</h2>
-    {% include "reviews-list.html" %}
+    {% assign limit = config.reviews_truncate_limit %}
+    {%- if limit != -1 and reviews.size > limit -%}
+      {% assign reviews = reviews | slice: 0, limit %}
+      {% include "reviews-list.html" %}
+      <p><a href="{{ page.url }}reviews/">See all reviews</a></p>
+    {%- else -%}
+      {% include "reviews-list.html" %}
+    {%- endif -%}
   {%- endif -%}
   {%- include "etsy-buy-button.html" -%}
 {%- endif -%}

--- a/src/_layouts/item-reviews.html
+++ b/src/_layouts/item-reviews.html
@@ -1,0 +1,19 @@
+---
+layout: base
+---
+
+<section id="item">
+  <div class="title">
+    {% include "item-title.html" %}
+  </div>
+
+  {% include "item-gallery.html" %}
+
+  <div class="description">
+    {% assign reviews = collections.reviews | getReviewsByProduct: item.fileSlug %}
+    {%- if reviews.size > 0 -%}
+      <h2 id="reviews">Reviews</h2>
+      {% include "reviews-list.html" %}
+    {%- endif -%}
+  </div>
+</div>

--- a/src/pages/product-reviews.html
+++ b/src/pages/product-reviews.html
@@ -1,0 +1,9 @@
+---
+pagination:
+  data: collections.products
+  size: 1
+  alias: item
+permalink: "/{{ strings.product_permalink_dir }}/{{ item.fileSlug }}/reviews/"
+layout: item-reviews
+eleventyExcludeFromCollections: true
+---


### PR DESCRIPTION
Add configurable truncation for product reviews on item pages. When more reviews exist than the limit (default 10, configurable via reviews_truncate_limit in config.json), show truncated list with a 'See all reviews' link to /products/{slug}/reviews/.

- Add reviews_truncate_limit config option (-1 disables truncation)
- Create item-reviews.html layout for full reviews page
- Generate /reviews/ pages for each product via pagination