### PR TITLE
Add conditional reviews page generation based on review count

### DIFF
--- a/src/pages/product-reviews.html
+++ b/src/pages/product-reviews.html
@@ -1,6 +1,6 @@
 ---
 pagination:
-  data: collections.products
+  data: collections.productsWithReviewsPage
   size: 1
   alias: item
 permalink: "/{{ strings.product_permalink_dir }}/{{ item.fileSlug }}/reviews/"

--- a/src/utils/product-reviews-redirect.html
+++ b/src/utils/product-reviews-redirect.html
@@ -1,0 +1,10 @@
+---
+pagination:
+  data: collections.productReviewsRedirects
+  size: 1
+  alias: redirect
+permalink: "/{{ strings.product_permalink_dir }}/{{ redirect.fileSlug }}/reviews/index.html"
+eleventyExcludeFromCollections: true
+---
+{%- assign redirect_url = "/" | append: strings.product_permalink_dir | append: "/" | append: redirect.fileSlug | append: "/" -%}
+{%- include "redirect-page.html" -%}


### PR DESCRIPTION
Only generate separate /reviews/ pages for products with more reviews
than the reviews_truncate_limit config value. Products with fewer
reviews now redirect from /reviews/ back to the product page, since
all reviews are already visible there.