### PR TITLE
Make list item layout configurable via config.json

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,6 +27,7 @@ import { configureFileUtils } from "#eleventy/file-utils.js";
 import { configureICal } from "#eleventy/ical.js";
 import { configureJsConfig } from "#eleventy/js-config.js";
 import { configureLayoutAliases } from "#eleventy/layout-aliases.js";
+import { configureListItemFields } from "#eleventy/list-item-fields.js";
 import { configureOpeningTimes } from "#eleventy/opening-times.js";
 import { configurePdf } from "#eleventy/pdf.js";
 import { configureRecurringEvents } from "#eleventy/recurring-events.js";
@@ -59,6 +60,7 @@ export default async function (eleventyConfig) {
   configureCanonicalUrl(eleventyConfig);
   configureCategories(eleventyConfig);
   configureLayoutAliases(eleventyConfig);
+  configureListItemFields(eleventyConfig);
   await configureExternalLinks(eleventyConfig);
   await configureFeed(eleventyConfig);
   configureFileUtils(eleventyConfig);

--- a/src/_data/config.js
+++ b/src/_data/config.js
@@ -21,6 +21,7 @@ const DEFAULTS = {
   map_embed_src: null,
   cart_mode: null,
   has_products_filter: false,
+  list_item_fields: null, // null uses default: thumbnail, link, price, date, subtitle, location, event-date, cart-button
 };
 
 const VALID_CART_MODES = ["paypal", "stripe", "quote"];

--- a/src/_includes/list-item-date.html
+++ b/src/_includes/list-item-date.html
@@ -1,0 +1,3 @@
+{%- if item.data.date -%}
+  <p><strong>{{ item.data.date | date: "%b %-d, %Y" }}</strong></p>
+{%- endif -%}

--- a/src/_includes/list-item-event-date.html
+++ b/src/_includes/list-item-event-date.html
@@ -1,0 +1,6 @@
+{%- if item.data.recurring_date or item.data.event_date -%}
+  <p>
+    <strong>Date:</strong>
+    {{ item.data.recurring_date | default: item.data.event_date | date: "%b %-d, %Y" }}
+  </p>
+{%- endif -%}

--- a/src/_includes/list-item-link.html
+++ b/src/_includes/list-item-link.html
@@ -1,0 +1,3 @@
+<h3>
+  <a href="{{- item.url -}}#content">{{ item.data.title }}</a>
+</h3>

--- a/src/_includes/list-item-location.html
+++ b/src/_includes/list-item-location.html
@@ -1,0 +1,3 @@
+{%- if item.data.event_location -%}
+  <p><strong>Location:</strong> {{ item.data.event_location }}</p>
+{%- endif -%}

--- a/src/_includes/list-item-price.html
+++ b/src/_includes/list-item-price.html
@@ -1,0 +1,3 @@
+{%- if item.data.price -%}
+  <p>{{ item.data.price }}</p>
+{%- endif -%}

--- a/src/_includes/list-item-subtitle.html
+++ b/src/_includes/list-item-subtitle.html
@@ -1,0 +1,3 @@
+{%- if item.data.subtitle -%}
+  <p>{{ item.data.subtitle }}</p>
+{%- endif -%}

--- a/src/_includes/list-item-thumbnail.html
+++ b/src/_includes/list-item-thumbnail.html
@@ -1,0 +1,5 @@
+{%- if item.data.thumbnail -%}
+  <a class="image-link" href="{{ item.url }}#content">
+    {%- image item.data.thumbnail, item.data.title, widths -%}
+  </a>
+{%- endif -%}

--- a/src/_includes/list-item.html
+++ b/src/_includes/list-item.html
@@ -1,36 +1,23 @@
 <li>
-  {%- if item.data.thumbnail -%}
-    <a class="image-link" href="{{ item.url }}#content">
-      {%- image item.data.thumbnail, item.data.title, widths -%}
-    </a>
-  {%- endif -%}
-
-  <h3>
-    <a href="{{- item.url -}}#content">{{ item.data.title }}</a>
-  </h3>
-
-  {%- if item.data.price -%}
-    <p>{{ item.data.price }}</p>
-  {%- endif -%}
-
-  {%- if item.data.date -%}
-    <p><strong>{{ item.data.date | date: "%b %-d, %Y" }}</strong></p>
-  {%- endif -%}
-
-  {%- if item.data.subtitle -%}
-    <p>{{ item.data.subtitle }}</p>
-  {%- endif -%}
-
-  {%- if item.data.event_location -%}
-    <p><strong>Location:</strong> {{ item.data.event_location }}</p>
-  {%- endif -%}
-
-  {%- if item.data.recurring_date or item.data.event_date -%}
-    <p>
-      <strong>Date:</strong>
-      {{ item.data.recurring_date | default: item.data.event_date | date: "%b %-d, %Y" }}
-    </p>
-  {%- endif -%}
-
-  {%- include "list-item-cart-button.html" -%}
+  {%- assign fields = config | getListItemFields -%}
+  {%- for field in fields -%}
+    {%- case field -%}
+      {%- when "thumbnail" -%}
+        {%- include "list-item-thumbnail.html" -%}
+      {%- when "link" -%}
+        {%- include "list-item-link.html" -%}
+      {%- when "price" -%}
+        {%- include "list-item-price.html" -%}
+      {%- when "date" -%}
+        {%- include "list-item-date.html" -%}
+      {%- when "subtitle" -%}
+        {%- include "list-item-subtitle.html" -%}
+      {%- when "location" -%}
+        {%- include "list-item-location.html" -%}
+      {%- when "event-date" -%}
+        {%- include "list-item-event-date.html" -%}
+      {%- when "cart-button" -%}
+        {%- include "list-item-cart-button.html" -%}
+    {%- endcase -%}
+  {%- endfor -%}
 </li>

--- a/src/_lib/eleventy/list-item-fields.js
+++ b/src/_lib/eleventy/list-item-fields.js
@@ -1,0 +1,35 @@
+// Default field order matching original list-item.html
+// Field names match include files: list-item-{field}.html
+const DEFAULT_FIELDS = [
+  "thumbnail",
+  "link",
+  "price",
+  "date",
+  "subtitle",
+  "location",
+  "event-date",
+  "cart-button",
+];
+
+/**
+ * Get the field order from config, or return defaults
+ * @param {Object} config - The site config object
+ * @returns {string[]} - Array of field names in order
+ */
+function getFieldOrder(config) {
+  const fields = config?.list_item_fields;
+  if (!fields || !Array.isArray(fields) || fields.length === 0) {
+    return DEFAULT_FIELDS;
+  }
+  return fields;
+}
+
+/**
+ * Configure the list item fields filter
+ * @param {Object} eleventyConfig - Eleventy config object
+ */
+function configureListItemFields(eleventyConfig) {
+  eleventyConfig.addFilter("getListItemFields", getFieldOrder);
+}
+
+export { DEFAULT_FIELDS, getFieldOrder, configureListItemFields };

--- a/test/list-item-fields.test.js
+++ b/test/list-item-fields.test.js
@@ -1,0 +1,139 @@
+import {
+  DEFAULT_FIELDS,
+  getFieldOrder,
+} from "#eleventy/list-item-fields.js";
+import {
+  createTestRunner,
+  expectDeepEqual,
+} from "./test-utils.js";
+
+const testCases = [
+  // DEFAULT_FIELDS constant test
+  {
+    name: "DEFAULT_FIELDS-order",
+    description: "Default fields are in expected order",
+    test: () => {
+      expectDeepEqual(
+        DEFAULT_FIELDS,
+        [
+          "thumbnail",
+          "link",
+          "price",
+          "date",
+          "subtitle",
+          "location",
+          "event-date",
+          "cart-button",
+        ],
+        "Should have all fields in correct order",
+      );
+    },
+  },
+
+  // getFieldOrder tests
+  {
+    name: "getFieldOrder-default-empty-config",
+    description: "Returns default fields when config is empty object",
+    test: () => {
+      expectDeepEqual(
+        getFieldOrder({}),
+        DEFAULT_FIELDS,
+        "Should return default fields for empty config",
+      );
+    },
+  },
+  {
+    name: "getFieldOrder-default-null-field",
+    description: "Returns default fields when list_item_fields is null",
+    test: () => {
+      expectDeepEqual(
+        getFieldOrder({ list_item_fields: null }),
+        DEFAULT_FIELDS,
+        "Should return default fields when null",
+      );
+    },
+  },
+  {
+    name: "getFieldOrder-default-empty-array",
+    description: "Returns default fields when list_item_fields is empty array",
+    test: () => {
+      expectDeepEqual(
+        getFieldOrder({ list_item_fields: [] }),
+        DEFAULT_FIELDS,
+        "Should return default fields when empty array",
+      );
+    },
+  },
+  {
+    name: "getFieldOrder-default-null-config",
+    description: "Returns default fields when config is null",
+    test: () => {
+      expectDeepEqual(
+        getFieldOrder(null),
+        DEFAULT_FIELDS,
+        "Should return default fields when config is null",
+      );
+    },
+  },
+  {
+    name: "getFieldOrder-default-undefined-config",
+    description: "Returns default fields when config is undefined",
+    test: () => {
+      expectDeepEqual(
+        getFieldOrder(undefined),
+        DEFAULT_FIELDS,
+        "Should return default fields when config is undefined",
+      );
+    },
+  },
+  {
+    name: "getFieldOrder-custom-order",
+    description: "Returns custom field order from config",
+    test: () => {
+      const customFields = ["link", "price", "thumbnail"];
+      expectDeepEqual(
+        getFieldOrder({ list_item_fields: customFields }),
+        customFields,
+        "Should return custom field order",
+      );
+    },
+  },
+  {
+    name: "getFieldOrder-partial-fields",
+    description: "Returns partial field list from config",
+    test: () => {
+      const partialFields = ["link", "price"];
+      expectDeepEqual(
+        getFieldOrder({ list_item_fields: partialFields }),
+        partialFields,
+        "Should return partial field list",
+      );
+    },
+  },
+  {
+    name: "getFieldOrder-reordered",
+    description: "Returns fields in specified order",
+    test: () => {
+      const reordered = ["price", "thumbnail", "link", "subtitle"];
+      expectDeepEqual(
+        getFieldOrder({ list_item_fields: reordered }),
+        reordered,
+        "Should return fields in specified order",
+      );
+    },
+  },
+  {
+    name: "getFieldOrder-single-field",
+    description: "Returns single field when configured",
+    test: () => {
+      const singleField = ["link"];
+      expectDeepEqual(
+        getFieldOrder({ list_item_fields: singleField }),
+        singleField,
+        "Should return single field",
+      );
+    },
+  },
+];
+
+export default createTestRunner("list-item-fields", testCases);


### PR DESCRIPTION
Add ability to customize the order and visibility of fields in list-item.html through config.json's list_item_fields setting. Empty/null defaults to current order: thumbnail, link, price, date, subtitle, location, event-date, cart-button.

- Create individual list-item-*.html includes for each field
- Add list-item-fields.js with getListItemFields filter for ordering
- Update list-item.html to loop through configured fields
- Add tests for field ordering logic