### PR TITLE
Refactor area-list-shortcode from Liquid to JavaScript

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,6 +21,7 @@ import { configureTags } from "#collections/tags.js";
 // Eleventy plugins
 import { configureCacheBuster } from "#eleventy/cache-buster.js";
 import { configureCanonicalUrl } from "#eleventy/canonical-url.js";
+import { configureAreaList } from "#eleventy/area-list.js";
 import { configureExternalLinks } from "#eleventy/external-links.js";
 import { configureFeed } from "#eleventy/feed.js";
 import { configureFileUtils } from "#eleventy/file-utils.js";
@@ -56,6 +57,7 @@ export default async function (eleventyConfig) {
 
   // configureLayoutAliases(eleventyConfig);
 
+  configureAreaList(eleventyConfig);
   configureCacheBuster(eleventyConfig);
   configureCanonicalUrl(eleventyConfig);
   configureCategories(eleventyConfig);

--- a/src/_includes/area-list-shortcode.html
+++ b/src/_includes/area-list-shortcode.html
@@ -1,16 +1,1 @@
-{%- assign sorted_areas = collections.location | sort: "data.eleventyNavigation.key" -%}
-{%- assign filtered_areas = "" | split: "" -%}
-{%- for area in sorted_areas -%}
-  {%- assign url_segments = area.url | split: "/" -%}
-  {%- comment -%}Only include top-level locations (e.g. /locations/name/ has 3 segments when split){%- endcomment -%}
-  {%- if url_segments.size == 3 and area.url != page.url -%}
-    {%- assign filtered_areas = filtered_areas | push: area -%}
-  {%- endif -%}
-{%- endfor -%}
-
-{{ prefix }} {% for area in filtered_areas -%}
-<a href="{{ area.url }}#content">
-  {{- area.data.eleventyNavigation.key -}}
-</a>
-{%- unless forloop.last -%}{% if forloop.index == forloop.length | minus: 1 %} and {% else %},{% endif %}{% endunless -%}
-{%- endfor %}{{ suffix }}
+{% areaList collections.location, prefix, suffix %}

--- a/src/_lib/eleventy/area-list.js
+++ b/src/_lib/eleventy/area-list.js
@@ -1,0 +1,126 @@
+/**
+ * Area list formatting - converts location collections into
+ * formatted HTML lists with proper comma/and separation.
+ *
+ * Replaces complex Liquid template logic with testable JavaScript.
+ */
+
+/**
+ * Check if a URL represents a top-level location.
+ * Top-level locations have exactly 3 segments when split by "/".
+ * e.g., "/locations/springfield/" splits to ["", "locations", "springfield", ""]
+ * which has size 4, but we check for 3 non-empty segments.
+ *
+ * @param {string} url - The URL to check
+ * @returns {boolean} True if top-level location
+ */
+const isTopLevelLocation = (url) => {
+  if (!url) return false;
+  const segments = url.split("/").filter((s) => s !== "");
+  return segments.length === 2; // e.g., ["locations", "springfield"]
+};
+
+/**
+ * Sort locations by their navigation key.
+ *
+ * @param {Array} locations - Array of location objects
+ * @returns {Array} Sorted array
+ */
+const sortByNavigationKey = (locations) => {
+  if (!locations || !Array.isArray(locations)) return [];
+  return [...locations].sort((a, b) => {
+    const keyA = a.data?.eleventyNavigation?.key || "";
+    const keyB = b.data?.eleventyNavigation?.key || "";
+    return keyA.localeCompare(keyB);
+  });
+};
+
+/**
+ * Filter locations to only include top-level ones, excluding the current page.
+ *
+ * @param {Array} locations - Array of location objects
+ * @param {string} currentUrl - URL of the current page to exclude
+ * @returns {Array} Filtered array
+ */
+const filterTopLevelLocations = (locations, currentUrl) => {
+  if (!locations || !Array.isArray(locations)) return [];
+  return locations.filter(
+    (loc) => isTopLevelLocation(loc.url) && loc.url !== currentUrl,
+  );
+};
+
+/**
+ * Format a list of items with commas and "and" before the last item.
+ * e.g., ["a", "b", "c"] => "a, b and c"
+ *
+ * @param {Array<string>} items - Array of strings to join
+ * @returns {string} Formatted string
+ */
+const formatListWithAnd = (items) => {
+  if (!items || items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+
+  const allButLast = items.slice(0, -1);
+  const last = items[items.length - 1];
+  return `${allButLast.join(", ")} and ${last}`;
+};
+
+/**
+ * Generate HTML link for a location.
+ *
+ * @param {Object} location - Location object with url and data.eleventyNavigation.key
+ * @returns {string} HTML anchor tag
+ */
+const locationToLink = (location) => {
+  const url = location.url || "";
+  const name = location.data?.eleventyNavigation?.key || "";
+  return `<a href="${url}#content">${name}</a>`;
+};
+
+/**
+ * Generate formatted area list HTML.
+ *
+ * @param {Array} locations - Array of location objects from collections.location
+ * @param {string} currentUrl - URL of the current page (to exclude from list)
+ * @param {string} prefix - Text to prepend (e.g., "We also serve ")
+ * @param {string} suffix - Text to append (e.g., ".")
+ * @returns {string} Complete HTML string
+ */
+const formatAreaList = (locations, currentUrl, prefix = "", suffix = "") => {
+  const sorted = sortByNavigationKey(locations);
+  const filtered = filterTopLevelLocations(sorted, currentUrl);
+
+  if (filtered.length === 0) return "";
+
+  const links = filtered.map(locationToLink);
+  const formattedList = formatListWithAnd(links);
+
+  return `${prefix}${formattedList}${suffix}`;
+};
+
+/**
+ * Configure the Eleventy shortcode for area list.
+ *
+ * @param {Object} eleventyConfig - Eleventy configuration object
+ */
+const configureAreaList = (eleventyConfig) => {
+  eleventyConfig.addShortcode(
+    "areaList",
+    function (locations, prefix = "", suffix = "") {
+      // `this.page.url` gives us the current page URL in Eleventy shortcodes
+      const currentUrl = this.page?.url || "";
+      return formatAreaList(locations, currentUrl, prefix, suffix);
+    },
+  );
+};
+
+export {
+  isTopLevelLocation,
+  sortByNavigationKey,
+  filterTopLevelLocations,
+  formatListWithAnd,
+  locationToLink,
+  formatAreaList,
+  configureAreaList,
+};

--- a/test/area-list.test.js
+++ b/test/area-list.test.js
@@ -1,0 +1,554 @@
+import {
+  isTopLevelLocation,
+  sortByNavigationKey,
+  filterTopLevelLocations,
+  formatListWithAnd,
+  locationToLink,
+  formatAreaList,
+  configureAreaList,
+} from "#eleventy/area-list.js";
+import {
+  createMockEleventyConfig,
+  createTestRunner,
+  expectDeepEqual,
+  expectStrictEqual,
+  expectTrue,
+  expectFalse,
+} from "./test-utils.js";
+
+// Test fixtures
+const createLocation = (name, url) => ({
+  url,
+  data: {
+    eleventyNavigation: {
+      key: name,
+    },
+  },
+});
+
+const testCases = [
+  // isTopLevelLocation tests
+  {
+    name: "isTopLevelLocation-top-level",
+    description: "Returns true for top-level location URLs",
+    test: () => {
+      expectTrue(
+        isTopLevelLocation("/locations/springfield/"),
+        "Should match /locations/springfield/",
+      );
+      expectTrue(
+        isTopLevelLocation("/locations/fulchester/"),
+        "Should match /locations/fulchester/",
+      );
+    },
+  },
+  {
+    name: "isTopLevelLocation-nested",
+    description: "Returns false for nested location URLs",
+    test: () => {
+      expectFalse(
+        isTopLevelLocation("/locations/springfield/downtown/"),
+        "Should not match nested locations",
+      );
+      expectFalse(
+        isTopLevelLocation("/locations/springfield/heights/area/"),
+        "Should not match deeply nested",
+      );
+    },
+  },
+  {
+    name: "isTopLevelLocation-root",
+    description: "Returns false for root locations URL",
+    test: () => {
+      expectFalse(
+        isTopLevelLocation("/locations/"),
+        "Should not match /locations/",
+      );
+    },
+  },
+  {
+    name: "isTopLevelLocation-null",
+    description: "Returns false for null/undefined/empty",
+    test: () => {
+      expectFalse(isTopLevelLocation(null), "Should return false for null");
+      expectFalse(
+        isTopLevelLocation(undefined),
+        "Should return false for undefined",
+      );
+      expectFalse(isTopLevelLocation(""), "Should return false for empty");
+    },
+  },
+
+  // sortByNavigationKey tests
+  {
+    name: "sortByNavigationKey-alphabetical",
+    description: "Sorts locations alphabetically by navigation key",
+    test: () => {
+      const locations = [
+        createLocation("Zebra Town", "/locations/zebra-town/"),
+        createLocation("Alpha City", "/locations/alpha-city/"),
+        createLocation("Metro Area", "/locations/metro-area/"),
+      ];
+
+      const sorted = sortByNavigationKey(locations);
+
+      expectStrictEqual(
+        sorted[0].data.eleventyNavigation.key,
+        "Alpha City",
+        "First should be Alpha City",
+      );
+      expectStrictEqual(
+        sorted[1].data.eleventyNavigation.key,
+        "Metro Area",
+        "Second should be Metro Area",
+      );
+      expectStrictEqual(
+        sorted[2].data.eleventyNavigation.key,
+        "Zebra Town",
+        "Third should be Zebra Town",
+      );
+    },
+  },
+  {
+    name: "sortByNavigationKey-empty",
+    description: "Returns empty array for null/undefined/empty input",
+    test: () => {
+      expectDeepEqual(
+        sortByNavigationKey(null),
+        [],
+        "Should return [] for null",
+      );
+      expectDeepEqual(
+        sortByNavigationKey(undefined),
+        [],
+        "Should return [] for undefined",
+      );
+      expectDeepEqual(sortByNavigationKey([]), [], "Should return [] for []");
+    },
+  },
+  {
+    name: "sortByNavigationKey-missing-keys",
+    description: "Handles locations with missing navigation keys",
+    test: () => {
+      const locations = [
+        createLocation("Bravo", "/locations/bravo/"),
+        { url: "/locations/no-key/", data: {} },
+        createLocation("Alpha", "/locations/alpha/"),
+      ];
+
+      const sorted = sortByNavigationKey(locations);
+
+      // Empty key should sort first (empty string < "Alpha")
+      expectStrictEqual(sorted.length, 3, "Should have 3 items");
+      expectStrictEqual(
+        sorted[0].data.eleventyNavigation,
+        undefined,
+        "Missing key should sort first",
+      );
+    },
+  },
+  {
+    name: "sortByNavigationKey-immutable",
+    description: "Does not mutate the original array",
+    test: () => {
+      const locations = [
+        createLocation("Beta", "/locations/beta/"),
+        createLocation("Alpha", "/locations/alpha/"),
+      ];
+      const original = [...locations];
+
+      sortByNavigationKey(locations);
+
+      expectStrictEqual(
+        locations[0].data.eleventyNavigation.key,
+        "Beta",
+        "Original should be unchanged",
+      );
+      expectDeepEqual(
+        locations.map((l) => l.data.eleventyNavigation.key),
+        original.map((l) => l.data.eleventyNavigation.key),
+        "Original array should not be mutated",
+      );
+    },
+  },
+
+  // filterTopLevelLocations tests
+  {
+    name: "filterTopLevelLocations-filters-correctly",
+    description: "Filters to only top-level locations",
+    test: () => {
+      const locations = [
+        createLocation("Springfield", "/locations/springfield/"),
+        createLocation("Downtown", "/locations/springfield/downtown/"),
+        createLocation("Fulchester", "/locations/fulchester/"),
+      ];
+
+      const filtered = filterTopLevelLocations(
+        locations,
+        "/locations/other-page/",
+      );
+
+      expectStrictEqual(filtered.length, 2, "Should have 2 top-level items");
+      expectStrictEqual(
+        filtered[0].data.eleventyNavigation.key,
+        "Springfield",
+        "First should be Springfield",
+      );
+      expectStrictEqual(
+        filtered[1].data.eleventyNavigation.key,
+        "Fulchester",
+        "Second should be Fulchester",
+      );
+    },
+  },
+  {
+    name: "filterTopLevelLocations-excludes-current-page",
+    description: "Excludes the current page from results",
+    test: () => {
+      const locations = [
+        createLocation("Springfield", "/locations/springfield/"),
+        createLocation("Fulchester", "/locations/fulchester/"),
+        createLocation("Royston Vasey", "/locations/royston-vasey/"),
+      ];
+
+      const filtered = filterTopLevelLocations(
+        locations,
+        "/locations/springfield/",
+      );
+
+      expectStrictEqual(filtered.length, 2, "Should have 2 items");
+      expectFalse(
+        filtered.some((l) => l.url === "/locations/springfield/"),
+        "Should not include current page",
+      );
+    },
+  },
+  {
+    name: "filterTopLevelLocations-empty",
+    description: "Returns empty array for null/undefined/empty",
+    test: () => {
+      expectDeepEqual(
+        filterTopLevelLocations(null, "/page/"),
+        [],
+        "Should return [] for null",
+      );
+      expectDeepEqual(
+        filterTopLevelLocations(undefined, "/page/"),
+        [],
+        "Should return [] for undefined",
+      );
+      expectDeepEqual(
+        filterTopLevelLocations([], "/page/"),
+        [],
+        "Should return [] for []",
+      );
+    },
+  },
+
+  // formatListWithAnd tests
+  {
+    name: "formatListWithAnd-empty",
+    description: "Returns empty string for empty array",
+    test: () => {
+      expectStrictEqual(formatListWithAnd([]), "", "Should return empty");
+      expectStrictEqual(formatListWithAnd(null), "", "Should return empty");
+      expectStrictEqual(formatListWithAnd(undefined), "", "Should return empty");
+    },
+  },
+  {
+    name: "formatListWithAnd-single",
+    description: "Returns single item without separator",
+    test: () => {
+      expectStrictEqual(
+        formatListWithAnd(["Alpha"]),
+        "Alpha",
+        "Should return single item",
+      );
+    },
+  },
+  {
+    name: "formatListWithAnd-two",
+    description: "Returns two items with 'and'",
+    test: () => {
+      expectStrictEqual(
+        formatListWithAnd(["Alpha", "Beta"]),
+        "Alpha and Beta",
+        "Should join two with 'and'",
+      );
+    },
+  },
+  {
+    name: "formatListWithAnd-three",
+    description: "Returns three items with commas and 'and'",
+    test: () => {
+      expectStrictEqual(
+        formatListWithAnd(["Alpha", "Beta", "Gamma"]),
+        "Alpha, Beta and Gamma",
+        "Should join three correctly",
+      );
+    },
+  },
+  {
+    name: "formatListWithAnd-many",
+    description: "Returns many items with commas and final 'and'",
+    test: () => {
+      expectStrictEqual(
+        formatListWithAnd(["A", "B", "C", "D", "E"]),
+        "A, B, C, D and E",
+        "Should join many correctly",
+      );
+    },
+  },
+
+  // locationToLink tests
+  {
+    name: "locationToLink-basic",
+    description: "Generates HTML link with #content anchor",
+    test: () => {
+      const location = createLocation("Springfield", "/locations/springfield/");
+      const link = locationToLink(location);
+
+      expectStrictEqual(
+        link,
+        '<a href="/locations/springfield/#content">Springfield</a>',
+        "Should generate correct HTML",
+      );
+    },
+  },
+  {
+    name: "locationToLink-missing-data",
+    description: "Handles missing data gracefully",
+    test: () => {
+      const location = { url: "/test/" };
+      const link = locationToLink(location);
+
+      expectStrictEqual(
+        link,
+        '<a href="/test/#content"></a>',
+        "Should generate link with empty name",
+      );
+    },
+  },
+  {
+    name: "locationToLink-missing-url",
+    description: "Handles missing URL gracefully",
+    test: () => {
+      const location = { data: { eleventyNavigation: { key: "Test" } } };
+      const link = locationToLink(location);
+
+      expectStrictEqual(
+        link,
+        '<a href="#content">Test</a>',
+        "Should generate link with empty url",
+      );
+    },
+  },
+
+  // formatAreaList integration tests
+  {
+    name: "formatAreaList-full-integration",
+    description: "Produces correct output for typical use case",
+    test: () => {
+      const locations = [
+        createLocation("Zebra Town", "/locations/zebra-town/"),
+        createLocation("Springfield", "/locations/springfield/"),
+        createLocation("Downtown", "/locations/springfield/downtown/"),
+        createLocation("Alpha City", "/locations/alpha-city/"),
+      ];
+
+      const result = formatAreaList(
+        locations,
+        "/locations/springfield/",
+        "We also serve ",
+        ".",
+      );
+
+      expectStrictEqual(
+        result,
+        'We also serve <a href="/locations/alpha-city/#content">Alpha City</a> and <a href="/locations/zebra-town/#content">Zebra Town</a>.',
+        "Should produce formatted list",
+      );
+    },
+  },
+  {
+    name: "formatAreaList-three-locations",
+    description: "Handles three locations with comma and 'and'",
+    test: () => {
+      const locations = [
+        createLocation("Charlie", "/locations/charlie/"),
+        createLocation("Alpha", "/locations/alpha/"),
+        createLocation("Bravo", "/locations/bravo/"),
+      ];
+
+      const result = formatAreaList(locations, "/locations/other/", "", "");
+
+      expectStrictEqual(
+        result,
+        '<a href="/locations/alpha/#content">Alpha</a>, <a href="/locations/bravo/#content">Bravo</a> and <a href="/locations/charlie/#content">Charlie</a>',
+        "Should handle three locations",
+      );
+    },
+  },
+  {
+    name: "formatAreaList-single-location",
+    description: "Handles single remaining location",
+    test: () => {
+      const locations = [
+        createLocation("Springfield", "/locations/springfield/"),
+        createLocation("Fulchester", "/locations/fulchester/"),
+      ];
+
+      const result = formatAreaList(
+        locations,
+        "/locations/springfield/",
+        "Also: ",
+        "!",
+      );
+
+      expectStrictEqual(
+        result,
+        'Also: <a href="/locations/fulchester/#content">Fulchester</a>!',
+        "Should handle single location",
+      );
+    },
+  },
+  {
+    name: "formatAreaList-empty-result",
+    description: "Returns empty string when no locations remain",
+    test: () => {
+      const locations = [
+        createLocation("Springfield", "/locations/springfield/"),
+      ];
+
+      const result = formatAreaList(
+        locations,
+        "/locations/springfield/",
+        "Prefix",
+        "Suffix",
+      );
+
+      expectStrictEqual(result, "", "Should return empty when no locations");
+    },
+  },
+  {
+    name: "formatAreaList-excludes-nested",
+    description: "Excludes nested locations from output",
+    test: () => {
+      const locations = [
+        createLocation("Springfield", "/locations/springfield/"),
+        createLocation("Downtown", "/locations/springfield/downtown/"),
+        createLocation("Heights", "/locations/springfield/heights/"),
+      ];
+
+      const result = formatAreaList(locations, "/locations/other/", "", "");
+
+      expectStrictEqual(
+        result,
+        '<a href="/locations/springfield/#content">Springfield</a>',
+        "Should only include top-level",
+      );
+    },
+  },
+  {
+    name: "formatAreaList-empty-locations",
+    description: "Returns empty string for empty locations array",
+    test: () => {
+      expectStrictEqual(
+        formatAreaList([], "/page/", "Pre", "Suf"),
+        "",
+        "Should return empty",
+      );
+      expectStrictEqual(
+        formatAreaList(null, "/page/", "Pre", "Suf"),
+        "",
+        "Should return empty for null",
+      );
+    },
+  },
+  {
+    name: "formatAreaList-default-prefix-suffix",
+    description: "Works with default empty prefix and suffix",
+    test: () => {
+      const locations = [
+        createLocation("Alpha", "/locations/alpha/"),
+        createLocation("Beta", "/locations/beta/"),
+      ];
+
+      const result = formatAreaList(locations, "/locations/other/");
+
+      expectStrictEqual(
+        result,
+        '<a href="/locations/alpha/#content">Alpha</a> and <a href="/locations/beta/#content">Beta</a>',
+        "Should work without prefix/suffix",
+      );
+    },
+  },
+
+  // configureAreaList tests
+  {
+    name: "configureAreaList-registers-shortcode",
+    description: "Registers areaList shortcode with Eleventy",
+    test: () => {
+      const mockConfig = createMockEleventyConfig();
+      configureAreaList(mockConfig);
+
+      expectTrue(
+        mockConfig.shortcodes !== undefined,
+        "Should have shortcodes object",
+      );
+      expectTrue(
+        typeof mockConfig.shortcodes.areaList === "function",
+        "Should register areaList shortcode",
+      );
+    },
+  },
+  {
+    name: "configureAreaList-shortcode-uses-page-url",
+    description: "Shortcode uses this.page.url for current page",
+    test: () => {
+      const mockConfig = createMockEleventyConfig();
+      configureAreaList(mockConfig);
+
+      const locations = [
+        createLocation("Alpha", "/locations/alpha/"),
+        createLocation("Beta", "/locations/beta/"),
+      ];
+
+      // Simulate Eleventy's `this` context
+      const context = { page: { url: "/locations/alpha/" } };
+      const result = mockConfig.shortcodes.areaList.call(
+        context,
+        locations,
+        "Serving ",
+        ".",
+      );
+
+      expectStrictEqual(
+        result,
+        'Serving <a href="/locations/beta/#content">Beta</a>.',
+        "Should exclude current page URL",
+      );
+    },
+  },
+  {
+    name: "configureAreaList-shortcode-handles-missing-page",
+    description: "Shortcode handles missing page context gracefully",
+    test: () => {
+      const mockConfig = createMockEleventyConfig();
+      configureAreaList(mockConfig);
+
+      const locations = [createLocation("Alpha", "/locations/alpha/")];
+
+      // Call with empty context
+      const result = mockConfig.shortcodes.areaList.call({}, locations, "", "");
+
+      expectStrictEqual(
+        result,
+        '<a href="/locations/alpha/#content">Alpha</a>',
+        "Should work without page context",
+      );
+    },
+  },
+];
+
+export default createTestRunner("area-list", testCases);


### PR DESCRIPTION
Replace complex Liquid template logic with testable JavaScript:
- Add area-list.js with functions for filtering, sorting, and formatting
- Add 29 comprehensive tests covering all edge cases
- Simplify area-list-shortcode.html to single shortcode call