### PR TITLE
Add let-usage.test.js helper functions to test hygiene whitelist

### DIFF
--- a/test/test-hygiene.test.js
+++ b/test/test-hygiene.test.js
@@ -54,6 +54,10 @@ const ALLOWED_TEST_FUNCTIONS = new Set([
   "calculateOwnLines",
   "analyzeFunctionLengths",
   "formatViolations",
+  // let-usage.test.js - analysis helpers
+  "findLetDeclarations",
+  "isAllowedLet",
+  "analyzeLetUsage",
   // missing-folders-lib.test.js
   "testLibModules",
   // naming-conventions.test.js - analysis helpers


### PR DESCRIPTION
Adds findLetDeclarations, isAllowedLet, and analyzeLetUsage to the
ALLOWED_TEST_FUNCTIONS set so the let-usage test passes the test-hygiene
check for non-production code in test files.