### PR TITLE
Remove test skip functionality from test runner

### DIFF
--- a/test/news.test.js
+++ b/test/news.test.js
@@ -53,13 +53,6 @@ const testCases = [
   {
     name: "news-author-rendered-with-link",
     description: "News post with author renders author link in HTML",
-    skipIf: () => {
-      const newsHtmlPath = path.join(
-        process.cwd(),
-        "_site/news/first/index.html",
-      );
-      return !fs.existsSync(newsHtmlPath) && "Build output not found";
-    },
     test: () => {
       const newsHtmlPath = path.join(
         process.cwd(),
@@ -88,13 +81,6 @@ const testCases = [
   {
     name: "news-without-author-no-link",
     description: "News post without author does not render author section",
-    skipIf: () => {
-      const newsHtmlPath = path.join(
-        process.cwd(),
-        "_site/news/second/index.html",
-      );
-      return !fs.existsSync(newsHtmlPath) && "Build output not found";
-    },
     test: () => {
       const newsHtmlPath = path.join(
         process.cwd(),

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -136,15 +136,6 @@ const runTestSuite = async (testName, testCases) => {
     for (const testCase of testCases) {
       const testId = `${testName}/${testCase.name}`;
 
-      // Check if test should be skipped
-      if (testCase.skipIf) {
-        const skipReason = testCase.skipIf();
-        if (skipReason) {
-          console.log(`⏭️  SKIP: ${testId} - ${skipReason}`);
-          continue;
-        }
-      }
-
       try {
         if (testCase.test) {
           testCase.test();


### PR DESCRIPTION
Tests should always run and fail explicitly if prerequisites are not met,
rather than being silently skipped. This removes the skipIf option from
the test framework and removes its usage from news tests.