### PR TITLE
Refactor location.html Liquid loops to JavaScript filters

### DIFF
--- a/src/_layouts/location.html
+++ b/src/_layouts/location.html
@@ -13,21 +13,10 @@ layout: base
   {%- include "items.html", items: services -%}
 {%- endif -%}
 
-{%- if categories.size > 0 -%}
-  {%- assign locationProducts = "" | split: "" -%}
-  {%- for category in categories -%}
-    {%- assign categoryProducts = collections.products | getProductsByCategory: category -%}
-    {%- for product in categoryProducts -%}
-      {%- unless locationProducts contains product -%}
-        {%- assign locationProducts = locationProducts | push: product -%}
-      {%- endunless -%}
-    {%- endfor -%}
-  {%- endfor -%}
-
-  {%- if locationProducts.size > 0 -%}
-    <h2>{{ strings.product_name }} in {{ title }}</h2>
-    {%- include "items.html", items: locationProducts -%}
-  {%- endif -%}
+{%- assign locationProducts = collections.products | getProductsByCategories: categories -%}
+{%- if locationProducts.size > 0 -%}
+  <h2>{{ strings.product_name }} in {{ title }}</h2>
+  {%- include "items.html", items: locationProducts -%}
 {%- endif -%}
 
 {%- assign locationProperties = collections.properties | getPropertiesByLocation: locationSlug -%}
@@ -36,17 +25,8 @@ layout: base
   {%- include "items.html", items: locationProperties -%}
 {%- endif -%}
 
-{%- if parentLocation -%}
-  {%- assign siblingServices = collections.location | where: "data.parentLocation", parentLocation -%}
-  {%- assign otherServices = "" | split: "" -%}
-  {%- for service in siblingServices -%}
-    {%- unless service.url == page.url -%}
-      {%- assign otherServices = otherServices | push: service -%}
-    {%- endunless -%}
-  {%- endfor -%}
-
-  {%- if otherServices.size > 0 -%}
-    <h2>Other Services</h2>
-    {%- include "items.html", items: otherServices -%}
-  {%- endif -%}
+{%- assign otherServices = collections.location | getSiblingLocations: parentLocation, page.url -%}
+{%- if otherServices.size > 0 -%}
+  <h2>Other Services</h2>
+  {%- include "items.html", items: otherServices -%}
 {%- endif -%}

--- a/src/_lib/collections/locations.js
+++ b/src/_lib/collections/locations.js
@@ -1,8 +1,21 @@
 const getRootLocations = (locations) =>
   locations?.filter((loc) => !loc.data.parentLocation) || [];
 
-const configureLocations = (eleventyConfig) => {
-  eleventyConfig.addFilter("getRootLocations", getRootLocations);
+/**
+ * Get sibling locations (same parent) excluding the current page
+ * Replaces gnarly Liquid loop with unless/push pattern
+ */
+const getSiblingLocations = (locations, parentLocationSlug, currentUrl) => {
+  if (!locations || !parentLocationSlug) return [];
+  return locations.filter(
+    (loc) =>
+      loc.data.parentLocation === parentLocationSlug && loc.url !== currentUrl,
+  );
 };
 
-export { getRootLocations, configureLocations };
+const configureLocations = (eleventyConfig) => {
+  eleventyConfig.addFilter("getRootLocations", getRootLocations);
+  eleventyConfig.addFilter("getSiblingLocations", getSiblingLocations);
+};
+
+export { getRootLocations, getSiblingLocations, configureLocations };

--- a/src/_lib/collections/products.js
+++ b/src/_lib/collections/products.js
@@ -37,6 +37,25 @@ const getProductsByCategory = (products, categorySlug) => {
     .sort(sortItems);
 };
 
+/**
+ * Get unique products that belong to any of the given categories
+ * Replaces gnarly Liquid nested loops with contains checks
+ */
+const getProductsByCategories = (products, categorySlugs) => {
+  if (!products || !categorySlugs?.length) return [];
+  const seen = new Set();
+  const result = [];
+  for (const slug of categorySlugs) {
+    for (const product of products) {
+      if (product.data.categories?.includes(slug) && !seen.has(product)) {
+        seen.add(product);
+        result.push(product);
+      }
+    }
+  }
+  return result.sort(sortItems);
+};
+
 const getProductsByEvent = (products, eventSlug) => {
   if (!products) return [];
   return products
@@ -100,6 +119,7 @@ const configureProducts = (eleventyConfig) => {
   );
 
   eleventyConfig.addFilter("getProductsByCategory", getProductsByCategory);
+  eleventyConfig.addFilter("getProductsByCategories", getProductsByCategories);
   eleventyConfig.addFilter("getProductsByEvent", getProductsByEvent);
   eleventyConfig.addFilter("getFeaturedProducts", getFeaturedProducts);
 };
@@ -113,6 +133,7 @@ export {
   productsWithReviewsPage,
   productReviewsRedirects,
   getProductsByCategory,
+  getProductsByCategories,
   getProductsByEvent,
   getFeaturedProducts,
   configureProducts,

--- a/test/locations.test.js
+++ b/test/locations.test.js
@@ -1,0 +1,149 @@
+import {
+  configureLocations,
+  getRootLocations,
+  getSiblingLocations,
+} from "#collections/locations.js";
+import {
+  createMockEleventyConfig,
+  createTestRunner,
+  expectDeepEqual,
+  expectFunctionType,
+  expectStrictEqual,
+} from "./test-utils.js";
+
+const testCases = [
+  {
+    name: "getRootLocations-basic",
+    description: "Filters locations without parent",
+    test: () => {
+      const locations = [
+        { data: { title: "London" } },
+        { data: { title: "Manchester", parentLocation: "uk" } },
+        { data: { title: "UK" } },
+      ];
+
+      const result = getRootLocations(locations);
+
+      expectStrictEqual(result.length, 2, "Should return 2 root locations");
+      expectStrictEqual(
+        result[0].data.title,
+        "London",
+        "Should include London",
+      );
+      expectStrictEqual(result[1].data.title, "UK", "Should include UK");
+    },
+  },
+  {
+    name: "getRootLocations-null",
+    description: "Handles null/undefined input",
+    test: () => {
+      expectDeepEqual(
+        getRootLocations(null),
+        [],
+        "Should return empty for null",
+      );
+      expectDeepEqual(
+        getRootLocations(undefined),
+        [],
+        "Should return empty for undefined",
+      );
+    },
+  },
+  {
+    name: "getSiblingLocations-basic",
+    description: "Gets sibling locations excluding current page",
+    test: () => {
+      const locations = [
+        { data: { title: "Cleaning", parentLocation: "london" }, url: "/london/cleaning/" },
+        { data: { title: "Repairs", parentLocation: "london" }, url: "/london/repairs/" },
+        { data: { title: "Painting", parentLocation: "london" }, url: "/london/painting/" },
+        { data: { title: "Plumbing", parentLocation: "manchester" }, url: "/manchester/plumbing/" },
+      ];
+
+      const result = getSiblingLocations(locations, "london", "/london/cleaning/");
+
+      expectStrictEqual(result.length, 2, "Should return 2 siblings");
+      expectStrictEqual(
+        result[0].data.title,
+        "Repairs",
+        "Should include Repairs",
+      );
+      expectStrictEqual(
+        result[1].data.title,
+        "Painting",
+        "Should include Painting",
+      );
+    },
+  },
+  {
+    name: "getSiblingLocations-no-siblings",
+    description: "Returns empty when no siblings exist",
+    test: () => {
+      const locations = [
+        { data: { title: "Cleaning", parentLocation: "london" }, url: "/london/cleaning/" },
+        { data: { title: "Plumbing", parentLocation: "manchester" }, url: "/manchester/plumbing/" },
+      ];
+
+      const result = getSiblingLocations(locations, "london", "/london/cleaning/");
+
+      expectStrictEqual(result.length, 0, "Should return no siblings");
+    },
+  },
+  {
+    name: "getSiblingLocations-null-inputs",
+    description: "Handles null/undefined inputs",
+    test: () => {
+      const locations = [
+        { data: { title: "Cleaning", parentLocation: "london" }, url: "/london/cleaning/" },
+      ];
+
+      expectDeepEqual(
+        getSiblingLocations(null, "london", "/url/"),
+        [],
+        "Should return empty for null locations",
+      );
+      expectDeepEqual(
+        getSiblingLocations(locations, null, "/url/"),
+        [],
+        "Should return empty for null parent",
+      );
+      expectStrictEqual(
+        getSiblingLocations(locations, "london", null).length,
+        1,
+        "Should still filter with null currentUrl",
+      );
+    },
+  },
+  {
+    name: "configureLocations-basic",
+    description: "Configures location filters",
+    test: () => {
+      const mockConfig = createMockEleventyConfig();
+
+      configureLocations(mockConfig);
+
+      expectFunctionType(
+        mockConfig.filters,
+        "getRootLocations",
+        "Should add getRootLocations filter",
+      );
+      expectFunctionType(
+        mockConfig.filters,
+        "getSiblingLocations",
+        "Should add getSiblingLocations filter",
+      );
+      expectStrictEqual(
+        mockConfig.filters.getRootLocations,
+        getRootLocations,
+        "Should use correct filter function",
+      );
+      expectStrictEqual(
+        mockConfig.filters.getSiblingLocations,
+        getSiblingLocations,
+        "Should use correct filter function",
+      );
+    },
+  },
+];
+
+export default createTestRunner("locations", testCases);

--- a/test/products.test.js
+++ b/test/products.test.js
@@ -4,6 +4,7 @@ import {
   createProductsCollection,
   getFeaturedProducts,
   getProductsByCategory,
+  getProductsByCategories,
   processGallery,
 } from "#collections/products.js";
 import {
@@ -230,6 +231,106 @@ const testCases = [
     },
   },
   {
+    name: "getProductsByCategories-basic",
+    description: "Gets products from multiple categories",
+    test: () => {
+      const products = [
+        { data: { title: "Product 1", categories: ["widgets"] } },
+        { data: { title: "Product 2", categories: ["tools"] } },
+        { data: { title: "Product 3", categories: ["gadgets"] } },
+        { data: { title: "Product 4", categories: ["other"] } },
+      ];
+
+      const result = getProductsByCategories(products, ["widgets", "gadgets"]);
+
+      expectStrictEqual(
+        result.length,
+        2,
+        "Should return products from both categories",
+      );
+      const titles = result.map((p) => p.data.title);
+      expectStrictEqual(
+        titles.includes("Product 1"),
+        true,
+        "Should include widget product",
+      );
+      expectStrictEqual(
+        titles.includes("Product 3"),
+        true,
+        "Should include gadget product",
+      );
+    },
+  },
+  {
+    name: "getProductsByCategories-deduplication",
+    description: "Returns unique products even if in multiple categories",
+    test: () => {
+      const products = [
+        { data: { title: "Product 1", categories: ["widgets", "gadgets"] } },
+        { data: { title: "Product 2", categories: ["tools"] } },
+        { data: { title: "Product 3", categories: ["widgets"] } },
+      ];
+
+      const result = getProductsByCategories(products, ["widgets", "gadgets"]);
+
+      expectStrictEqual(
+        result.length,
+        2,
+        "Should deduplicate products in multiple matching categories",
+      );
+      const titles = result.map((p) => p.data.title);
+      expectStrictEqual(
+        titles.includes("Product 1"),
+        true,
+        "Should include multi-category product once",
+      );
+      expectStrictEqual(
+        titles.includes("Product 3"),
+        true,
+        "Should include widget-only product",
+      );
+    },
+  },
+  {
+    name: "getProductsByCategories-empty-inputs",
+    description: "Handles empty or null inputs",
+    test: () => {
+      const products = [
+        { data: { title: "Product 1", categories: ["widgets"] } },
+      ];
+
+      expectDeepEqual(
+        getProductsByCategories(null, ["widgets"]),
+        [],
+        "Should return empty for null products",
+      );
+      expectDeepEqual(
+        getProductsByCategories(products, null),
+        [],
+        "Should return empty for null categories",
+      );
+      expectDeepEqual(
+        getProductsByCategories(products, []),
+        [],
+        "Should return empty for empty categories array",
+      );
+    },
+  },
+  {
+    name: "getProductsByCategories-no-matches",
+    description: "Returns empty when no products match categories",
+    test: () => {
+      const products = [
+        { data: { title: "Product 1", categories: ["widgets"] } },
+        { data: { title: "Product 2" } },
+      ];
+
+      const result = getProductsByCategories(products, ["nonexistent"]);
+
+      expectStrictEqual(result.length, 0, "Should return empty for no matches");
+    },
+  },
+  {
     name: "configureProducts-basic",
     description: "Configures products collection and filters",
     test: () => {
@@ -259,6 +360,11 @@ const testCases = [
       );
       expectFunctionType(
         mockConfig.filters,
+        "getProductsByCategories",
+        "Should add getProductsByCategories filter",
+      );
+      expectFunctionType(
+        mockConfig.filters,
         "getFeaturedProducts",
         "Should add getFeaturedProducts filter",
       );
@@ -266,6 +372,11 @@ const testCases = [
       expectStrictEqual(
         mockConfig.filters.getProductsByCategory,
         getProductsByCategory,
+        "Should use correct filter function",
+      );
+      expectStrictEqual(
+        mockConfig.filters.getProductsByCategories,
+        getProductsByCategories,
         "Should use correct filter function",
       );
       expectStrictEqual(


### PR DESCRIPTION
Replace two gnarly Liquid patterns with clean JS filters:
- getProductsByCategories: collects unique products from multiple categories
- getSiblingLocations: gets sibling locations excluding current page

Reduces location.html from 53 to 33 lines while improving readability.