### PR TITLE
Refactor test counters to use const instead of let

### DIFF
--- a/test/let-usage.test.js
+++ b/test/let-usage.test.js
@@ -31,7 +31,6 @@ const ALLOWED_PATTERNS = [
   /^let\s+fontLink\s*=/, // theme-switcher.js - reassigned
   /^let\s+(fcpDone|initialized)\s*=/, // autosizes.js state flags
   /^let\s+(paypalToken|paypalTokenExpiry)\s*=/, // server.js PayPal token cache
-  /^let\s+(passed|failed)\s*=\s*0/, // run-all-tests.js test counters
 ];
 
 const shouldSkipDir = (name) => {

--- a/test/run-all-tests.js
+++ b/test/run-all-tests.js
@@ -19,8 +19,6 @@ async function runAllTests() {
 
     console.log(`Found ${testFiles.length} test files\n`);
 
-    let passed = 0;
-    let failed = 0;
     const failedTests = [];
 
     for (const testFile of testFiles) {
@@ -33,21 +31,20 @@ async function runAllTests() {
           stdio: "inherit",
           cwd: rootDir,
         });
-        passed++;
         console.log(`✅ ${testFile} passed`);
       } catch (error) {
-        failed++;
         failedTests.push(testFile);
         console.log(`❌ ${testFile} failed`);
       }
     }
 
     // Summary
+    const passed = testFiles.length - failedTests.length;
     console.log("\n" + "=".repeat(50));
     console.log("TEST SUMMARY");
     console.log("=".repeat(50));
     console.log(`✅ Passed: ${passed}`);
-    console.log(`❌ Failed: ${failed}`);
+    console.log(`❌ Failed: ${failedTests.length}`);
 
     if (failedTests.length > 0) {
       console.log("\nFailed tests:");


### PR DESCRIPTION
Compute passed count from array length instead of maintaining
mutable counters. This removes the need for the ALLOWED_PATTERNS
exception for run-all-tests.js test counters.