### PR TITLE
Refactor fontLink to use const instead of let

### DIFF
--- a/src/assets/js/theme-switcher.js
+++ b/src/assets/js/theme-switcher.js
@@ -41,16 +41,13 @@ const themeFonts = {
 
 function loadFontForTheme(themeName) {
   const fontLinkId = "theme-font-link";
-  let fontLink = document.getElementById(fontLinkId);
 
   // Remove existing font link if present
-  if (fontLink) {
-    fontLink.remove();
-  }
+  document.getElementById(fontLinkId)?.remove();
 
   // Add font link if theme has a custom font
   if (themeFonts[themeName]) {
-    fontLink = document.createElement("link");
+    const fontLink = document.createElement("link");
     fontLink.id = fontLinkId;
     fontLink.rel = "stylesheet";
     fontLink.href = `https://fonts.bunny.net/css?family=${themeFonts[themeName]}`;

--- a/test/let-usage.test.js
+++ b/test/let-usage.test.js
@@ -28,7 +28,6 @@ const ALLOWED_PATTERNS = [
   /^let\s+(cachedConfig|cachedSite)\s*=\s*null/, // Caching pattern
   /^let\s+(userStrings|userIcons)\s*=\s*\{\}/, // Try/catch assignment pattern
   /^let\s+storedCollections\s*=\s*null/, // pdf.js state
-  /^let\s+fontLink\s*=/, // theme-switcher.js - reassigned
   /^let\s+(fcpDone|initialized)\s*=/, // autosizes.js state flags
   /^let\s+(paypalToken|paypalTokenExpiry)\s*=/, // server.js PayPal token cache
 ];


### PR DESCRIPTION
Use optional chaining to remove existing element and declare new
element with const inside the conditional block, eliminating the
need for variable reassignment.