### PR TITLE
Remove example from ALLOWED_PATTERNS

### DIFF
--- a/src/_data/specs_icons.js
+++ b/src/_data/specs_icons.js
@@ -5,20 +5,8 @@
  * Values are icon filenames in assets/icons/
  */
 
-import { readFileSync } from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
 import baseIcons from "./specs-icons-base.json" with { type: "json" };
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-let userIcons = {};
-try {
-  const userIconsPath = join(__dirname, "./specs_icons.json");
-  userIcons = JSON.parse(readFileSync(userIconsPath, "utf-8"));
-} catch {
-  // No user overrides
-}
+import userIcons from "./specs_icons.json" with { type: "json" };
 
 export default {
   ...baseIcons,

--- a/src/_data/strings.js
+++ b/src/_data/strings.js
@@ -7,18 +7,8 @@
  * This is enforced by tests in test/strings.test.js
  */
 
-import { readFileSync } from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
 import baseStrings from "./strings-base.json" with { type: "json" };
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-let userStrings = {};
-try {
-  const userStringsPath = join(__dirname, "./strings.json");
-  userStrings = JSON.parse(readFileSync(userStringsPath, "utf-8"));
-} catch (e) {}
+import userStrings from "./strings.json" with { type: "json" };
 
 export default {
   ...baseStrings,

--- a/test/let-usage.test.js
+++ b/test/let-usage.test.js
@@ -15,7 +15,6 @@ const ALLOWED_PATTERNS = [
   /^let\s+(ELEMENTS|PREVIOUS_GLOBAL_VARS)\s*=\s*null/, // theme-editor.js state
   /^let\s+(gallery|currentImage|imagePopup)\s*[,;=]/, // gallery.js DOM refs
   /^let\s+currentPopupIndex\s*=/, // gallery.js state
-  /^let\s+(userStrings|userIcons)\s*=\s*\{\}/, // Try/catch assignment pattern
   /^let\s+storedCollections\s*=\s*null/, // pdf.js state
   /^let\s+(fcpDone|initialized)\s*=/, // autosizes.js state flags
   /^let\s+(paypalToken|paypalTokenExpiry)\s*=/, // server.js PayPal token cache
@@ -124,8 +123,8 @@ let d, e, f;
     test: () => {
       const allowedLines = [
         "let ELEMENTS = null;",
-        "let userStrings = {};",
         "let gallery, currentImage, imagePopup;",
+        "let storedCollections = null;",
       ];
       for (const line of allowedLines) {
         expectTrue(


### PR DESCRIPTION
Replace IIFE+try/catch with direct JSON imports for strings.json and specs_icons.json. Since these files always exist, no error handling is needed. Removes userStrings/userIcons from ALLOWED_PATTERNS.