### PR TITLE
Remove example from ALLOWED_PATTERNS

### DIFF
--- a/test/let-usage.test.js
+++ b/test/let-usage.test.js
@@ -16,8 +16,6 @@ const ALLOWED_PATTERNS = [
   /^let\s+(gallery|currentImage|imagePopup)\s*[,;=]/, // gallery.js DOM refs
   /^let\s+currentPopupIndex\s*=/, // gallery.js state
   /^let\s+storedCollections\s*=\s*null/, // pdf.js state
-  /^let\s+(fcpDone|initialized)\s*=/, // autosizes.js state flags
-  /^let\s+(paypalToken|paypalTokenExpiry)\s*=/, // server.js PayPal token cache
 ];
 
 /**


### PR DESCRIPTION
- Remove fcpDone|initialized pattern: autosizes.js is already in ALLOWED_FILES, so the file is skipped entirely before patterns check
- Remove paypalToken|paypalTokenExpiry pattern: server.js is in ecommerce-backend/, not src/, so it's not in SRC_JS_FILES and never scanned

Both patterns were dead code that could never match anything.