### PR TITLE
Remove unused IDs and improve unused ID detection in tests

### DIFF
--- a/src/_includes/contact-form.html
+++ b/src/_includes/contact-form.html
@@ -1,7 +1,6 @@
 <noscript><p>JavaScript is required to submit this form.</p></noscript>
 {%- if config.form_target and config.form_target != "" -%}
   <form
-    id="contact-form"
     class="contact-form"
     action="{{ config.form_target }}"
     {% if config.botpoison_public_key and config.botpoison_public_key != "" -%}

--- a/src/_includes/item-reviews-count.html
+++ b/src/_includes/item-reviews-count.html
@@ -2,6 +2,6 @@
   {% assign reviews = collections.reviews | getReviewsFor: page.fileSlug, reviewsField %}
   {% assign rating = collections.reviews | getRating: page.fileSlug, reviewsField %}
   {%- if rating -%}
-    <p id="reviews-count"><a href="#reviews">{{ rating | ratingToStars }} after {{ reviews.size }} reviews</a></p>
+    <p><a href="#reviews">{{ rating | ratingToStars }} after {{ reviews.size }} reviews</a></p>
   {%- endif -%}
 {%- endif -%}

--- a/src/_layouts/quote-checkout.html
+++ b/src/_layouts/quote-checkout.html
@@ -6,7 +6,6 @@ layout: base
 
 {%- if config.form_target and config.form_target != "" -%}
   <form
-    id="quote-checkout-form"
     class="contact-form"
     action="{{ config.form_target }}"
     {% if config.botpoison_public_key and config.botpoison_public_key != "" -%}

--- a/test/test-hygiene.test.js
+++ b/test/test-hygiene.test.js
@@ -76,6 +76,7 @@ const ALLOWED_TEST_FUNCTIONS = new Set([
   "extractClassesFromHtml",
   "extractIdsFromHtml",
   "extractClassesFromJs",
+  "findIdReferencesInHtml",
   "findClassReferencesInScss",
   "findIdReferencesInScss",
   "findClassReferencesInJs",


### PR DESCRIPTION
- Remove unused IDs: contact-form, quote-checkout-form, reviews-count
- Add detection for dynamic ID construction patterns (e.g., getElementById(`${...}-tab`))
- Add detection for HTML anchor links (href="#id") and label associations (for="id")
- Add failing assertion for unused IDs (previously only classes were checked)
- Add findIdReferencesInHtml to test hygiene allowlist