### PR TITLE
Add tests for guides.js and memoize.js and increase c8 coverage limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"scripts": {
 		"build": "rm -rf _site && eleventy",
 		"serve": "rm -rf _site && eleventy --serve --incremental --quiet",
-		"test": "eleventy --quiet && c8 --lines 74 --functions 74 --branches 91 node test/run-all-tests.js",
+		"test": "eleventy --quiet && c8 --lines 74 --functions 75 --branches 91 node test/run-all-tests.js",
 		"cpd": "jscpd",
 		"knip": "knip",
 		"knip:fix": "knip --fix",

--- a/src/_lib/collections/guides.js
+++ b/src/_lib/collections/guides.js
@@ -15,4 +15,4 @@ const configureGuides = (eleventyConfig) => {
   eleventyConfig.addFilter("guidesByCategory", guidesByCategory);
 };
 
-export { configureGuides };
+export { guidesByCategory, configureGuides };

--- a/test/guides.test.js
+++ b/test/guides.test.js
@@ -1,0 +1,260 @@
+import {
+  configureGuides,
+  guidesByCategory,
+} from "#collections/guides.js";
+import {
+  createMockEleventyConfig,
+  createTestRunner,
+  expectDeepEqual,
+  expectFunctionType,
+  expectStrictEqual,
+} from "./test-utils.js";
+
+const testCases = [
+  {
+    name: "guidesByCategory-basic",
+    description: "Filters guide pages by category slug",
+    test: () => {
+      const guidePages = [
+        { data: { title: "Guide 1", "guide-category": "getting-started" } },
+        { data: { title: "Guide 2", "guide-category": "advanced" } },
+        { data: { title: "Guide 3", "guide-category": "getting-started" } },
+        { data: { title: "Guide 4", "guide-category": "tips" } },
+      ];
+
+      const result = guidesByCategory(guidePages, "getting-started");
+
+      expectStrictEqual(
+        result.length,
+        2,
+        "Should return 2 guides in getting-started category",
+      );
+      expectStrictEqual(
+        result[0].data.title,
+        "Guide 1",
+        "Should include first matching guide",
+      );
+      expectStrictEqual(
+        result[1].data.title,
+        "Guide 3",
+        "Should include second matching guide",
+      );
+    },
+  },
+  {
+    name: "guidesByCategory-single-match",
+    description: "Returns single guide when only one matches",
+    test: () => {
+      const guidePages = [
+        { data: { title: "Guide 1", "guide-category": "getting-started" } },
+        { data: { title: "Guide 2", "guide-category": "advanced" } },
+        { data: { title: "Guide 3", "guide-category": "tips" } },
+      ];
+
+      const result = guidesByCategory(guidePages, "advanced");
+
+      expectStrictEqual(result.length, 1, "Should return 1 guide");
+      expectStrictEqual(
+        result[0].data.title,
+        "Guide 2",
+        "Should return the correct guide",
+      );
+    },
+  },
+  {
+    name: "guidesByCategory-no-matches",
+    description: "Returns empty array when no guides match category",
+    test: () => {
+      const guidePages = [
+        { data: { title: "Guide 1", "guide-category": "getting-started" } },
+        { data: { title: "Guide 2", "guide-category": "advanced" } },
+      ];
+
+      const result = guidesByCategory(guidePages, "nonexistent");
+
+      expectStrictEqual(result.length, 0, "Should return no guides");
+    },
+  },
+  {
+    name: "guidesByCategory-null-pages",
+    description: "Handles null/undefined guide pages",
+    test: () => {
+      expectDeepEqual(
+        guidesByCategory(null, "getting-started"),
+        [],
+        "Should return empty array for null pages",
+      );
+      expectDeepEqual(
+        guidesByCategory(undefined, "getting-started"),
+        [],
+        "Should return empty array for undefined pages",
+      );
+    },
+  },
+  {
+    name: "guidesByCategory-null-category",
+    description: "Handles null/undefined category slug",
+    test: () => {
+      const guidePages = [
+        { data: { title: "Guide 1", "guide-category": "getting-started" } },
+      ];
+
+      expectDeepEqual(
+        guidesByCategory(guidePages, null),
+        [],
+        "Should return empty array for null category",
+      );
+      expectDeepEqual(
+        guidesByCategory(guidePages, undefined),
+        [],
+        "Should return empty array for undefined category",
+      );
+    },
+  },
+  {
+    name: "guidesByCategory-empty-pages",
+    description: "Handles empty guide pages array",
+    test: () => {
+      const result = guidesByCategory([], "getting-started");
+
+      expectDeepEqual(result, [], "Should return empty array for empty pages");
+    },
+  },
+  {
+    name: "guidesByCategory-missing-category-field",
+    description: "Skips guides without guide-category field",
+    test: () => {
+      const guidePages = [
+        { data: { title: "Guide 1", "guide-category": "getting-started" } },
+        { data: { title: "Guide 2" } },
+        { data: { title: "Guide 3", "guide-category": "getting-started" } },
+      ];
+
+      const result = guidesByCategory(guidePages, "getting-started");
+
+      expectStrictEqual(
+        result.length,
+        2,
+        "Should only return guides with matching category",
+      );
+    },
+  },
+  {
+    name: "guidesByCategory-case-sensitive",
+    description: "Category matching is case-sensitive",
+    test: () => {
+      const guidePages = [
+        { data: { title: "Guide 1", "guide-category": "Getting-Started" } },
+        { data: { title: "Guide 2", "guide-category": "getting-started" } },
+      ];
+
+      const result = guidesByCategory(guidePages, "getting-started");
+
+      expectStrictEqual(
+        result.length,
+        1,
+        "Should only match exact case",
+      );
+      expectStrictEqual(
+        result[0].data.title,
+        "Guide 2",
+        "Should return correctly cased guide",
+      );
+    },
+  },
+  {
+    name: "guidesByCategory-immutable",
+    description: "Does not modify input array",
+    test: () => {
+      const originalPages = [
+        { data: { title: "Guide 1", "guide-category": "getting-started" } },
+        { data: { title: "Guide 2", "guide-category": "advanced" } },
+      ];
+
+      const pagesCopy = structuredClone(originalPages);
+
+      guidesByCategory(pagesCopy, "getting-started");
+
+      expectDeepEqual(
+        pagesCopy,
+        originalPages,
+        "Should not modify input array",
+      );
+    },
+  },
+  {
+    name: "configureGuides-collections",
+    description: "Adds guide-categories and guide-pages collections",
+    test: () => {
+      const mockConfig = createMockEleventyConfig();
+
+      configureGuides(mockConfig);
+
+      expectFunctionType(
+        mockConfig.collections,
+        "guide-categories",
+        "Should add guide-categories collection",
+      );
+      expectFunctionType(
+        mockConfig.collections,
+        "guide-pages",
+        "Should add guide-pages collection",
+      );
+    },
+  },
+  {
+    name: "configureGuides-filter",
+    description: "Adds guidesByCategory filter",
+    test: () => {
+      const mockConfig = createMockEleventyConfig();
+
+      configureGuides(mockConfig);
+
+      expectFunctionType(
+        mockConfig.filters,
+        "guidesByCategory",
+        "Should add guidesByCategory filter",
+      );
+      expectStrictEqual(
+        mockConfig.filters.guidesByCategory,
+        guidesByCategory,
+        "Should use correct filter function",
+      );
+    },
+  },
+  {
+    name: "configureGuides-collection-functions",
+    description: "Collection functions filter by correct tags",
+    test: () => {
+      const mockConfig = createMockEleventyConfig();
+
+      configureGuides(mockConfig);
+
+      const mockCollectionApi = {
+        getFilteredByTag: (tag) => {
+          if (tag === "guide-category") return [{ slug: "cat-1" }];
+          if (tag === "guide-page") return [{ slug: "page-1" }];
+          return [];
+        },
+      };
+
+      const categories = mockConfig.collections["guide-categories"](mockCollectionApi);
+      const pages = mockConfig.collections["guide-pages"](mockCollectionApi);
+
+      expectStrictEqual(
+        categories.length,
+        1,
+        "Should return guide-category items",
+      );
+      expectStrictEqual(
+        categories[0].slug,
+        "cat-1",
+        "Should return correct category",
+      );
+      expectStrictEqual(pages.length, 1, "Should return guide-page items");
+      expectStrictEqual(pages[0].slug, "page-1", "Should return correct page");
+    },
+  },
+];
+
+export default createTestRunner("guides", testCases);

--- a/test/memoize.test.js
+++ b/test/memoize.test.js
@@ -1,0 +1,190 @@
+import { arraySlugKey, memoize } from "#utils/memoize.js";
+import {
+  createTestRunner,
+  expectStrictEqual,
+  expectFunctionType,
+} from "./test-utils.js";
+
+const testCases = [
+  {
+    name: "arraySlugKey-basic",
+    description: "Creates cache key from array length and slug",
+    test: () => {
+      const args = [["item1", "item2", "item3"], "test-slug"];
+
+      const result = arraySlugKey(args);
+
+      expectStrictEqual(
+        result,
+        "3:test-slug",
+        "Should combine array length and slug",
+      );
+    },
+  },
+  {
+    name: "arraySlugKey-empty-array",
+    description: "Handles empty array correctly",
+    test: () => {
+      const args = [[], "some-slug"];
+
+      const result = arraySlugKey(args);
+
+      expectStrictEqual(
+        result,
+        "0:some-slug",
+        "Should use 0 for empty array length",
+      );
+    },
+  },
+  {
+    name: "arraySlugKey-null-array",
+    description: "Handles null array gracefully",
+    test: () => {
+      const args = [null, "slug"];
+
+      const result = arraySlugKey(args);
+
+      expectStrictEqual(
+        result,
+        "0:slug",
+        "Should use 0 for null array length",
+      );
+    },
+  },
+  {
+    name: "arraySlugKey-undefined-array",
+    description: "Handles undefined array gracefully",
+    test: () => {
+      const args = [undefined, "slug"];
+
+      const result = arraySlugKey(args);
+
+      expectStrictEqual(
+        result,
+        "0:slug",
+        "Should use 0 for undefined array length",
+      );
+    },
+  },
+  {
+    name: "arraySlugKey-large-array",
+    description: "Handles large arrays correctly",
+    test: () => {
+      const largeArray = new Array(1000).fill("item");
+      const args = [largeArray, "large-slug"];
+
+      const result = arraySlugKey(args);
+
+      expectStrictEqual(
+        result,
+        "1000:large-slug",
+        "Should handle large array length",
+      );
+    },
+  },
+  {
+    name: "arraySlugKey-empty-slug",
+    description: "Handles empty slug",
+    test: () => {
+      const args = [["item"], ""];
+
+      const result = arraySlugKey(args);
+
+      expectStrictEqual(
+        result,
+        "1:",
+        "Should handle empty slug",
+      );
+    },
+  },
+  {
+    name: "arraySlugKey-special-characters",
+    description: "Preserves special characters in slug",
+    test: () => {
+      const args = [["item"], "test-slug-with-special-chars!@#"];
+
+      const result = arraySlugKey(args);
+
+      expectStrictEqual(
+        result,
+        "1:test-slug-with-special-chars!@#",
+        "Should preserve special characters in slug",
+      );
+    },
+  },
+  {
+    name: "memoize-exported",
+    description: "memoize function is exported and callable",
+    test: () => {
+      expectFunctionType(memoize, undefined, "memoize should be a function");
+    },
+  },
+  {
+    name: "memoize-works",
+    description: "memoize function memoizes correctly",
+    test: () => {
+      let callCount = 0;
+      const expensiveFn = (x) => {
+        callCount++;
+        return x * 2;
+      };
+
+      const memoizedFn = memoize(expensiveFn);
+
+      const result1 = memoizedFn(5);
+      const result2 = memoizedFn(5);
+      const result3 = memoizedFn(10);
+
+      expectStrictEqual(result1, 10, "First call should return correct result");
+      expectStrictEqual(result2, 10, "Second call should return cached result");
+      expectStrictEqual(result3, 20, "Different arg should compute new result");
+      expectStrictEqual(callCount, 2, "Function should only be called twice");
+    },
+  },
+  {
+    name: "arraySlugKey-with-memoize",
+    description: "arraySlugKey works as cache key for memoize",
+    test: () => {
+      let callCount = 0;
+      const filterFn = (arr, slug) => {
+        callCount++;
+        return arr.filter((item) => item.slug === slug);
+      };
+
+      const memoizedFilter = memoize(filterFn, { cacheKey: arraySlugKey });
+
+      const items = [
+        { slug: "a", name: "Item A" },
+        { slug: "b", name: "Item B" },
+      ];
+
+      const result1 = memoizedFilter(items, "a");
+      const result2 = memoizedFilter(items, "a");
+      const result3 = memoizedFilter(items, "b");
+
+      expectStrictEqual(result1.length, 1, "First call should filter correctly");
+      expectStrictEqual(
+        result1[0].name,
+        "Item A",
+        "First call should return correct item",
+      );
+      expectStrictEqual(
+        result2.length,
+        1,
+        "Second call should return cached result",
+      );
+      expectStrictEqual(
+        result3.length,
+        1,
+        "Different slug should compute new result",
+      );
+      expectStrictEqual(
+        callCount,
+        2,
+        "Function should only be called twice with different slugs",
+      );
+    },
+  },
+];
+
+export default createTestRunner("memoize", testCases);

--- a/test/test-hygiene.test.js
+++ b/test/test-hygiene.test.js
@@ -96,6 +96,9 @@ const ALLOWED_TEST_FUNCTIONS = new Set([
   "test",
   // naming-conventions.test.js - test fixture string
   "getUserById",
+  // memoize.test.js - test fixtures for memoize behavior
+  "expensiveFn",
+  "filterFn",
 ]);
 
 // Maximum lines for a function in a test file before it's suspicious


### PR DESCRIPTION
- Add comprehensive tests for guides.js collection functions
- Add tests for memoize.js arraySlugKey helper
- Export guidesByCategory function for testing
- Increase functions coverage threshold from 74% to 75%
- Add test fixture function names to allowed list