### PR TITLE
Move precommit checks into main test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"knip:fix": "knip --fix",
 		"lint": "pnpm dlx @biomejs/biome check .",
 		"lint:fix": "pnpm dlx @biomejs/biome check --write .",
-		"precommit": "run-s lint:fix cpd knip:fix test"
+		"precommit": "run-s lint:fix knip:fix test"
 	},
 	"devDependencies": {
 		"c8": "^10.1.3",

--- a/test/code-quality-exceptions.js
+++ b/test/code-quality-exceptions.js
@@ -114,6 +114,12 @@ const ALLOWED_TRY_CATCHES = new Set([
   "test/cache-buster.test.js:97",
   "test/cache-buster.test.js:120",
   "test/cache-buster.test.js:147",
+
+  // test/cpd.test.js - running external tool and capturing exit code
+  "test/cpd.test.js:12",
+
+  // test/knip.test.js - running external tool and capturing exit code
+  "test/knip.test.js:12",
 ]);
 
 // ============================================

--- a/test/cpd.test.js
+++ b/test/cpd.test.js
@@ -1,0 +1,37 @@
+import { execSync } from "child_process";
+import { createTestRunner, expectStrictEqual, rootDir } from "./test-utils.js";
+
+const testCases = [
+  {
+    name: "no-duplicate-code",
+    description: "jscpd finds no copy-pasted code blocks",
+    test: () => {
+      let output = "";
+      let exitCode = 0;
+
+      try {
+        output = execSync("pnpm cpd", {
+          cwd: rootDir,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (error) {
+        exitCode = error.status || 1;
+        output = error.stdout || error.stderr || error.message;
+      }
+
+      if (exitCode !== 0) {
+        console.log("\n  Duplicate code detected:\n");
+        console.log(output);
+      }
+
+      expectStrictEqual(
+        exitCode,
+        0,
+        "jscpd found duplicate code blocks. Run 'pnpm cpd' to see details.",
+      );
+    },
+  },
+];
+
+createTestRunner("cpd", testCases);

--- a/test/knip.test.js
+++ b/test/knip.test.js
@@ -1,0 +1,37 @@
+import { execSync } from "child_process";
+import { createTestRunner, expectStrictEqual, rootDir } from "./test-utils.js";
+
+const testCases = [
+  {
+    name: "no-unused-exports",
+    description: "Knip finds no unused exports or dependencies",
+    test: () => {
+      let output = "";
+      let exitCode = 0;
+
+      try {
+        output = execSync("pnpm knip", {
+          cwd: rootDir,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (error) {
+        exitCode = error.status || 1;
+        output = error.stdout || error.message;
+      }
+
+      if (exitCode !== 0) {
+        console.log("\n  Knip found issues:\n");
+        console.log(output);
+      }
+
+      expectStrictEqual(
+        exitCode,
+        0,
+        "Knip found unused exports or dependencies. Run 'pnpm knip' to see details, or 'pnpm knip:fix' to auto-fix.",
+      );
+    },
+  },
+];
+
+createTestRunner("knip", testCases);


### PR DESCRIPTION
Add knip.test.js and cpd.test.js to wrap the knip and jscpd tools as proper tests, so they run as part of `pnpm run test`. This means CI and developers get these checks automatically.

The precommit script now only runs the auto-fix versions (lint:fix, knip:fix) before running tests, avoiding redundant checks.