### PR TITLE
Remove try-catch blocks from snippet tests

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,11 +17,10 @@ import { configureProperties } from "#collections/properties.js";
 import { configureReviews } from "#collections/reviews.js";
 import { configureSearch } from "#collections/search.js";
 import { configureTags } from "#collections/tags.js";
-
+import { configureAreaList } from "#eleventy/area-list.js";
 // Eleventy plugins
 import { configureCacheBuster } from "#eleventy/cache-buster.js";
 import { configureCanonicalUrl } from "#eleventy/canonical-url.js";
-import { configureAreaList } from "#eleventy/area-list.js";
 import { configureExternalLinks } from "#eleventy/external-links.js";
 import { configureFeed } from "#eleventy/feed.js";
 import { configureFileUtils } from "#eleventy/file-utils.js";

--- a/src/_data/categoryOrder.js
+++ b/src/_data/categoryOrder.js
@@ -1,14 +1,9 @@
 import configJson from "./config.json" with { type: "json" };
 
-const DEFAULT_ORDER = [
-  "content",
-  "faqs",
-  "subcategories",
-  "products",
-];
+const DEFAULT_ORDER = ["content", "faqs", "subcategories", "products"];
 
 const configOrder = configJson.category_order;
 
 export default Array.isArray(configOrder) && configOrder.length > 0
-    ? configOrder
-    : DEFAULT_ORDER
+  ? configOrder
+  : DEFAULT_ORDER;

--- a/src/_data/listItemFields.js
+++ b/src/_data/listItemFields.js
@@ -14,5 +14,5 @@ const DEFAULT_FIELDS = [
 const configFields = configJson.list_item_fields;
 
 export default Array.isArray(configFields) && configFields.length > 0
-    ? configFields
-    : DEFAULT_FIELDS
+  ? configFields
+  : DEFAULT_FIELDS;

--- a/src/_data/specs_icons.js
+++ b/src/_data/specs_icons.js
@@ -5,8 +5,8 @@
  * Values are icon filenames in assets/icons/
  */
 
-import baseIcons from "./specs-icons-base.json" with { type: "json" };
 import userIcons from "./specs_icons.json" with { type: "json" };
+import baseIcons from "./specs-icons-base.json" with { type: "json" };
 
 export default {
   ...baseIcons,

--- a/src/_data/strings.js
+++ b/src/_data/strings.js
@@ -7,8 +7,8 @@
  * This is enforced by tests in test/strings.test.js
  */
 
-import baseStrings from "./strings-base.json" with { type: "json" };
 import userStrings from "./strings.json" with { type: "json" };
+import baseStrings from "./strings-base.json" with { type: "json" };
 
 export default {
   ...baseStrings,

--- a/src/_lib/build/theme-compiler.js
+++ b/src/_lib/build/theme-compiler.js
@@ -60,7 +60,7 @@ const generateThemeSwitcherContent = memoize(() => {
   // Generate theme list as CSS custom property for JavaScript access
   const themeList = ["default", ...themes.map((t) => t.name)];
   const displayNames = themes.map(
-    (theme) => `  --theme-${theme.name}-name: "${toDisplayName(theme.name)}";`
+    (theme) => `  --theme-${theme.name}-name: "${toDisplayName(theme.name)}";`,
   );
 
   const metadata = `// Theme metadata for JavaScript access

--- a/src/_lib/collections/menus.js
+++ b/src/_lib/collections/menus.js
@@ -57,8 +57,4 @@ const configureMenus = (eleventyConfig) => {
   eleventyConfig.addFilter("getItemsByCategory", getItemsByCategory);
 };
 
-export {
-  configureMenus,
-  getCategoriesByMenu,
-  getItemsByCategory,
-};
+export { configureMenus, getCategoriesByMenu, getItemsByCategory };

--- a/src/_lib/filters/item-filters.js
+++ b/src/_lib/filters/item-filters.js
@@ -194,7 +194,7 @@ const normalizeFilters = (filters) => {
 const countMatchingItems = (items, itemAttrMap, filters) => {
   const normalizedFilters = normalizeFilters(filters);
   return items.filter((item) =>
-    attrsMatch(itemAttrMap.get(item), normalizedFilters)
+    attrsMatch(itemAttrMap.get(item), normalizedFilters),
   ).length;
 };
 

--- a/src/_lib/filters/spec-filters.js
+++ b/src/_lib/filters/spec-filters.js
@@ -8,11 +8,11 @@ import { inlineAsset } from "#media/inline-asset.js";
  * @returns {string} - The icon SVG content or empty string if not found
  */
 const getSpecIcon = (specName) => {
-	if (!specName) return "";
-	const normalized = specName.toLowerCase().trim();
-	const iconFile = specsIcons[normalized];
-	if (!iconFile) return "";
-	return inlineAsset(`icons/${iconFile}`);
+  if (!specName) return "";
+  const normalized = specName.toLowerCase().trim();
+  const iconFile = specsIcons[normalized];
+  if (!iconFile) return "";
+  return inlineAsset(`icons/${iconFile}`);
 };
 
 /**
@@ -21,11 +21,11 @@ const getSpecIcon = (specName) => {
  * @returns {Array|undefined} - Specs array with icon property added
  */
 const computeSpecs = (data) => {
-	if (!data.specs) return undefined;
-	return data.specs.map((spec) => ({
-		...spec,
-		icon: getSpecIcon(spec.name),
-	}));
+  if (!data.specs) return undefined;
+  return data.specs.map((spec) => ({
+    ...spec,
+    icon: getSpecIcon(spec.name),
+  }));
 };
 
 export { getSpecIcon, computeSpecs };

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -112,7 +112,13 @@ const U = {
     return cachedPath;
   },
   // Build div HTML string directly instead of using JSDOM (much faster)
-  makeDivHtml: async (classes, thumbPromise, imageAspectRatio, maxWidth, innerHTML) => {
+  makeDivHtml: async (
+    classes,
+    thumbPromise,
+    imageAspectRatio,
+    maxWidth,
+    innerHTML,
+  ) => {
     const classAttr = classes
       ? `class="image-wrapper ${classes}"`
       : 'class="image-wrapper"';

--- a/src/products/products.11tydata.js
+++ b/src/products/products.11tydata.js
@@ -18,9 +18,7 @@ function computeCartAttributes(data) {
       max_quantity: opt.max_quantity || null,
       sku: opt.sku || null,
     })),
-    specs: specs
-      ? specs.map((s) => ({ name: s.name, value: s.value }))
-      : null,
+    specs: specs ? specs.map((s) => ({ name: s.name, value: s.value })) : null,
   }).replace(/"/g, "&quot;");
 }
 

--- a/test/area-list.test.js
+++ b/test/area-list.test.js
@@ -1,19 +1,19 @@
 import {
-  isTopLevelLocation,
-  sortByNavigationKey,
-  filterTopLevelLocations,
-  formatListWithAnd,
-  locationToLink,
-  formatAreaList,
   configureAreaList,
+  filterTopLevelLocations,
+  formatAreaList,
+  formatListWithAnd,
+  isTopLevelLocation,
+  locationToLink,
+  sortByNavigationKey,
 } from "#eleventy/area-list.js";
 import {
   createMockEleventyConfig,
   createTestRunner,
   expectDeepEqual,
+  expectFalse,
   expectStrictEqual,
   expectTrue,
-  expectFalse,
 } from "./test-utils.js";
 
 // Test fixtures
@@ -252,7 +252,11 @@ const testCases = [
     test: () => {
       expectStrictEqual(formatListWithAnd([]), "", "Should return empty");
       expectStrictEqual(formatListWithAnd(null), "", "Should return empty");
-      expectStrictEqual(formatListWithAnd(undefined), "", "Should return empty");
+      expectStrictEqual(
+        formatListWithAnd(undefined),
+        "",
+        "Should return empty",
+      );
     },
   },
   {

--- a/test/category-order.test.js
+++ b/test/category-order.test.js
@@ -1,12 +1,7 @@
 import categoryOrder from "../src/_data/categoryOrder.js";
 import { createTestRunner, expectDeepEqual } from "./test-utils.js";
 
-const DEFAULT_ORDER = [
-  "content",
-  "faqs",
-  "subcategories",
-  "products",
-];
+const DEFAULT_ORDER = ["content", "faqs", "subcategories", "products"];
 
 const testCases = [
   {

--- a/test/checkout.test.js
+++ b/test/checkout.test.js
@@ -342,8 +342,14 @@ const testCases = [
       const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
       global.document = dom.window.document;
       try {
-        assert.strictEqual(escapeHtml("<script>alert('xss')</script>"), "&lt;script&gt;alert('xss')&lt;/script&gt;");
-        assert.strictEqual(escapeHtml("Hello & Goodbye"), "Hello &amp; Goodbye");
+        assert.strictEqual(
+          escapeHtml("<script>alert('xss')</script>"),
+          "&lt;script&gt;alert('xss')&lt;/script&gt;",
+        );
+        assert.strictEqual(
+          escapeHtml("Hello & Goodbye"),
+          "Hello &amp; Goodbye",
+        );
         // Note: innerHTML doesn't escape quotes, only < > and &
         assert.strictEqual(escapeHtml('"quoted"'), '"quoted"');
         assert.strictEqual(escapeHtml("normal text"), "normal text");
@@ -377,9 +383,17 @@ const testCases = [
         updateCartIcon();
         const icon = dom.window.document.querySelector(".cart-icon");
         const badge = icon.querySelector(".cart-count");
-        assert.strictEqual(icon.style.display, "flex", "Icon should be visible");
+        assert.strictEqual(
+          icon.style.display,
+          "flex",
+          "Icon should be visible",
+        );
         assert.strictEqual(badge.textContent, "5", "Badge should show count 5");
-        assert.strictEqual(badge.style.display, "block", "Badge should be visible");
+        assert.strictEqual(
+          badge.style.display,
+          "block",
+          "Badge should be visible",
+        );
       } finally {
         globalThis.localStorage = origStorage;
         delete global.document;
@@ -409,7 +423,11 @@ const testCases = [
         const icon = dom.window.document.querySelector(".cart-icon");
         const badge = icon.querySelector(".cart-count");
         assert.strictEqual(icon.style.display, "none", "Icon should be hidden");
-        assert.strictEqual(badge.style.display, "none", "Badge should be hidden");
+        assert.strictEqual(
+          badge.style.display,
+          "none",
+          "Badge should be hidden",
+        );
       } finally {
         globalThis.localStorage = origStorage;
         delete global.document;
@@ -424,9 +442,17 @@ const testCases = [
       withMockStorage(() => {
         saveCart([{ item_name: "Widget", unit_price: 10, quantity: 2 }]);
         const result = updateItemQuantity("Widget", 5);
-        assert.strictEqual(result, true, "Should return true for existing item");
+        assert.strictEqual(
+          result,
+          true,
+          "Should return true for existing item",
+        );
         const cart = getCart();
-        assert.strictEqual(cart[0].quantity, 5, "Quantity should be updated to 5");
+        assert.strictEqual(
+          cart[0].quantity,
+          5,
+          "Quantity should be updated to 5",
+        );
       });
     },
   },
@@ -442,7 +468,11 @@ const testCases = [
         updateItemQuantity("Remove", 0);
         const cart = getCart();
         assert.strictEqual(cart.length, 1, "Cart should have 1 item");
-        assert.strictEqual(cart[0].item_name, "Keep", "Only Keep should remain");
+        assert.strictEqual(
+          cart[0].item_name,
+          "Keep",
+          "Only Keep should remain",
+        );
       });
     },
   },
@@ -455,12 +485,26 @@ const testCases = [
       global.alert = (msg) => alerts.push(msg);
       try {
         withMockStorage(() => {
-          saveCart([{ item_name: "Limited", unit_price: 10, quantity: 2, max_quantity: 5 }]);
+          saveCart([
+            {
+              item_name: "Limited",
+              unit_price: 10,
+              quantity: 2,
+              max_quantity: 5,
+            },
+          ]);
           updateItemQuantity("Limited", 10);
           const cart = getCart();
-          assert.strictEqual(cart[0].quantity, 5, "Quantity should be capped at max_quantity");
+          assert.strictEqual(
+            cart[0].quantity,
+            5,
+            "Quantity should be capped at max_quantity",
+          );
           assert.strictEqual(alerts.length, 1, "Should show alert");
-          assert.ok(alerts[0].includes("5"), "Alert should mention max quantity");
+          assert.ok(
+            alerts[0].includes("5"),
+            "Alert should mention max quantity",
+          );
         });
       } finally {
         global.alert = origAlert;
@@ -474,7 +518,11 @@ const testCases = [
       withMockStorage(() => {
         saveCart([{ item_name: "Widget", unit_price: 10, quantity: 2 }]);
         const result = updateItemQuantity("NonExistent", 5);
-        assert.strictEqual(result, false, "Should return false for non-existent item");
+        assert.strictEqual(
+          result,
+          false,
+          "Should return false for non-existent item",
+        );
       });
     },
   },
@@ -497,16 +545,32 @@ const testCases = [
 
         const decreaseBtn = container.querySelector(".qty-decrease");
         assert.ok(decreaseBtn, "Should have decrease button");
-        assert.strictEqual(decreaseBtn.dataset.name, "Widget", "Decrease button should have data-name");
+        assert.strictEqual(
+          decreaseBtn.dataset.name,
+          "Widget",
+          "Decrease button should have data-name",
+        );
 
         const increaseBtn = container.querySelector(".qty-increase");
         assert.ok(increaseBtn, "Should have increase button");
-        assert.strictEqual(increaseBtn.dataset.name, "Widget", "Increase button should have data-name");
+        assert.strictEqual(
+          increaseBtn.dataset.name,
+          "Widget",
+          "Increase button should have data-name",
+        );
 
         const input = container.querySelector(".qty-input");
         assert.ok(input, "Should have quantity input");
-        assert.strictEqual(input.value, "3", "Input should have quantity value");
-        assert.strictEqual(input.dataset.name, "Widget", "Input should have data-name");
+        assert.strictEqual(
+          input.value,
+          "3",
+          "Input should have quantity value",
+        );
+        assert.strictEqual(
+          input.dataset.name,
+          "Widget",
+          "Input should have data-name",
+        );
       } finally {
         delete global.document;
         dom.window.close();
@@ -515,7 +579,8 @@ const testCases = [
   },
   {
     name: "cart-utils-renderQuantityControls-max-quantity",
-    description: "renderQuantityControls includes max attribute when max_quantity set",
+    description:
+      "renderQuantityControls includes max attribute when max_quantity set",
     asyncTest: async () => {
       const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
       global.document = dom.window.document;
@@ -527,7 +592,11 @@ const testCases = [
         container.innerHTML = html;
 
         const input = container.querySelector(".qty-input");
-        assert.strictEqual(input.getAttribute("max"), "5", "Input should have max attribute");
+        assert.strictEqual(
+          input.getAttribute("max"),
+          "5",
+          "Input should have max attribute",
+        );
       } finally {
         delete global.document;
         dom.window.close();
@@ -544,8 +613,14 @@ const testCases = [
         const item = { item_name: "<script>xss</script>", quantity: 1 };
         const html = renderQuantityControls(item);
 
-        assert.ok(!html.includes("<script>xss</script>"), "Should escape HTML in item name");
-        assert.ok(html.includes("&lt;script&gt;"), "Should contain escaped HTML");
+        assert.ok(
+          !html.includes("<script>xss</script>"),
+          "Should escape HTML in item name",
+        );
+        assert.ok(
+          html.includes("&lt;script&gt;"),
+          "Should contain escaped HTML",
+        );
       } finally {
         delete global.document;
         dom.window.close();
@@ -703,10 +778,18 @@ const testCases = [
         const removeBtn = container.querySelector(".remove-btn");
         removeBtn.click();
 
-        assert.strictEqual(removeCalled, true, "onRemove callback should be called");
+        assert.strictEqual(
+          removeCalled,
+          true,
+          "onRemove callback should be called",
+        );
         const cart = getCart();
         assert.strictEqual(cart.length, 1, "Cart should have 1 item");
-        assert.strictEqual(cart[0].item_name, "Gadget", "Widget should be removed");
+        assert.strictEqual(
+          cart[0].item_name,
+          "Gadget",
+          "Widget should be removed",
+        );
       } finally {
         globalThis.localStorage = origStorage;
         dom.window.close();
@@ -1085,7 +1168,8 @@ const testCases = [
   },
   {
     name: "template-list-item-cart-button-no-options",
-    description: "List item cart button renders nothing for items without options",
+    description:
+      "List item cart button renders nothing for items without options",
     asyncTest: async () => {
       const config = { cart_mode: "stripe" };
       const item = {
@@ -1867,7 +1951,8 @@ const testCases = [
   },
   {
     name: "multi-option-select-options-have-data",
-    description: "Select options have index values and button has consolidated data",
+    description:
+      "Select options have index values and button has consolidated data",
     asyncTest: async () => {
       const dom = await createCheckoutPage({
         productOptions: [
@@ -1934,10 +2019,7 @@ const testCases = [
       assert.strictEqual(button.disabled, false, "Button should be enabled");
       assert.strictEqual(option.name, "Small");
       assert.strictEqual(option.unit_price, 5.0);
-      assert.ok(
-        button.textContent.includes("5"),
-        "Button should show price",
-      );
+      assert.ok(button.textContent.includes("5"), "Button should show price");
 
       dom.window.close();
     },

--- a/test/code-quality-exceptions.js
+++ b/test/code-quality-exceptions.js
@@ -42,10 +42,6 @@ const ALLOWED_TRY_CATCHES = new Set([
   // ecommerce-backend/server.test.js - test assertions
   "ecommerce-backend/server.test.js:370",
 
-  // test/render-snippet.test.js - test cleanup
-  "test/render-snippet.test.js:102",
-  "test/render-snippet.test.js:130",
-
   // src/assets/js/cart.js - localStorage and fetch handling
   "src/assets/js/cart.js:132",
   "src/assets/js/cart.js:181",
@@ -53,7 +49,7 @@ const ALLOWED_TRY_CATCHES = new Set([
 
   // src/_lib/media/image.js - image processing
   "src/_lib/media/image.js:74",
-  "src/_lib/media/image.js:331",
+  "src/_lib/media/image.js:337",
 
   // src/assets/js/stripe-checkout.js - Stripe API
   "src/assets/js/stripe-checkout.js:38",
@@ -80,16 +76,16 @@ const ALLOWED_TRY_CATCHES = new Set([
   "test/checkout.test.js:235",
   "test/checkout.test.js:283",
   "test/checkout.test.js:344",
-  "test/checkout.test.js:372",
-  "test/checkout.test.js:406",
-  "test/checkout.test.js:456",
-  "test/checkout.test.js:487",
-  "test/checkout.test.js:522",
-  "test/checkout.test.js:543",
-  "test/checkout.test.js:572",
+  "test/checkout.test.js:378",
+  "test/checkout.test.js:420",
+  "test/checkout.test.js:486",
+  "test/checkout.test.js:535",
+  "test/checkout.test.js:587",
   "test/checkout.test.js:612",
-  "test/checkout.test.js:650",
-  "test/checkout.test.js:689",
+  "test/checkout.test.js:647",
+  "test/checkout.test.js:687",
+  "test/checkout.test.js:725",
+  "test/checkout.test.js:764",
 
   // test/inline-asset.test.js - inline asset tests
   "test/inline-asset.test.js:128",
@@ -122,7 +118,7 @@ const ALLOWED_TRY_CATCHES = new Set([
 const ALLOWED_LOOSE_EQUALITY = new Set([
   // src/_lib/media/image.js - null checks
   "src/_lib/media/image.js:101",
-  "src/_lib/media/image.js:171",
+  "src/_lib/media/image.js:177",
 
   // src/categories/categories.11tydata.js - null check
   "src/categories/categories.11tydata.js:8",

--- a/test/commented-code.test.js
+++ b/test/commented-code.test.js
@@ -1,4 +1,13 @@
-import { createTestRunner, ECOMMERCE_JS_FILES, expectTrue, fs, path, rootDir, SRC_JS_FILES, TEST_FILES } from "./test-utils.js";
+import {
+  createTestRunner,
+  ECOMMERCE_JS_FILES,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_JS_FILES,
+  TEST_FILES,
+} from "./test-utils.js";
 
 /**
  * Patterns that indicate commented-out code (not documentation)
@@ -121,8 +130,11 @@ const analyzeCommentedCode = () => {
   const violations = [];
 
   // Exclude this test file
-  const allJsFiles = [...SRC_JS_FILES, ...ECOMMERCE_JS_FILES, ...TEST_FILES]
-    .filter((f) => f !== "test/commented-code.test.js");
+  const allJsFiles = [
+    ...SRC_JS_FILES,
+    ...ECOMMERCE_JS_FILES,
+    ...TEST_FILES,
+  ].filter((f) => f !== "test/commented-code.test.js");
 
   for (const relativePath of allJsFiles) {
     const fullPath = path.join(rootDir, relativePath);
@@ -155,11 +167,11 @@ const c = 3;
       const results = findCommentedCode(source, "test.js");
       expectTrue(
         results.length === 1,
-        `Expected 1 commented code, found ${results.length}`
+        `Expected 1 commented code, found ${results.length}`,
       );
       expectTrue(
         results[0].lineNumber === 3,
-        `Expected line 3, got ${results[0].lineNumber}`
+        `Expected line 3, got ${results[0].lineNumber}`,
       );
     },
   },
@@ -175,7 +187,7 @@ function active() {}
       const results = findCommentedCode(source, "test.js");
       expectTrue(
         results.length === 2,
-        `Expected 2 commented code, found ${results.length}`
+        `Expected 2 commented code, found ${results.length}`,
       );
     },
   },
@@ -191,13 +203,14 @@ console.log("active");
       const results = findCommentedCode(source, "test.js");
       expectTrue(
         results.length === 2,
-        `Expected 2 commented code, found ${results.length}`
+        `Expected 2 commented code, found ${results.length}`,
       );
     },
   },
   {
     name: "ignore-template-literals",
-    description: "Ignores commented code inside template literals (test fixtures)",
+    description:
+      "Ignores commented code inside template literals (test fixtures)",
     test: () => {
       const source = `
 const testFixture = \`
@@ -209,7 +222,7 @@ const real = 1;
       const results = findCommentedCode(source, "test.js");
       expectTrue(
         results.length === 0,
-        `Expected 0 commented code in template literals, found ${results.length}`
+        `Expected 0 commented code in template literals, found ${results.length}`,
       );
     },
   },
@@ -226,7 +239,7 @@ const a = 1;
       const results = findCommentedCode(source, "test.js");
       expectTrue(
         results.length === 0,
-        `Expected 0 commented code, found ${results.length}`
+        `Expected 0 commented code, found ${results.length}`,
       );
     },
   },
@@ -247,7 +260,7 @@ const a = 1;
 
       expectTrue(
         violations.length === 0,
-        `Found ${violations.length} commented-out code. See list above.`
+        `Found ${violations.length} commented-out code. See list above.`,
       );
     },
   },

--- a/test/function-length.test.js
+++ b/test/function-length.test.js
@@ -1,4 +1,11 @@
-import { createTestRunner, expectTrue, fs, path, rootDir, SRC_JS_FILES } from "./test-utils.js";
+import {
+  createTestRunner,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_JS_FILES,
+} from "./test-utils.js";
 
 // Configuration
 const MAX_LINES = 30;
@@ -160,7 +167,9 @@ const analyzeFunctionLengths = () => {
   const violations = [];
 
   // Only check library code, not frontend assets
-  for (const relativePath of SRC_JS_FILES.filter((f) => !f.startsWith("src/assets/"))) {
+  for (const relativePath of SRC_JS_FILES.filter(
+    (f) => !f.startsWith("src/assets/"),
+  )) {
     const fullPath = path.join(rootDir, relativePath);
     const source = fs.readFileSync(fullPath, "utf-8");
     const functions = calculateOwnLines(extractFunctions(source));

--- a/test/guides.test.js
+++ b/test/guides.test.js
@@ -1,7 +1,4 @@
-import {
-  configureGuides,
-  guidesByCategory,
-} from "#collections/guides.js";
+import { configureGuides, guidesByCategory } from "#collections/guides.js";
 import {
   createMockEleventyConfig,
   createTestRunner,
@@ -150,11 +147,7 @@ const testCases = [
 
       const result = guidesByCategory(guidePages, "getting-started");
 
-      expectStrictEqual(
-        result.length,
-        1,
-        "Should only match exact case",
-      );
+      expectStrictEqual(result.length, 1, "Should only match exact case");
       expectStrictEqual(
         result[0].data.title,
         "Guide 2",
@@ -238,7 +231,8 @@ const testCases = [
         },
       };
 
-      const categories = mockConfig.collections["guide-categories"](mockCollectionApi);
+      const categories =
+        mockConfig.collections["guide-categories"](mockCollectionApi);
       const pages = mockConfig.collections["guide-pages"](mockCollectionApi);
 
       expectStrictEqual(

--- a/test/let-usage.test.js
+++ b/test/let-usage.test.js
@@ -1,5 +1,17 @@
-import { createTestRunner, ECOMMERCE_JS_FILES, expectTrue, fs, path, rootDir, SRC_JS_FILES, TEST_FILES } from "./test-utils.js";
-import { ALLOWED_MUTABLE_VAR_FILES, ALLOWED_LET_PATTERNS } from "./code-quality-exceptions.js";
+import {
+  ALLOWED_LET_PATTERNS,
+  ALLOWED_MUTABLE_VAR_FILES,
+} from "./code-quality-exceptions.js";
+import {
+  createTestRunner,
+  ECOMMERCE_JS_FILES,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_JS_FILES,
+  TEST_FILES,
+} from "./test-utils.js";
 
 // Set to true once all lets are removed to enforce const-only style
 const ENFORCE_NO_LET = false;
@@ -56,8 +68,11 @@ const analyzeMutableVarUsage = () => {
   const letWarnings = [];
 
   // Exclude this test file since it contains var/let examples in test strings
-  const allJsFiles = [...SRC_JS_FILES, ...ECOMMERCE_JS_FILES, ...TEST_FILES]
-    .filter((f) => f !== "test/let-usage.test.js");
+  const allJsFiles = [
+    ...SRC_JS_FILES,
+    ...ECOMMERCE_JS_FILES,
+    ...TEST_FILES,
+  ].filter((f) => f !== "test/let-usage.test.js");
 
   for (const relativePath of allJsFiles) {
     // Skip fully allowed files
@@ -124,11 +139,11 @@ const d = "not a declaration";
       const vars = results.filter((r) => r.keyword === "var");
       expectTrue(
         lets.length === 2,
-        `Expected 2 let declarations, found ${lets.length}`
+        `Expected 2 let declarations, found ${lets.length}`,
       );
       expectTrue(
         vars.length === 2,
-        `Expected 2 var declarations, found ${vars.length}`
+        `Expected 2 var declarations, found ${vars.length}`,
       );
     },
   },
@@ -144,7 +159,7 @@ const d = "not a declaration";
       for (const line of allowedLines) {
         expectTrue(
           isAllowedLetPattern(line),
-          `Expected "${line}" to be allowed`
+          `Expected "${line}" to be allowed`,
         );
       }
 
@@ -156,7 +171,7 @@ const d = "not a declaration";
       for (const line of disallowedLines) {
         expectTrue(
           !isAllowedLetPattern(line),
-          `Expected "${line}" to NOT be allowed`
+          `Expected "${line}" to NOT be allowed`,
         );
       }
     },
@@ -168,17 +183,21 @@ const d = "not a declaration";
       const { varViolations } = analyzeMutableVarUsage();
 
       if (varViolations.length > 0) {
-        console.log(`\n  Found ${varViolations.length} non-whitelisted var declarations:`);
+        console.log(
+          `\n  Found ${varViolations.length} non-whitelisted var declarations:`,
+        );
         for (const v of varViolations) {
           console.log(`     - ${v.file}:${v.line}`);
           console.log(`       ${v.code}`);
         }
-        console.log("\n  To fix: refactor to const, or add file to ALLOWED_MUTABLE_VAR_FILES in code-quality-exceptions.js\n");
+        console.log(
+          "\n  To fix: refactor to const, or add file to ALLOWED_MUTABLE_VAR_FILES in code-quality-exceptions.js\n",
+        );
       }
 
       expectTrue(
         varViolations.length === 0,
-        `Found ${varViolations.length} non-whitelisted var declarations. See list above.`
+        `Found ${varViolations.length} non-whitelisted var declarations. See list above.`,
       );
     },
   },
@@ -189,7 +208,9 @@ const d = "not a declaration";
       const { letWarnings } = analyzeMutableVarUsage();
 
       if (letWarnings.length > 0) {
-        console.log(`\n  Found ${letWarnings.length} let declarations to review:`);
+        console.log(
+          `\n  Found ${letWarnings.length} let declarations to review:`,
+        );
         for (const w of letWarnings) {
           console.log(`     - ${w.file}:${w.line}`);
           console.log(`       ${w.code}`);
@@ -201,7 +222,7 @@ const d = "not a declaration";
       if (ENFORCE_NO_LET && letWarnings.length > 0) {
         throw new Error(
           `Found ${letWarnings.length} let declarations. ` +
-          `Refactor to use const or add to ALLOWED_LET_PATTERNS.`
+            `Refactor to use const or add to ALLOWED_LET_PATTERNS.`,
         );
       }
 

--- a/test/locations.test.js
+++ b/test/locations.test.js
@@ -54,13 +54,29 @@ const testCases = [
     description: "Gets sibling locations excluding current page",
     test: () => {
       const locations = [
-        { data: { title: "Cleaning", parentLocation: "london" }, url: "/london/cleaning/" },
-        { data: { title: "Repairs", parentLocation: "london" }, url: "/london/repairs/" },
-        { data: { title: "Painting", parentLocation: "london" }, url: "/london/painting/" },
-        { data: { title: "Plumbing", parentLocation: "manchester" }, url: "/manchester/plumbing/" },
+        {
+          data: { title: "Cleaning", parentLocation: "london" },
+          url: "/london/cleaning/",
+        },
+        {
+          data: { title: "Repairs", parentLocation: "london" },
+          url: "/london/repairs/",
+        },
+        {
+          data: { title: "Painting", parentLocation: "london" },
+          url: "/london/painting/",
+        },
+        {
+          data: { title: "Plumbing", parentLocation: "manchester" },
+          url: "/manchester/plumbing/",
+        },
       ];
 
-      const result = getSiblingLocations(locations, "london", "/london/cleaning/");
+      const result = getSiblingLocations(
+        locations,
+        "london",
+        "/london/cleaning/",
+      );
 
       expectStrictEqual(result.length, 2, "Should return 2 siblings");
       expectStrictEqual(
@@ -80,11 +96,21 @@ const testCases = [
     description: "Returns empty when no siblings exist",
     test: () => {
       const locations = [
-        { data: { title: "Cleaning", parentLocation: "london" }, url: "/london/cleaning/" },
-        { data: { title: "Plumbing", parentLocation: "manchester" }, url: "/manchester/plumbing/" },
+        {
+          data: { title: "Cleaning", parentLocation: "london" },
+          url: "/london/cleaning/",
+        },
+        {
+          data: { title: "Plumbing", parentLocation: "manchester" },
+          url: "/manchester/plumbing/",
+        },
       ];
 
-      const result = getSiblingLocations(locations, "london", "/london/cleaning/");
+      const result = getSiblingLocations(
+        locations,
+        "london",
+        "/london/cleaning/",
+      );
 
       expectStrictEqual(result.length, 0, "Should return no siblings");
     },
@@ -94,7 +120,10 @@ const testCases = [
     description: "Handles null/undefined inputs",
     test: () => {
       const locations = [
-        { data: { title: "Cleaning", parentLocation: "london" }, url: "/london/cleaning/" },
+        {
+          data: { title: "Cleaning", parentLocation: "london" },
+          url: "/london/cleaning/",
+        },
       ];
 
       expectDeepEqual(

--- a/test/loose-equality.test.js
+++ b/test/loose-equality.test.js
@@ -1,5 +1,14 @@
-import { createTestRunner, ECOMMERCE_JS_FILES, expectTrue, fs, path, rootDir, SRC_JS_FILES, TEST_FILES } from "./test-utils.js";
 import { ALLOWED_LOOSE_EQUALITY } from "./code-quality-exceptions.js";
+import {
+  createTestRunner,
+  ECOMMERCE_JS_FILES,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_JS_FILES,
+  TEST_FILES,
+} from "./test-utils.js";
 
 /**
  * Find all loose equality comparisons (== or !=) in a file
@@ -26,7 +35,12 @@ const findLooseEquality = (source) => {
       const singleQuotes = (beforeMatch.match(/'/g) || []).length;
       const doubleQuotes = (beforeMatch.match(/"/g) || []).length;
       const backticks = (beforeMatch.match(/`/g) || []).length;
-      if (singleQuotes % 2 === 1 || doubleQuotes % 2 === 1 || backticks % 2 === 1) continue;
+      if (
+        singleQuotes % 2 === 1 ||
+        doubleQuotes % 2 === 1 ||
+        backticks % 2 === 1
+      )
+        continue;
 
       results.push({
         lineNumber: i + 1,
@@ -47,8 +61,11 @@ const analyzeLooseEquality = () => {
   const allowed = [];
 
   // Exclude this test file since it contains examples in test strings
-  const allJsFiles = [...SRC_JS_FILES, ...ECOMMERCE_JS_FILES, ...TEST_FILES]
-    .filter((f) => f !== "test/loose-equality.test.js");
+  const allJsFiles = [
+    ...SRC_JS_FILES,
+    ...ECOMMERCE_JS_FILES,
+    ...TEST_FILES,
+  ].filter((f) => f !== "test/loose-equality.test.js");
 
   for (const relativePath of allJsFiles) {
     const fullPath = path.join(rootDir, relativePath);
@@ -96,15 +113,15 @@ const str = "x == y";
       const results = findLooseEquality(source);
       expectTrue(
         results.length === 2,
-        `Expected 2 loose equality comparisons, found ${results.length}`
+        `Expected 2 loose equality comparisons, found ${results.length}`,
       );
       expectTrue(
         results[0].operator === "==",
-        `Expected first operator to be ==, got ${results[0].operator}`
+        `Expected first operator to be ==, got ${results[0].operator}`,
       );
       expectTrue(
         results[1].operator === "!=",
-        `Expected second operator to be !=, got ${results[1].operator}`
+        `Expected second operator to be !=, got ${results[1].operator}`,
       );
     },
   },
@@ -115,17 +132,21 @@ const str = "x == y";
       const { violations, allowed } = analyzeLooseEquality();
 
       if (violations.length > 0) {
-        console.log(`\n  Found ${violations.length} non-whitelisted loose equality comparisons:`);
+        console.log(
+          `\n  Found ${violations.length} non-whitelisted loose equality comparisons:`,
+        );
         for (const v of violations) {
           console.log(`     - ${v.file}:${v.line} (${v.operator})`);
           console.log(`       ${v.code}`);
         }
-        console.log("\n  To fix: use === or !== instead, or add to ALLOWED_LOOSE_EQUALITY in code-quality-exceptions.js\n");
+        console.log(
+          "\n  To fix: use === or !== instead, or add to ALLOWED_LOOSE_EQUALITY in code-quality-exceptions.js\n",
+        );
       }
 
       expectTrue(
         violations.length === 0,
-        `Found ${violations.length} non-whitelisted loose equality comparisons. See list above.`
+        `Found ${violations.length} non-whitelisted loose equality comparisons. See list above.`,
       );
     },
   },
@@ -135,7 +156,9 @@ const str = "x == y";
     test: () => {
       const { allowed } = analyzeLooseEquality();
 
-      console.log(`\n  Whitelisted loose equality comparisons: ${allowed.length}`);
+      console.log(
+        `\n  Whitelisted loose equality comparisons: ${allowed.length}`,
+      );
       console.log("  These should be refactored to === or !== over time:\n");
 
       // Group by file for cleaner output

--- a/test/memoize.test.js
+++ b/test/memoize.test.js
@@ -1,8 +1,8 @@
 import { arraySlugKey, memoize } from "#utils/memoize.js";
 import {
   createTestRunner,
-  expectStrictEqual,
   expectFunctionType,
+  expectStrictEqual,
 } from "./test-utils.js";
 
 const testCases = [
@@ -44,11 +44,7 @@ const testCases = [
 
       const result = arraySlugKey(args);
 
-      expectStrictEqual(
-        result,
-        "0:slug",
-        "Should use 0 for null array length",
-      );
+      expectStrictEqual(result, "0:slug", "Should use 0 for null array length");
     },
   },
   {
@@ -90,11 +86,7 @@ const testCases = [
 
       const result = arraySlugKey(args);
 
-      expectStrictEqual(
-        result,
-        "1:",
-        "Should handle empty slug",
-      );
+      expectStrictEqual(result, "1:", "Should handle empty slug");
     },
   },
   {
@@ -162,7 +154,11 @@ const testCases = [
       const result2 = memoizedFilter(items, "a");
       const result3 = memoizedFilter(items, "b");
 
-      expectStrictEqual(result1.length, 1, "First call should filter correctly");
+      expectStrictEqual(
+        result1.length,
+        1,
+        "First call should filter correctly",
+      );
       expectStrictEqual(
         result1[0].name,
         "Item A",

--- a/test/naming-conventions.test.js
+++ b/test/naming-conventions.test.js
@@ -1,4 +1,11 @@
-import { createTestRunner, expectTrue, fs, path, rootDir, SRC_JS_FILES } from "./test-utils.js";
+import {
+  createTestRunner,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_JS_FILES,
+} from "./test-utils.js";
 
 // Configuration
 const MAX_WORDS = 4;

--- a/test/opening-times.test.js
+++ b/test/opening-times.test.js
@@ -16,7 +16,11 @@ const testCases = [
     description: "Returns empty string for empty array",
     test: () => {
       const result = renderOpeningTimes([]);
-      expectStrictEqual(result, "", "Should return empty string for empty array");
+      expectStrictEqual(
+        result,
+        "",
+        "Should return empty string for empty array",
+      );
     },
   },
   {
@@ -88,7 +92,10 @@ const testCases = [
       const input = [{ day: "Friday", hours: "8am - 4pm" }];
       const result = renderOpeningTimes(input);
 
-      expectTrue(result.startsWith('<ul class="opening-times">'), "Should start with ul");
+      expectTrue(
+        result.startsWith('<ul class="opening-times">'),
+        "Should start with ul",
+      );
       expectTrue(result.endsWith("</ul>"), "Should end with closing ul");
       expectTrue(result.includes("</li>"), "Should have closing li tags");
     },
@@ -145,7 +152,11 @@ const testCases = [
       configureOpeningTimes(mockConfig);
 
       const result = mockConfig.filters.format_opening_times([]);
-      expectStrictEqual(result, "", "Filter should return empty string for empty input");
+      expectStrictEqual(
+        result,
+        "",
+        "Filter should return empty string for empty input",
+      );
     },
   },
 ];

--- a/test/products.test.js
+++ b/test/products.test.js
@@ -3,8 +3,8 @@ import {
   configureProducts,
   createProductsCollection,
   getFeaturedProducts,
-  getProductsByCategory,
   getProductsByCategories,
+  getProductsByCategory,
   processGallery,
 } from "#collections/products.js";
 import {

--- a/test/recurring-events.test.js
+++ b/test/recurring-events.test.js
@@ -1,14 +1,14 @@
 import { JSDOM } from "jsdom";
 import {
-  renderRecurringEvents,
   configureRecurringEvents,
+  renderRecurringEvents,
 } from "#eleventy/recurring-events.js";
 import {
   createMockEleventyConfig,
   createTestRunner,
+  expectFunctionType,
   expectStrictEqual,
   expectTrue,
-  expectFunctionType,
 } from "./test-utils.js";
 
 const testCases = [
@@ -18,7 +18,11 @@ const testCases = [
     description: "Returns empty string for empty events array",
     test: () => {
       const result = renderRecurringEvents([]);
-      expectStrictEqual(result, "", "Should return empty string for empty array");
+      expectStrictEqual(
+        result,
+        "",
+        "Should return empty string for empty array",
+      );
     },
   },
   {
@@ -63,10 +67,21 @@ const testCases = [
       expectTrue(li !== null, "Should have li element");
 
       const link = doc.querySelector("a");
-      expectStrictEqual(link.getAttribute("href"), "/events/market-day/", "Link should have correct href");
-      expectStrictEqual(link.textContent, "Farmers Market", "Link should have event title");
+      expectStrictEqual(
+        link.getAttribute("href"),
+        "/events/market-day/",
+        "Link should have correct href",
+      );
+      expectStrictEqual(
+        link.textContent,
+        "Farmers Market",
+        "Link should have event title",
+      );
 
-      expectTrue(li.textContent.includes("Every Saturday"), "Should show recurring date");
+      expectTrue(
+        li.textContent.includes("Every Saturday"),
+        "Should show recurring date",
+      );
     },
   },
   {
@@ -89,7 +104,11 @@ const testCases = [
       expectStrictEqual(link, null, "Should not have link when no URL");
 
       const strong = doc.querySelector("strong");
-      expectStrictEqual(strong.textContent, "Weekly Meeting", "Title should be in strong tag");
+      expectStrictEqual(
+        strong.textContent,
+        "Weekly Meeting",
+        "Title should be in strong tag",
+      );
     },
   },
   {
@@ -111,7 +130,10 @@ const testCases = [
       const doc = dom.window.document;
 
       const li = doc.querySelector("li");
-      expectTrue(li.textContent.includes("Community Center"), "Should show location");
+      expectTrue(
+        li.textContent.includes("Community Center"),
+        "Should show location",
+      );
     },
   },
   {
@@ -131,7 +153,10 @@ const testCases = [
       const doc = dom.window.document;
 
       const li = doc.querySelector("li");
-      expectTrue(!li.textContent.includes("event_location"), "Should not have location text");
+      expectTrue(
+        !li.textContent.includes("event_location"),
+        "Should not have location text",
+      );
     },
   },
 
@@ -161,7 +186,11 @@ const testCases = [
       expectStrictEqual(listItems.length, 3, "Should have 3 list items");
 
       const links = doc.querySelectorAll("a");
-      expectStrictEqual(links.length, 2, "Should have 2 links (third event has no URL)");
+      expectStrictEqual(
+        links.length,
+        2,
+        "Should have 2 links (third event has no URL)",
+      );
     },
   },
 
@@ -182,8 +211,16 @@ const testCases = [
       const doc = dom.window.document;
 
       const link = doc.querySelector("a");
-      expectStrictEqual(link.textContent, "Flat Event", "Should handle flat data structure");
-      expectStrictEqual(link.getAttribute("href"), "/flat/", "Should use url from flat structure");
+      expectStrictEqual(
+        link.textContent,
+        "Flat Event",
+        "Should handle flat data structure",
+      );
+      expectStrictEqual(
+        link.getAttribute("href"),
+        "/flat/",
+        "Should use url from flat structure",
+      );
     },
   },
   {
@@ -204,7 +241,11 @@ const testCases = [
       const doc = dom.window.document;
 
       const link = doc.querySelector("a");
-      expectStrictEqual(link.textContent, "Nested Event", "Should handle nested data structure");
+      expectStrictEqual(
+        link.textContent,
+        "Nested Event",
+        "Should handle nested data structure",
+      );
     },
   },
   {
@@ -225,7 +266,11 @@ const testCases = [
       const doc = dom.window.document;
 
       const link = doc.querySelector("a");
-      expectStrictEqual(link.getAttribute("href"), "/data-url/", "Should use URL from data object");
+      expectStrictEqual(
+        link.getAttribute("href"),
+        "/data-url/",
+        "Should use URL from data object",
+      );
     },
   },
 
@@ -269,7 +314,10 @@ const testCases = [
         },
       ];
       const result = renderRecurringEvents(events);
-      expectTrue(result.includes("Music & Arts Festival"), "Should preserve ampersand in title");
+      expectTrue(
+        result.includes("Music & Arts Festival"),
+        "Should preserve ampersand in title",
+      );
     },
   },
   {
@@ -285,7 +333,10 @@ const testCases = [
         },
       ];
       const result = renderRecurringEvents(events);
-      expectTrue(result.includes('"Open Mic" Night'), "Should preserve quotes in title");
+      expectTrue(
+        result.includes('"Open Mic" Night'),
+        "Should preserve quotes in title",
+      );
     },
   },
   {
@@ -306,7 +357,10 @@ const testCases = [
       const doc = dom.window.document;
 
       const li = doc.querySelector("li");
-      expectTrue(li.textContent.includes("Café René"), "Should preserve unicode in location");
+      expectTrue(
+        li.textContent.includes("Café René"),
+        "Should preserve unicode in location",
+      );
     },
   },
 
@@ -318,8 +372,15 @@ const testCases = [
       const mockConfig = createMockEleventyConfig();
       configureRecurringEvents(mockConfig);
 
-      expectTrue("recurring_events" in mockConfig.shortcodes, "Should add recurring_events shortcode");
-      expectFunctionType(mockConfig.shortcodes, "recurring_events", "Shortcode should be a function");
+      expectTrue(
+        "recurring_events" in mockConfig.shortcodes,
+        "Should add recurring_events shortcode",
+      );
+      expectFunctionType(
+        mockConfig.shortcodes,
+        "recurring_events",
+        "Shortcode should be a function",
+      );
     },
   },
   {
@@ -329,8 +390,15 @@ const testCases = [
       const mockConfig = createMockEleventyConfig();
       configureRecurringEvents(mockConfig);
 
-      expectTrue("format_recurring_events" in mockConfig.filters, "Should add format_recurring_events filter");
-      expectFunctionType(mockConfig.filters, "format_recurring_events", "Filter should be a function");
+      expectTrue(
+        "format_recurring_events" in mockConfig.filters,
+        "Should add format_recurring_events filter",
+      );
+      expectFunctionType(
+        mockConfig.filters,
+        "format_recurring_events",
+        "Filter should be a function",
+      );
     },
   },
   {
@@ -341,7 +409,11 @@ const testCases = [
       configureRecurringEvents(mockConfig);
 
       const filter = mockConfig.filters.format_recurring_events;
-      expectStrictEqual(filter, renderRecurringEvents, "Filter should be renderRecurringEvents function");
+      expectStrictEqual(
+        filter,
+        renderRecurringEvents,
+        "Filter should be renderRecurringEvents function",
+      );
     },
   },
 
@@ -363,7 +435,7 @@ const testCases = [
       expectStrictEqual(
         JSON.stringify(originalEvents),
         JSON.stringify(eventsCopy),
-        "Should not mutate input array"
+        "Should not mutate input array",
       );
     },
   },

--- a/test/reviews.test.js
+++ b/test/reviews.test.js
@@ -415,22 +415,14 @@ const testCases = [
         "M",
         "Should return M for single name",
       );
-      expectStrictEqual(
-        getInitials("Cher"),
-        "C",
-        "Should return C for Cher",
-      );
+      expectStrictEqual(getInitials("Cher"), "C", "Should return C for Cher");
     },
   },
   {
     name: "getInitials-already-initials",
     description: "Returns name unchanged if already 2 chars or less",
     test: () => {
-      expectStrictEqual(
-        getInitials("JS"),
-        "JS",
-        "Should return JS unchanged",
-      );
+      expectStrictEqual(getInitials("JS"), "JS", "Should return JS unchanged");
       expectStrictEqual(getInitials("A"), "A", "Should return A unchanged");
       expectStrictEqual(getInitials("ab"), "AB", "Should uppercase ab to AB");
     },
@@ -552,11 +544,7 @@ const testCases = [
         "MS",
         "Should handle umlauts",
       );
-      expectStrictEqual(
-        getInitials("Björk"),
-        "B",
-        "Should return B for Björk",
-      );
+      expectStrictEqual(getInitials("Björk"), "B", "Should return B for Björk");
     },
   },
   {

--- a/test/schema-helper.test.js
+++ b/test/schema-helper.test.js
@@ -1,559 +1,572 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import {
-	buildBaseMeta,
-	buildProductMeta,
-	buildPostMeta,
-	buildOrganizationMeta,
+  buildBaseMeta,
+  buildOrganizationMeta,
+  buildPostMeta,
+  buildProductMeta,
 } from "#utils/schema-helper.js";
 
 describe("buildBaseMeta", () => {
-	it("returns basic meta with url, title, and description", () => {
-		const data = {
-			page: { url: "/test-page/" },
-			title: "Test Page",
-			meta_description: "A test description",
-			site: { url: "https://example.com" },
-		};
+  it("returns basic meta with url, title, and description", () => {
+    const data = {
+      page: { url: "/test-page/" },
+      title: "Test Page",
+      meta_description: "A test description",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.title, "Test Page");
-		assert.strictEqual(result.description, "A test description");
-		assert.ok(result.url.includes("/test-page/"));
-	});
+    assert.strictEqual(result.title, "Test Page");
+    assert.strictEqual(result.description, "A test description");
+    assert.ok(result.url.includes("/test-page/"));
+  });
 
-	it("uses meta_title when title is not provided", () => {
-		const data = {
-			page: { url: "/page/" },
-			meta_title: "Meta Title",
-			site: { url: "https://example.com" },
-		};
+  it("uses meta_title when title is not provided", () => {
+    const data = {
+      page: { url: "/page/" },
+      meta_title: "Meta Title",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.title, "Meta Title");
-	});
+    assert.strictEqual(result.title, "Meta Title");
+  });
 
-	it("falls back to Untitled when no title or meta_title", () => {
-		const data = {
-			page: { url: "/page/" },
-			site: { url: "https://example.com" },
-		};
+  it("falls back to Untitled when no title or meta_title", () => {
+    const data = {
+      page: { url: "/page/" },
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.title, "Untitled");
-	});
+    assert.strictEqual(result.title, "Untitled");
+  });
 
-	it("uses subtitle as description when meta_description is not provided", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			subtitle: "A subtitle",
-			site: { url: "https://example.com" },
-		};
+  it("uses subtitle as description when meta_description is not provided", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      subtitle: "A subtitle",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.description, "A subtitle");
-	});
+    assert.strictEqual(result.description, "A subtitle");
+  });
 
-	it("includes image from header_image", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			header_image: "test-image.jpg",
-			site: { url: "https://example.com" },
-		};
+  it("includes image from header_image", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      header_image: "test-image.jpg",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.ok(result.image);
-		assert.ok(result.image.src.includes("test-image.jpg"));
-	});
+    assert.ok(result.image);
+    assert.ok(result.image.src.includes("test-image.jpg"));
+  });
 
-	it("includes image from image field when header_image is not provided", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			image: "fallback-image.jpg",
-			site: { url: "https://example.com" },
-		};
+  it("includes image from image field when header_image is not provided", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      image: "fallback-image.jpg",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.ok(result.image);
-		assert.ok(result.image.src.includes("fallback-image.jpg"));
-	});
+    assert.ok(result.image);
+    assert.ok(result.image.src.includes("fallback-image.jpg"));
+  });
 
-	it("handles absolute URL images (http://)", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			header_image: "http://other.com/image.jpg",
-			site: { url: "https://example.com" },
-		};
+  it("handles absolute URL images (http://)", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      header_image: "http://other.com/image.jpg",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.image.src, "http://other.com/image.jpg");
-	});
+    assert.strictEqual(result.image.src, "http://other.com/image.jpg");
+  });
 
-	it("handles absolute URL images (https://)", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			header_image: "https://other.com/image.jpg",
-			site: { url: "https://example.com" },
-		};
+  it("handles absolute URL images (https://)", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      header_image: "https://other.com/image.jpg",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.image.src, "https://other.com/image.jpg");
-	});
+    assert.strictEqual(result.image.src, "https://other.com/image.jpg");
+  });
 
-	it("handles images with leading slash", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			header_image: "/images/photo.jpg",
-			site: { url: "https://example.com" },
-		};
+  it("handles images with leading slash", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      header_image: "/images/photo.jpg",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.image.src, "https://example.com/images/photo.jpg");
-	});
+    assert.strictEqual(
+      result.image.src,
+      "https://example.com/images/photo.jpg",
+    );
+  });
 
-	it("prepends /images/ for plain image filenames", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			header_image: "photo.jpg",
-			site: { url: "https://example.com" },
-		};
+  it("prepends /images/ for plain image filenames", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      header_image: "photo.jpg",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.image.src, "https://example.com/images/photo.jpg");
-	});
+    assert.strictEqual(
+      result.image.src,
+      "https://example.com/images/photo.jpg",
+    );
+  });
 
-	it("does not include image when none provided", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			site: { url: "https://example.com" },
-		};
+  it("does not include image when none provided", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.image, undefined);
-	});
+    assert.strictEqual(result.image, undefined);
+  });
 
-	it("includes FAQs when provided", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			faqs: [
-				{ question: "Q1", answer: "A1" },
-				{ question: "Q2", answer: "A2" },
-			],
-			site: { url: "https://example.com" },
-		};
+  it("includes FAQs when provided", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      faqs: [
+        { question: "Q1", answer: "A1" },
+        { question: "Q2", answer: "A2" },
+      ],
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.deepStrictEqual(result.faq, data.faqs);
-	});
+    assert.deepStrictEqual(result.faq, data.faqs);
+  });
 
-	it("does not include empty FAQs array", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			faqs: [],
-			site: { url: "https://example.com" },
-		};
+  it("does not include empty FAQs array", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      faqs: [],
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.faq, undefined);
-	});
+    assert.strictEqual(result.faq, undefined);
+  });
 
-	it("preserves metaComputed properties", () => {
-		const data = {
-			page: { url: "/page/" },
-			title: "Test",
-			metaComputed: {
-				customField: "custom value",
-				anotherField: 123,
-			},
-			site: { url: "https://example.com" },
-		};
+  it("preserves metaComputed properties", () => {
+    const data = {
+      page: { url: "/page/" },
+      title: "Test",
+      metaComputed: {
+        customField: "custom value",
+        anotherField: 123,
+      },
+      site: { url: "https://example.com" },
+    };
 
-		const result = buildBaseMeta(data);
+    const result = buildBaseMeta(data);
 
-		assert.strictEqual(result.customField, "custom value");
-		assert.strictEqual(result.anotherField, 123);
-	});
+    assert.strictEqual(result.customField, "custom value");
+    assert.strictEqual(result.anotherField, 123);
+  });
 });
 
 describe("buildProductMeta", () => {
-	it("returns product meta with name and brand", () => {
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			site: { url: "https://example.com", name: "Test Store" },
-		};
+  it("returns product meta with name and brand", () => {
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      site: { url: "https://example.com", name: "Test Store" },
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.name, "Test Product");
-		assert.strictEqual(result.brand, "Test Store");
-	});
+    assert.strictEqual(result.name, "Test Product");
+    assert.strictEqual(result.brand, "Test Store");
+  });
 
-	it("includes offers when price is provided", () => {
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			price: "29.99",
-			site: { url: "https://example.com", name: "Test Store" },
-		};
+  it("includes offers when price is provided", () => {
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      price: "29.99",
+      site: { url: "https://example.com", name: "Test Store" },
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.ok(result.offers);
-		assert.strictEqual(result.offers.price, "29.99");
-		assert.strictEqual(result.offers.priceCurrency, "GBP");
-		assert.strictEqual(result.offers.availability, "https://schema.org/InStock");
-		assert.ok(result.offers.priceValidUntil);
-	});
+    assert.ok(result.offers);
+    assert.strictEqual(result.offers.price, "29.99");
+    assert.strictEqual(result.offers.priceCurrency, "GBP");
+    assert.strictEqual(
+      result.offers.availability,
+      "https://schema.org/InStock",
+    );
+    assert.ok(result.offers.priceValidUntil);
+  });
 
-	it("strips currency symbols from price", () => {
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			price: "£29.99",
-			site: { url: "https://example.com", name: "Test Store" },
-		};
+  it("strips currency symbols from price", () => {
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      price: "£29.99",
+      site: { url: "https://example.com", name: "Test Store" },
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.offers.price, "29.99");
-	});
+    assert.strictEqual(result.offers.price, "29.99");
+  });
 
-	it("strips dollar sign from price", () => {
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			price: "$49.99",
-			site: { url: "https://example.com", name: "Test Store" },
-		};
+  it("strips dollar sign from price", () => {
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      price: "$49.99",
+      site: { url: "https://example.com", name: "Test Store" },
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.offers.price, "49.99");
-	});
+    assert.strictEqual(result.offers.price, "49.99");
+  });
 
-	it("strips euro sign from price", () => {
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			price: "€39.99",
-			site: { url: "https://example.com", name: "Test Store" },
-		};
+  it("strips euro sign from price", () => {
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      price: "€39.99",
+      site: { url: "https://example.com", name: "Test Store" },
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.offers.price, "39.99");
-	});
+    assert.strictEqual(result.offers.price, "39.99");
+  });
 
-	it("strips commas from price", () => {
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			price: "1,299.99",
-			site: { url: "https://example.com", name: "Test Store" },
-		};
+  it("strips commas from price", () => {
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      price: "1,299.99",
+      site: { url: "https://example.com", name: "Test Store" },
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.offers.price, "1299.99");
-	});
+    assert.strictEqual(result.offers.price, "1299.99");
+  });
 
-	it("does not include offers when price is not provided", () => {
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			site: { url: "https://example.com", name: "Test Store" },
-		};
+  it("does not include offers when price is not provided", () => {
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      site: { url: "https://example.com", name: "Test Store" },
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.offers, undefined);
-	});
+    assert.strictEqual(result.offers, undefined);
+  });
 
-	it("includes reviews and rating when reviewsField and collections.reviews are provided", () => {
-		const mockReviews = [
-			{
-				data: { name: "Reviewer 1", rating: 5, products: ["test"] },
-				date: new Date("2024-01-15"),
-			},
-			{
-				data: { name: "Reviewer 2", rating: 4, products: ["test"] },
-				date: new Date("2024-02-20"),
-			},
-		];
+  it("includes reviews and rating when reviewsField and collections.reviews are provided", () => {
+    const mockReviews = [
+      {
+        data: { name: "Reviewer 1", rating: 5, products: ["test"] },
+        date: new Date("2024-01-15"),
+      },
+      {
+        data: { name: "Reviewer 2", rating: 4, products: ["test"] },
+        date: new Date("2024-02-20"),
+      },
+    ];
 
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			site: { url: "https://example.com", name: "Test Store" },
-			collections: { reviews: mockReviews },
-			reviewsField: "products",
-		};
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      site: { url: "https://example.com", name: "Test Store" },
+      collections: { reviews: mockReviews },
+      reviewsField: "products",
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.ok(result.reviews);
-		assert.strictEqual(result.reviews.length, 2);
-		assert.ok(result.rating);
-		assert.strictEqual(result.rating.reviewCount, 2);
-		assert.strictEqual(result.rating.bestRating, 5);
-		assert.strictEqual(result.rating.worstRating, 1);
-	});
+    assert.ok(result.reviews);
+    assert.strictEqual(result.reviews.length, 2);
+    assert.ok(result.rating);
+    assert.strictEqual(result.rating.reviewCount, 2);
+    assert.strictEqual(result.rating.bestRating, 5);
+    assert.strictEqual(result.rating.worstRating, 1);
+  });
 
-	it("calculates correct average rating", () => {
-		const mockReviews = [
-			{
-				data: { name: "Reviewer 1", rating: 5, products: ["test"] },
-				date: new Date("2024-01-15"),
-			},
-			{
-				data: { name: "Reviewer 2", rating: 3, products: ["test"] },
-				date: new Date("2024-02-20"),
-			},
-		];
+  it("calculates correct average rating", () => {
+    const mockReviews = [
+      {
+        data: { name: "Reviewer 1", rating: 5, products: ["test"] },
+        date: new Date("2024-01-15"),
+      },
+      {
+        data: { name: "Reviewer 2", rating: 3, products: ["test"] },
+        date: new Date("2024-02-20"),
+      },
+    ];
 
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			site: { url: "https://example.com", name: "Test Store" },
-			collections: { reviews: mockReviews },
-			reviewsField: "products",
-		};
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      site: { url: "https://example.com", name: "Test Store" },
+      collections: { reviews: mockReviews },
+      reviewsField: "products",
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		// Average of 5 and 3 is 4.0
-		assert.strictEqual(result.rating.ratingValue, "4.0");
-	});
+    // Average of 5 and 3 is 4.0
+    assert.strictEqual(result.rating.ratingValue, "4.0");
+  });
 
-	it("formats review with author and rating", () => {
-		const mockReviews = [
-			{
-				data: { name: "John Doe", rating: 5, products: ["test"] },
-				date: new Date("2024-06-15"),
-			},
-		];
+  it("formats review with author and rating", () => {
+    const mockReviews = [
+      {
+        data: { name: "John Doe", rating: 5, products: ["test"] },
+        date: new Date("2024-06-15"),
+      },
+    ];
 
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			site: { url: "https://example.com", name: "Test Store" },
-			collections: { reviews: mockReviews },
-			reviewsField: "products",
-		};
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      site: { url: "https://example.com", name: "Test Store" },
+      collections: { reviews: mockReviews },
+      reviewsField: "products",
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.reviews[0].author, "John Doe");
-		assert.strictEqual(result.reviews[0].rating, 5);
-		assert.strictEqual(result.reviews[0].date, "2024-06-15");
-	});
+    assert.strictEqual(result.reviews[0].author, "John Doe");
+    assert.strictEqual(result.reviews[0].rating, 5);
+    assert.strictEqual(result.reviews[0].date, "2024-06-15");
+  });
 
-	it("defaults review rating to 5 when not specified", () => {
-		const mockReviews = [
-			{
-				data: { name: "Reviewer", products: ["test"] },
-				date: new Date("2024-01-15"),
-			},
-		];
+  it("defaults review rating to 5 when not specified", () => {
+    const mockReviews = [
+      {
+        data: { name: "Reviewer", products: ["test"] },
+        date: new Date("2024-01-15"),
+      },
+    ];
 
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			site: { url: "https://example.com", name: "Test Store" },
-			collections: { reviews: mockReviews },
-			reviewsField: "products",
-		};
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      site: { url: "https://example.com", name: "Test Store" },
+      collections: { reviews: mockReviews },
+      reviewsField: "products",
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.reviews[0].rating, 5);
-	});
+    assert.strictEqual(result.reviews[0].rating, 5);
+  });
 
-	it("does not include reviews and rating when no matching reviews", () => {
-		const mockReviews = [
-			{
-				data: { name: "Reviewer", rating: 5, products: ["other-product"] },
-				date: new Date("2024-01-15"),
-			},
-		];
+  it("does not include reviews and rating when no matching reviews", () => {
+    const mockReviews = [
+      {
+        data: { name: "Reviewer", rating: 5, products: ["other-product"] },
+        date: new Date("2024-01-15"),
+      },
+    ];
 
-		const data = {
-			page: { url: "/products/test/", fileSlug: "test" },
-			title: "Test Product",
-			site: { url: "https://example.com", name: "Test Store" },
-			collections: { reviews: mockReviews },
-			reviewsField: "products",
-		};
+    const data = {
+      page: { url: "/products/test/", fileSlug: "test" },
+      title: "Test Product",
+      site: { url: "https://example.com", name: "Test Store" },
+      collections: { reviews: mockReviews },
+      reviewsField: "products",
+    };
 
-		const result = buildProductMeta(data);
+    const result = buildProductMeta(data);
 
-		assert.strictEqual(result.reviews, undefined);
-		assert.strictEqual(result.rating, undefined);
-	});
+    assert.strictEqual(result.reviews, undefined);
+    assert.strictEqual(result.rating, undefined);
+  });
 });
 
 describe("buildPostMeta", () => {
-	it("returns post meta with author", () => {
-		const data = {
-			page: { url: "/news/test-post/", date: new Date("2024-03-15") },
-			title: "Test Post",
-			author: "John Author",
-			site: { url: "https://example.com", name: "Test Site" },
-		};
+  it("returns post meta with author", () => {
+    const data = {
+      page: { url: "/news/test-post/", date: new Date("2024-03-15") },
+      title: "Test Post",
+      author: "John Author",
+      site: { url: "https://example.com", name: "Test Site" },
+    };
 
-		const result = buildPostMeta(data);
+    const result = buildPostMeta(data);
 
-		assert.ok(result.author);
-		assert.strictEqual(result.author.name, "John Author");
-	});
+    assert.ok(result.author);
+    assert.strictEqual(result.author.name, "John Author");
+  });
 
-	it("uses site name as author when author not provided", () => {
-		const data = {
-			page: { url: "/news/test-post/", date: new Date("2024-03-15") },
-			title: "Test Post",
-			site: { url: "https://example.com", name: "Test Site" },
-		};
+  it("uses site name as author when author not provided", () => {
+    const data = {
+      page: { url: "/news/test-post/", date: new Date("2024-03-15") },
+      title: "Test Post",
+      site: { url: "https://example.com", name: "Test Site" },
+    };
 
-		const result = buildPostMeta(data);
+    const result = buildPostMeta(data);
 
-		assert.strictEqual(result.author.name, "Test Site");
-	});
+    assert.strictEqual(result.author.name, "Test Site");
+  });
 
-	it("includes datePublished from page.date", () => {
-		const data = {
-			page: { url: "/news/test-post/", date: new Date("2024-03-15") },
-			title: "Test Post",
-			site: { url: "https://example.com", name: "Test Site" },
-		};
+  it("includes datePublished from page.date", () => {
+    const data = {
+      page: { url: "/news/test-post/", date: new Date("2024-03-15") },
+      title: "Test Post",
+      site: { url: "https://example.com", name: "Test Site" },
+    };
 
-		const result = buildPostMeta(data);
+    const result = buildPostMeta(data);
 
-		assert.strictEqual(result.datePublished, "2024-03-15");
-	});
+    assert.strictEqual(result.datePublished, "2024-03-15");
+  });
 
-	it("includes publisher with name and logo", () => {
-		const data = {
-			page: { url: "/news/test-post/", date: new Date("2024-03-15") },
-			title: "Test Post",
-			site: { url: "https://example.com", name: "Test Site", logo: "/custom-logo.png" },
-		};
+  it("includes publisher with name and logo", () => {
+    const data = {
+      page: { url: "/news/test-post/", date: new Date("2024-03-15") },
+      title: "Test Post",
+      site: {
+        url: "https://example.com",
+        name: "Test Site",
+        logo: "/custom-logo.png",
+      },
+    };
 
-		const result = buildPostMeta(data);
+    const result = buildPostMeta(data);
 
-		assert.ok(result.publisher);
-		assert.strictEqual(result.publisher.name, "Test Site");
-		assert.ok(result.publisher.logo);
-		assert.ok(result.publisher.logo.src.includes("custom-logo.png"));
-		assert.strictEqual(result.publisher.logo.width, 512);
-		assert.strictEqual(result.publisher.logo.height, 512);
-	});
+    assert.ok(result.publisher);
+    assert.strictEqual(result.publisher.name, "Test Site");
+    assert.ok(result.publisher.logo);
+    assert.ok(result.publisher.logo.src.includes("custom-logo.png"));
+    assert.strictEqual(result.publisher.logo.width, 512);
+    assert.strictEqual(result.publisher.logo.height, 512);
+  });
 
-	it("uses default logo path when site.logo not provided", () => {
-		const data = {
-			page: { url: "/news/test-post/", date: new Date("2024-03-15") },
-			title: "Test Post",
-			site: { url: "https://example.com", name: "Test Site" },
-		};
+  it("uses default logo path when site.logo not provided", () => {
+    const data = {
+      page: { url: "/news/test-post/", date: new Date("2024-03-15") },
+      title: "Test Post",
+      site: { url: "https://example.com", name: "Test Site" },
+    };
 
-		const result = buildPostMeta(data);
+    const result = buildPostMeta(data);
 
-		assert.ok(result.publisher.logo.src.includes("/images/logo.png"));
-	});
+    assert.ok(result.publisher.logo.src.includes("/images/logo.png"));
+  });
 
-	it("does not include datePublished when page.date is not provided", () => {
-		const data = {
-			page: { url: "/news/test-post/" },
-			title: "Test Post",
-			site: { url: "https://example.com", name: "Test Site" },
-		};
+  it("does not include datePublished when page.date is not provided", () => {
+    const data = {
+      page: { url: "/news/test-post/" },
+      title: "Test Post",
+      site: { url: "https://example.com", name: "Test Site" },
+    };
 
-		const result = buildPostMeta(data);
+    const result = buildPostMeta(data);
 
-		assert.strictEqual(result.datePublished, undefined);
-	});
+    assert.strictEqual(result.datePublished, undefined);
+  });
 });
 
 describe("buildOrganizationMeta", () => {
-	it("returns organization meta with base properties", () => {
-		const data = {
-			page: { url: "/" },
-			title: "Home",
-			site: { url: "https://example.com", name: "Test Organization" },
-		};
+  it("returns organization meta with base properties", () => {
+    const data = {
+      page: { url: "/" },
+      title: "Home",
+      site: { url: "https://example.com", name: "Test Organization" },
+    };
 
-		const result = buildOrganizationMeta(data);
+    const result = buildOrganizationMeta(data);
 
-		assert.strictEqual(result.title, "Home");
-		assert.ok(result.url);
-	});
+    assert.strictEqual(result.title, "Home");
+    assert.ok(result.url);
+  });
 
-	it("includes organization from metaComputed when available", () => {
-		const data = {
-			page: { url: "/" },
-			title: "Home",
-			site: { url: "https://example.com", name: "Test Organization" },
-			metaComputed: {
-				organization: {
-					name: "Test Org",
-					telephone: "+1234567890",
-					address: { streetAddress: "123 Main St" },
-				},
-			},
-		};
+  it("includes organization from metaComputed when available", () => {
+    const data = {
+      page: { url: "/" },
+      title: "Home",
+      site: { url: "https://example.com", name: "Test Organization" },
+      metaComputed: {
+        organization: {
+          name: "Test Org",
+          telephone: "+1234567890",
+          address: { streetAddress: "123 Main St" },
+        },
+      },
+    };
 
-		const result = buildOrganizationMeta(data);
+    const result = buildOrganizationMeta(data);
 
-		assert.ok(result.organization);
-		assert.strictEqual(result.organization.name, "Test Org");
-		assert.strictEqual(result.organization.telephone, "+1234567890");
-	});
+    assert.ok(result.organization);
+    assert.strictEqual(result.organization.name, "Test Org");
+    assert.strictEqual(result.organization.telephone, "+1234567890");
+  });
 
-	it("does not include organization when metaComputed.organization is not set", () => {
-		const data = {
-			page: { url: "/" },
-			title: "Home",
-			site: { url: "https://example.com", name: "Test Organization" },
-			metaComputed: {},
-		};
+  it("does not include organization when metaComputed.organization is not set", () => {
+    const data = {
+      page: { url: "/" },
+      title: "Home",
+      site: { url: "https://example.com", name: "Test Organization" },
+      metaComputed: {},
+    };
 
-		const result = buildOrganizationMeta(data);
+    const result = buildOrganizationMeta(data);
 
-		assert.strictEqual(result.organization, undefined);
-	});
+    assert.strictEqual(result.organization, undefined);
+  });
 
-	it("does not include organization when metaComputed is not set", () => {
-		const data = {
-			page: { url: "/" },
-			title: "Home",
-			site: { url: "https://example.com", name: "Test Organization" },
-		};
+  it("does not include organization when metaComputed is not set", () => {
+    const data = {
+      page: { url: "/" },
+      title: "Home",
+      site: { url: "https://example.com", name: "Test Organization" },
+    };
 
-		const result = buildOrganizationMeta(data);
+    const result = buildOrganizationMeta(data);
 
-		assert.strictEqual(result.organization, undefined);
-	});
+    assert.strictEqual(result.organization, undefined);
+  });
 });

--- a/test/slug-utils.test.js
+++ b/test/slug-utils.test.js
@@ -1,9 +1,9 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import {
-  normaliseSlug,
-  buildPermalink,
   buildPdfFilename,
+  buildPermalink,
+  normaliseSlug,
 } from "#utils/slug-utils.js";
 
 describe("normaliseSlug", () => {
@@ -45,7 +45,10 @@ describe("buildPermalink", () => {
 
   it("builds permalink from dir and fileSlug when no permalink set", () => {
     const data = { page: { fileSlug: "my-product" } };
-    assert.strictEqual(buildPermalink(data, "products"), "/products/my-product/");
+    assert.strictEqual(
+      buildPermalink(data, "products"),
+      "/products/my-product/",
+    );
   });
 
   it("builds permalink for different directories", () => {

--- a/test/spec-filters.test.js
+++ b/test/spec-filters.test.js
@@ -1,139 +1,139 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { getSpecIcon, computeSpecs } from "#filters/spec-filters.js";
+import { computeSpecs, getSpecIcon } from "#filters/spec-filters.js";
 
 describe("getSpecIcon", () => {
-	it("returns empty string for null input", () => {
-		assert.strictEqual(getSpecIcon(null), "");
-	});
+  it("returns empty string for null input", () => {
+    assert.strictEqual(getSpecIcon(null), "");
+  });
 
-	it("returns empty string for undefined input", () => {
-		assert.strictEqual(getSpecIcon(undefined), "");
-	});
+  it("returns empty string for undefined input", () => {
+    assert.strictEqual(getSpecIcon(undefined), "");
+  });
 
-	it("returns empty string for empty string input", () => {
-		assert.strictEqual(getSpecIcon(""), "");
-	});
+  it("returns empty string for empty string input", () => {
+    assert.strictEqual(getSpecIcon(""), "");
+  });
 
-	it("returns empty string for non-existent spec", () => {
-		assert.strictEqual(getSpecIcon("nonexistent-spec-name"), "");
-	});
+  it("returns empty string for non-existent spec", () => {
+    assert.strictEqual(getSpecIcon("nonexistent-spec-name"), "");
+  });
 
-	it("normalizes spec name to lowercase before lookup", () => {
-		// "has dongle" is defined in specs-icons-base.json -> tick.svg
-		const lowerResult = getSpecIcon("has dongle");
-		const upperResult = getSpecIcon("HAS DONGLE");
-		const mixedResult = getSpecIcon("Has Dongle");
+  it("normalizes spec name to lowercase before lookup", () => {
+    // "has dongle" is defined in specs-icons-base.json -> tick.svg
+    const lowerResult = getSpecIcon("has dongle");
+    const upperResult = getSpecIcon("HAS DONGLE");
+    const mixedResult = getSpecIcon("Has Dongle");
 
-		// All should return the same icon content
-		assert.strictEqual(lowerResult, upperResult);
-		assert.strictEqual(lowerResult, mixedResult);
-		// And it should contain SVG content (tick.svg exists)
-		assert.ok(lowerResult.includes("<svg") || lowerResult.includes("<SVG"));
-	});
+    // All should return the same icon content
+    assert.strictEqual(lowerResult, upperResult);
+    assert.strictEqual(lowerResult, mixedResult);
+    // And it should contain SVG content (tick.svg exists)
+    assert.ok(lowerResult.includes("<svg") || lowerResult.includes("<SVG"));
+  });
 
-	it("trims spec name before lookup", () => {
-		const normalResult = getSpecIcon("has dongle");
-		const paddedResult = getSpecIcon("  has dongle  ");
+  it("trims spec name before lookup", () => {
+    const normalResult = getSpecIcon("has dongle");
+    const paddedResult = getSpecIcon("  has dongle  ");
 
-		assert.strictEqual(normalResult, paddedResult);
-	});
+    assert.strictEqual(normalResult, paddedResult);
+  });
 
-	it("returns SVG content for existing spec icon", () => {
-		// "has dongle" maps to tick.svg which exists
-		const result = getSpecIcon("has dongle");
-		assert.ok(result.length > 0, "Should return non-empty content");
-		assert.ok(
-			result.includes("<svg") || result.includes("<SVG"),
-			"Should contain SVG markup",
-		);
-	});
+  it("returns SVG content for existing spec icon", () => {
+    // "has dongle" maps to tick.svg which exists
+    const result = getSpecIcon("has dongle");
+    assert.ok(result.length > 0, "Should return non-empty content");
+    assert.ok(
+      result.includes("<svg") || result.includes("<SVG"),
+      "Should contain SVG markup",
+    );
+  });
 });
 
 describe("computeSpecs", () => {
-	it("returns undefined when data.specs is undefined", () => {
-		const result = computeSpecs({});
-		assert.strictEqual(result, undefined);
-	});
+  it("returns undefined when data.specs is undefined", () => {
+    const result = computeSpecs({});
+    assert.strictEqual(result, undefined);
+  });
 
-	it("returns undefined when data.specs is null-ish", () => {
-		const result = computeSpecs({ specs: null });
-		assert.strictEqual(result, undefined);
-	});
+  it("returns undefined when data.specs is null-ish", () => {
+    const result = computeSpecs({ specs: null });
+    assert.strictEqual(result, undefined);
+  });
 
-	it("returns empty array when specs is empty array", () => {
-		const result = computeSpecs({ specs: [] });
-		assert.deepStrictEqual(result, []);
-	});
+  it("returns empty array when specs is empty array", () => {
+    const result = computeSpecs({ specs: [] });
+    assert.deepStrictEqual(result, []);
+  });
 
-	it("adds icon property to each spec", () => {
-		const data = {
-			specs: [{ name: "has dongle", value: "Yes" }],
-		};
-		const result = computeSpecs(data);
+  it("adds icon property to each spec", () => {
+    const data = {
+      specs: [{ name: "has dongle", value: "Yes" }],
+    };
+    const result = computeSpecs(data);
 
-		assert.strictEqual(result.length, 1);
-		assert.ok("icon" in result[0], "Should have icon property");
-		assert.strictEqual(result[0].name, "has dongle");
-		assert.strictEqual(result[0].value, "Yes");
-	});
+    assert.strictEqual(result.length, 1);
+    assert.ok("icon" in result[0], "Should have icon property");
+    assert.strictEqual(result[0].name, "has dongle");
+    assert.strictEqual(result[0].value, "Yes");
+  });
 
-	it("preserves all original spec properties", () => {
-		const data = {
-			specs: [
-				{
-					name: "test spec",
-					value: "test value",
-					customProp: "custom",
-					nested: { a: 1 },
-				},
-			],
-		};
-		const result = computeSpecs(data);
+  it("preserves all original spec properties", () => {
+    const data = {
+      specs: [
+        {
+          name: "test spec",
+          value: "test value",
+          customProp: "custom",
+          nested: { a: 1 },
+        },
+      ],
+    };
+    const result = computeSpecs(data);
 
-		assert.strictEqual(result[0].name, "test spec");
-		assert.strictEqual(result[0].value, "test value");
-		assert.strictEqual(result[0].customProp, "custom");
-		assert.deepStrictEqual(result[0].nested, { a: 1 });
-	});
+    assert.strictEqual(result[0].name, "test spec");
+    assert.strictEqual(result[0].value, "test value");
+    assert.strictEqual(result[0].customProp, "custom");
+    assert.deepStrictEqual(result[0].nested, { a: 1 });
+  });
 
-	it("returns empty string icon for specs without matching icon", () => {
-		const data = {
-			specs: [{ name: "nonexistent-spec", value: "test" }],
-		};
-		const result = computeSpecs(data);
+  it("returns empty string icon for specs without matching icon", () => {
+    const data = {
+      specs: [{ name: "nonexistent-spec", value: "test" }],
+    };
+    const result = computeSpecs(data);
 
-		assert.strictEqual(result[0].icon, "");
-	});
+    assert.strictEqual(result[0].icon, "");
+  });
 
-	it("returns SVG content for specs with matching icon", () => {
-		const data = {
-			specs: [{ name: "has dongle", value: "Yes" }],
-		};
-		const result = computeSpecs(data);
+  it("returns SVG content for specs with matching icon", () => {
+    const data = {
+      specs: [{ name: "has dongle", value: "Yes" }],
+    };
+    const result = computeSpecs(data);
 
-		assert.ok(result[0].icon.length > 0);
-		assert.ok(
-			result[0].icon.includes("<svg") || result[0].icon.includes("<SVG"),
-		);
-	});
+    assert.ok(result[0].icon.length > 0);
+    assert.ok(
+      result[0].icon.includes("<svg") || result[0].icon.includes("<SVG"),
+    );
+  });
 
-	it("handles multiple specs with mixed icon availability", () => {
-		const data = {
-			specs: [
-				{ name: "has dongle", value: "Yes" },
-				{ name: "no-icon-spec", value: "test" },
-				{ name: "HAS DONGLE", value: "Also yes" },
-			],
-		};
-		const result = computeSpecs(data);
+  it("handles multiple specs with mixed icon availability", () => {
+    const data = {
+      specs: [
+        { name: "has dongle", value: "Yes" },
+        { name: "no-icon-spec", value: "test" },
+        { name: "HAS DONGLE", value: "Also yes" },
+      ],
+    };
+    const result = computeSpecs(data);
 
-		assert.strictEqual(result.length, 3);
-		// First and third should have icons (same icon due to normalization)
-		assert.ok(result[0].icon.length > 0);
-		assert.strictEqual(result[1].icon, "");
-		assert.ok(result[2].icon.length > 0);
-		// First and third icons should be identical
-		assert.strictEqual(result[0].icon, result[2].icon);
-	});
+    assert.strictEqual(result.length, 3);
+    // First and third should have icons (same icon due to normalization)
+    assert.ok(result[0].icon.length > 0);
+    assert.strictEqual(result[1].icon, "");
+    assert.ok(result[2].icon.length > 0);
+    // First and third icons should be identical
+    assert.strictEqual(result[0].icon, result[2].icon);
+  });
 });

--- a/test/test-hygiene.test.js
+++ b/test/test-hygiene.test.js
@@ -1,4 +1,15 @@
-import { createTestRunner, expectTrue, expectStrictEqual, fs, path, rootDir, SRC_JS_FILES, SRC_HTML_FILES, SRC_SCSS_FILES, TEST_FILES } from "./test-utils.js";
+import {
+  createTestRunner,
+  expectStrictEqual,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_HTML_FILES,
+  SRC_JS_FILES,
+  SRC_SCSS_FILES,
+  TEST_FILES,
+} from "./test-utils.js";
 
 // Allowed function names in test files (utilities, not production logic)
 const ALLOWED_TEST_FUNCTIONS = new Set([
@@ -180,7 +191,9 @@ const extractFunctionDefinitions = (source) => {
  * Returns true if it looks like a test helper (uses assertions, mocks, etc.)
  */
 const isTestHelper = (source, funcName, startLine, lineCount) => {
-  const lines = source.split("\n").slice(startLine - 1, startLine - 1 + lineCount);
+  const lines = source
+    .split("\n")
+    .slice(startLine - 1, startLine - 1 + lineCount);
   const funcBody = lines.join("\n");
 
   // Test-related keywords that indicate this is test code
@@ -253,15 +266,28 @@ const testCases = [
     name: "file-lists-populated",
     description: "Pre-computed file lists contain files",
     test: () => {
-      expectTrue(SRC_JS_FILES.length > 0, `SRC_JS_FILES should not be empty (found ${SRC_JS_FILES.length})`);
-      expectTrue(SRC_HTML_FILES.length > 0, `SRC_HTML_FILES should not be empty (found ${SRC_HTML_FILES.length})`);
-      expectTrue(SRC_SCSS_FILES.length > 0, `SRC_SCSS_FILES should not be empty (found ${SRC_SCSS_FILES.length})`);
-      expectTrue(TEST_FILES.length > 0, `TEST_FILES should not be empty (found ${TEST_FILES.length})`);
+      expectTrue(
+        SRC_JS_FILES.length > 0,
+        `SRC_JS_FILES should not be empty (found ${SRC_JS_FILES.length})`,
+      );
+      expectTrue(
+        SRC_HTML_FILES.length > 0,
+        `SRC_HTML_FILES should not be empty (found ${SRC_HTML_FILES.length})`,
+      );
+      expectTrue(
+        SRC_SCSS_FILES.length > 0,
+        `SRC_SCSS_FILES should not be empty (found ${SRC_SCSS_FILES.length})`,
+      );
+      expectTrue(
+        TEST_FILES.length > 0,
+        `TEST_FILES should not be empty (found ${TEST_FILES.length})`,
+      );
     },
   },
   {
     name: "no-production-code-in-tests",
-    description: "Test files should not contain production logic - only test and import real code",
+    description:
+      "Test files should not contain production logic - only test and import real code",
     test: () => {
       const issues = analyzeTestFiles();
 
@@ -278,7 +304,7 @@ const testCases = [
         issues.length,
         0,
         `Found ${issues.length} function(s) that may be production code in test files. ` +
-        `Tests should import and test real code, not copies.`
+          `Tests should import and test real code, not copies.`,
       );
     },
   },
@@ -289,7 +315,11 @@ const testCases = [
       const source = `const myFunc = (a, b) => {\n  return a + b;\n};`;
       const funcs = extractFunctionDefinitions(source);
       expectStrictEqual(funcs.length, 1, "Should find one function");
-      expectStrictEqual(funcs[0].name, "myFunc", "Should extract function name");
+      expectStrictEqual(
+        funcs[0].name,
+        "myFunc",
+        "Should extract function name",
+      );
     },
   },
   {
@@ -299,7 +329,11 @@ const testCases = [
       const source = `function doSomething(x) {\n  console.log(x);\n}`;
       const funcs = extractFunctionDefinitions(source);
       expectStrictEqual(funcs.length, 1, "Should find one function");
-      expectStrictEqual(funcs[0].name, "doSomething", "Should extract function name");
+      expectStrictEqual(
+        funcs[0].name,
+        "doSomething",
+        "Should extract function name",
+      );
     },
   },
   {
@@ -309,7 +343,11 @@ const testCases = [
       const source = `const fetchData = async (url) => {\n  return await fetch(url);\n};`;
       const funcs = extractFunctionDefinitions(source);
       expectStrictEqual(funcs.length, 1, "Should find async function");
-      expectStrictEqual(funcs[0].name, "fetchData", "Should extract async function name");
+      expectStrictEqual(
+        funcs[0].name,
+        "fetchData",
+        "Should extract async function name",
+      );
     },
   },
 ];

--- a/test/then-usage.test.js
+++ b/test/then-usage.test.js
@@ -1,5 +1,14 @@
-import { createTestRunner, ECOMMERCE_JS_FILES, expectTrue, fs, path, rootDir, SRC_JS_FILES, TEST_FILES } from "./test-utils.js";
 import { ALLOWED_THEN_USAGE } from "./code-quality-exceptions.js";
+import {
+  createTestRunner,
+  ECOMMERCE_JS_FILES,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_JS_FILES,
+  TEST_FILES,
+} from "./test-utils.js";
 
 /**
  * Find all .then() calls in a file
@@ -38,8 +47,11 @@ const analyzeThenUsage = () => {
   const allowed = [];
 
   // Exclude this test file since it contains examples in test strings
-  const allJsFiles = [...SRC_JS_FILES, ...ECOMMERCE_JS_FILES, ...TEST_FILES]
-    .filter((f) => f !== "test/then-usage.test.js");
+  const allJsFiles = [
+    ...SRC_JS_FILES,
+    ...ECOMMERCE_JS_FILES,
+    ...TEST_FILES,
+  ].filter((f) => f !== "test/then-usage.test.js");
 
   for (const relativePath of allJsFiles) {
     const fullPath = path.join(rootDir, relativePath);
@@ -83,28 +95,33 @@ await asyncFunction();
       const results = findThenCalls(source);
       expectTrue(
         results.length === 2,
-        `Expected 2 .then() calls, found ${results.length}`
+        `Expected 2 .then() calls, found ${results.length}`,
       );
     },
   },
   {
     name: "no-new-then-chains",
-    description: "No new .then() chains outside the whitelist - use async/await",
+    description:
+      "No new .then() chains outside the whitelist - use async/await",
     test: () => {
       const { violations, allowed } = analyzeThenUsage();
 
       if (violations.length > 0) {
-        console.log(`\n  Found ${violations.length} non-whitelisted .then() calls:`);
+        console.log(
+          `\n  Found ${violations.length} non-whitelisted .then() calls:`,
+        );
         for (const v of violations) {
           console.log(`     - ${v.file}:${v.line}`);
           console.log(`       ${v.code}`);
         }
-        console.log("\n  To fix: refactor to use async/await, or add to ALLOWED_THEN_USAGE in code-quality-exceptions.js\n");
+        console.log(
+          "\n  To fix: refactor to use async/await, or add to ALLOWED_THEN_USAGE in code-quality-exceptions.js\n",
+        );
       }
 
       expectTrue(
         violations.length === 0,
-        `Found ${violations.length} non-whitelisted .then() calls. See list above.`
+        `Found ${violations.length} non-whitelisted .then() calls. See list above.`,
       );
     },
   },

--- a/test/todo-fixme-comments.test.js
+++ b/test/todo-fixme-comments.test.js
@@ -1,4 +1,13 @@
-import { createTestRunner, ECOMMERCE_JS_FILES, expectTrue, fs, path, rootDir, SRC_JS_FILES, TEST_FILES } from "./test-utils.js";
+import {
+  createTestRunner,
+  ECOMMERCE_JS_FILES,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_JS_FILES,
+  TEST_FILES,
+} from "./test-utils.js";
 
 /**
  * Find all TODO/FIXME occurrences in a file
@@ -71,23 +80,23 @@ const todoList = []; // variable name, not a comment
       const results = findTodoFixme(source);
       expectTrue(
         results.length === 2,
-        `Expected 2 TODO/FIXME comments, found ${results.length}`
+        `Expected 2 TODO/FIXME comments, found ${results.length}`,
       );
       expectTrue(
         results[0].lineNumber === 3,
-        `Expected line 3, got ${results[0].lineNumber}`
+        `Expected line 3, got ${results[0].lineNumber}`,
       );
       expectTrue(
         results[0].match === "TODO",
-        `Expected TODO, got ${results[0].match}`
+        `Expected TODO, got ${results[0].match}`,
       );
       expectTrue(
         results[1].lineNumber === 5,
-        `Expected line 5, got ${results[1].lineNumber}`
+        `Expected line 5, got ${results[1].lineNumber}`,
       );
       expectTrue(
         results[1].match === "FIXME",
-        `Expected FIXME, got ${results[1].match}`
+        `Expected FIXME, got ${results[1].match}`,
       );
     },
   },
@@ -108,7 +117,7 @@ const todoList = []; // variable name, not a comment
 
       expectTrue(
         violations.length === 0,
-        `Found ${violations.length} TODO/FIXME comments. See list above.`
+        `Found ${violations.length} TODO/FIXME comments. See list above.`,
       );
     },
   },

--- a/test/try-catch-usage.test.js
+++ b/test/try-catch-usage.test.js
@@ -1,5 +1,14 @@
-import { createTestRunner, ECOMMERCE_JS_FILES, expectTrue, fs, path, rootDir, SRC_JS_FILES, TEST_FILES } from "./test-utils.js";
 import { ALLOWED_TRY_CATCHES } from "./code-quality-exceptions.js";
+import {
+  createTestRunner,
+  ECOMMERCE_JS_FILES,
+  expectTrue,
+  fs,
+  path,
+  rootDir,
+  SRC_JS_FILES,
+  TEST_FILES,
+} from "./test-utils.js";
 
 /**
  * Find all try { occurrences in a file
@@ -38,8 +47,11 @@ const analyzeTryCatchUsage = () => {
   const allowed = [];
 
   // Exclude this test file since it contains try/catch examples in test strings
-  const allJsFiles = [...SRC_JS_FILES, ...ECOMMERCE_JS_FILES, ...TEST_FILES]
-    .filter((f) => f !== "test/try-catch-usage.test.js");
+  const allJsFiles = [
+    ...SRC_JS_FILES,
+    ...ECOMMERCE_JS_FILES,
+    ...TEST_FILES,
+  ].filter((f) => f !== "test/try-catch-usage.test.js");
 
   for (const relativePath of allJsFiles) {
     const fullPath = path.join(rootDir, relativePath);
@@ -86,11 +98,11 @@ const b = 2;
       const results = findTryCatches(source);
       expectTrue(
         results.length === 1,
-        `Expected 1 try/catch, found ${results.length}`
+        `Expected 1 try/catch, found ${results.length}`,
       );
       expectTrue(
         results[0].lineNumber === 3,
-        `Expected line 3, got ${results[0].lineNumber}`
+        `Expected line 3, got ${results[0].lineNumber}`,
       );
     },
   },
@@ -101,17 +113,21 @@ const b = 2;
       const { violations, allowed } = analyzeTryCatchUsage();
 
       if (violations.length > 0) {
-        console.log(`\n  Found ${violations.length} non-whitelisted try/catch blocks:`);
+        console.log(
+          `\n  Found ${violations.length} non-whitelisted try/catch blocks:`,
+        );
         for (const v of violations) {
           console.log(`     - ${v.file}:${v.line}`);
           console.log(`       ${v.code}`);
         }
-        console.log("\n  To fix: refactor to avoid try/catch, or add to ALLOWED_TRY_CATCHES in code-quality-exceptions.js\n");
+        console.log(
+          "\n  To fix: refactor to avoid try/catch, or add to ALLOWED_TRY_CATCHES in code-quality-exceptions.js\n",
+        );
       }
 
       expectTrue(
         violations.length === 0,
-        `Found ${violations.length} non-whitelisted try/catch blocks. See list above.`
+        `Found ${violations.length} non-whitelisted try/catch blocks. See list above.`,
       );
     },
   },

--- a/test/unused-classes.test.js
+++ b/test/unused-classes.test.js
@@ -2,7 +2,16 @@
 // Detects HTML classes and IDs that are never referenced in SCSS or JS files
 // This helps identify dead code and potential cleanup opportunities
 
-import { createTestRunner, expectTrue, fs, path, rootDir, SRC_HTML_FILES, SRC_SCSS_FILES, getFiles } from "./test-utils.js";
+import {
+  createTestRunner,
+  expectTrue,
+  fs,
+  getFiles,
+  path,
+  rootDir,
+  SRC_HTML_FILES,
+  SRC_SCSS_FILES,
+} from "./test-utils.js";
 
 const { readFileSync } = fs;
 const { join } = path;
@@ -270,7 +279,13 @@ const collectAllClassesAndIds = (htmlFiles, jsFiles) => {
   return { allClasses, allIds };
 };
 
-const findUnusedClassesAndIds = (allClasses, allIds, scssFiles, jsFiles, htmlFiles) => {
+const findUnusedClassesAndIds = (
+  allClasses,
+  allIds,
+  scssFiles,
+  jsFiles,
+  htmlFiles,
+) => {
   // Load all SCSS, JS, and HTML content
   const scssContent = scssFiles.map((f) => readFileSync(f, "utf-8")).join("\n");
   const jsContent = jsFiles.map((f) => readFileSync(f, "utf-8")).join("\n");

--- a/test/url-construction.test.js
+++ b/test/url-construction.test.js
@@ -132,7 +132,7 @@ const testCases = [
     name: "detect-hardcoded-events-url",
     description: "Detects hardcoded /events/ URL pattern",
     test: () => {
-      const source = 'const url = `/events/${slug}/`;';
+      const source = "const url = `/events/${slug}/`;";
       const results = findHardcodedUrls(source, "test.js");
       expectTrue(results.length === 1, "Should detect hardcoded /events/ URL");
     },
@@ -145,7 +145,7 @@ const testCases = [
       const results = findHardcodedUrls(source, "test.js");
       expectTrue(
         results.length === 1,
-        "Should detect hardcoded /products/ URL"
+        "Should detect hardcoded /products/ URL",
       );
     },
   },
@@ -153,7 +153,7 @@ const testCases = [
     name: "allow-comments",
     description: "Allows hardcoded URLs in comments",
     test: () => {
-      const source = '// Example: `/events/${slug}/`';
+      const source = "// Example: `/events/${slug}/`";
       const results = findHardcodedUrls(source, "test.js");
       expectTrue(results.length === 0, "Should allow URLs in comments");
     },
@@ -176,7 +176,7 @@ const testCases = [
       const results = findHardcodedUrls(source, "test.js");
       expectTrue(
         results.length === 0,
-        "Should allow strings config URL construction"
+        "Should allow strings config URL construction",
       );
     },
   },
@@ -188,21 +188,21 @@ const testCases = [
 
       if (violations.length > 0) {
         console.log(
-          `\n  Found ${violations.length} hardcoded URL constructions:`
+          `\n  Found ${violations.length} hardcoded URL constructions:`,
         );
         for (const v of violations) {
           console.log(`     - ${v.file}:${v.lineNumber}`);
           console.log(`       ${v.line}`);
         }
         console.log(
-          "\n  To fix: Use strings.*_permalink_dir and/or check for data.permalink\n"
+          "\n  To fix: Use strings.*_permalink_dir and/or check for data.permalink\n",
         );
       }
 
       expectTrue(
         violations.length === 0,
         `Found ${violations.length} hardcoded URL constructions. ` +
-          `Use strings.*_permalink_dir instead of hardcoding paths.`
+          `Use strings.*_permalink_dir instead of hardcoding paths.`,
       );
     },
   },


### PR DESCRIPTION
Refactored the test to use a linear flow instead of nested try/catch blocks. Also updated code-quality-exceptions.js line numbers that drifted due to linting.