### PR TITLE
Remove unnecessary try-catch blocks from codebase

### DIFF
--- a/test/code-quality-exceptions.js
+++ b/test/code-quality-exceptions.js
@@ -52,13 +52,6 @@ const ALLOWED_TRY_CATCHES = new Set([
   // src/assets/js/stripe-checkout.js - Stripe API
   "src/assets/js/stripe-checkout.js:38",
 
-  // test/scss.test.js - SCSS compilation tests
-  "test/scss.test.js:42",
-  "test/scss.test.js:208",
-
-  // test/navigation.test.js - navigation tests
-  "test/navigation.test.js:80",
-
   // src/assets/js/cart-utils.js - JSON parsing of localStorage data
   // Needed: localStorage is browser-side storage that can be corrupted by users,
   // extensions, or data migration issues. We don't control this input.

--- a/test/navigation.test.js
+++ b/test/navigation.test.js
@@ -77,20 +77,9 @@ const testCases = [
       const filter = createNavigationFilter(mockEleventyConfig);
       // Just test that it handles collections without throwing, since real navUtil
       // requires collection to be processed by eleventyNavigation filter first
-      try {
-        filter([], "home"); // Empty collection should work
-        expectStrictEqual(
-          true,
-          true,
-          "Should handle collections without error",
-        );
-      } catch (error) {
-        expectStrictEqual(
-          false,
-          true,
-          `Should not throw error: ${error.message}`,
-        );
-      }
+      // If this throws, the test will fail - no need to catch
+      filter([], "home"); // Empty collection should work
+      expectStrictEqual(true, true, "Should handle collections without error");
     },
   },
   {

--- a/test/scss.test.js
+++ b/test/scss.test.js
@@ -3,9 +3,9 @@ import {
   createMockEleventyConfig,
   createTestRunner,
   expectArrayLength,
-  expectFalse,
   expectFunctionType,
   expectStrictEqual,
+  expectThrows,
   expectTrue,
 } from "./test-utils.js";
 
@@ -39,15 +39,12 @@ const testCases = [
 
       expectFunctionType(compiler, undefined, "Should return a function");
 
-      try {
-        compiler({});
-      } catch (error) {
-        expectTrue(
-          error.message.includes("Can't find stylesheet") ||
-            error.message.includes("file to import not found"),
-          "Should handle import errors gracefully",
-        );
-      }
+      // Missing import should throw an error
+      expectThrows(
+        () => compiler({}),
+        /Can't find stylesheet|file to import not found/i,
+        "Should throw error for missing import",
+      );
     },
   },
   {
@@ -205,12 +202,12 @@ const testCases = [
       const invalidScss = ".test { color: ; }"; // Invalid syntax
       const inputPath = "/test/invalid.scss";
 
-      try {
-        compileScss(invalidScss, inputPath);
-        expectFalse(true, "Should throw error for invalid SCSS");
-      } catch (error) {
-        expectTrue(error.message.length > 0, "Should provide error message");
-      }
+      // Invalid SCSS should throw an error with a message
+      expectThrows(
+        () => compileScss(invalidScss, inputPath),
+        /./,
+        "Should throw error for invalid SCSS",
+      );
     },
   },
   {


### PR DESCRIPTION
- test/navigation.test.js: Remove unnecessary try/catch that just catches errors to mark test as failed - if function throws, test fails naturally
- test/scss.test.js: Refactor to use expectThrows helper for testing error conditions instead of try/catch
- Update ALLOWED_TRY_CATCHES to remove the 3 exceptions that were fixed