### PR TITLE
Move test coverage limits to separate config file

### DIFF
--- a/.test_coverage.json
+++ b/.test_coverage.json
@@ -1,0 +1,5 @@
+{
+	"lines": 77,
+	"functions": 76,
+	"branches": 92
+}

--- a/knip.json
+++ b/knip.json
@@ -16,7 +16,8 @@
 		"@zachleat/heading-anchors",
 		"@botpoison/browser",
 		"@hotwired/turbo",
-		"liquidjs"
+		"liquidjs",
+		"c8"
 	],
 	"ignoreBinaries": [],
 	"ignoreExportsUsedInFile": true,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"scripts": {
 		"build": "rm -rf _site && eleventy",
 		"serve": "rm -rf _site && eleventy --serve --incremental --quiet",
-		"test": "eleventy --quiet && c8 --lines 77 --functions 76 --branches 92 node test/run-all-tests.js",
+		"test": "eleventy --quiet && node test/run-coverage.js",
 		"test:verbose": "TEST_VERBOSE=1 pnpm test",
 		"cpd": "jscpd",
 		"knip": "knip",

--- a/test/run-coverage.js
+++ b/test/run-coverage.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "child_process";
+import { readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = resolve(__dirname, "..");
+const configPath = resolve(rootDir, ".test_coverage.json");
+
+function readLimits() {
+	const content = readFileSync(configPath, "utf-8");
+	return JSON.parse(content);
+}
+
+function writeLimits(limits) {
+	const content = JSON.stringify(limits, null, "\t") + "\n";
+	writeFileSync(configPath, content, "utf-8");
+}
+
+function runCoverage() {
+	const limits = readLimits();
+
+	// Run c8 with current limits and JSON reporter
+	const c8Args = [
+		"--lines",
+		String(limits.lines),
+		"--functions",
+		String(limits.functions),
+		"--branches",
+		String(limits.branches),
+		"--reporter=text",
+		"--reporter=json",
+		"--report-dir=coverage",
+		"node",
+		"test/run-all-tests.js",
+	];
+
+	// Pass through any additional args (like --verbose via TEST_VERBOSE env)
+	const result = spawnSync("npx", ["c8", ...c8Args], {
+		cwd: rootDir,
+		stdio: "inherit",
+		env: process.env,
+	});
+
+	if (result.status !== 0) {
+		process.exit(result.status || 1);
+	}
+
+	// Tests passed, now check if we should ratchet up the limits
+	ratchetLimits(limits);
+}
+
+function ratchetLimits(currentLimits) {
+	// Read the JSON coverage report
+	const reportPath = resolve(rootDir, "coverage", "coverage-summary.json");
+	let report;
+	try {
+		const content = readFileSync(reportPath, "utf-8");
+		report = JSON.parse(content);
+	} catch {
+		// No JSON report available, skip ratcheting
+		return;
+	}
+
+	const total = report.total;
+	if (!total) {
+		return;
+	}
+
+	// Get actual coverage percentages (rounded down to match c8 behavior)
+	const actualLines = Math.floor(total.lines.pct);
+	const actualFunctions = Math.floor(total.functions.pct);
+	const actualBranches = Math.floor(total.branches.pct);
+
+	let updated = false;
+	const newLimits = { ...currentLimits };
+
+	if (actualLines > currentLimits.lines) {
+		newLimits.lines = actualLines;
+		updated = true;
+	}
+
+	if (actualFunctions > currentLimits.functions) {
+		newLimits.functions = actualFunctions;
+		updated = true;
+	}
+
+	if (actualBranches > currentLimits.branches) {
+		newLimits.branches = actualBranches;
+		updated = true;
+	}
+
+	if (updated) {
+		writeLimits(newLimits);
+		console.log("\n📈 Coverage limits updated in .test_coverage.json:");
+		if (newLimits.lines !== currentLimits.lines) {
+			console.log(`   lines: ${currentLimits.lines}% → ${newLimits.lines}%`);
+		}
+		if (newLimits.functions !== currentLimits.functions) {
+			console.log(
+				`   functions: ${currentLimits.functions}% → ${newLimits.functions}%`,
+			);
+		}
+		if (newLimits.branches !== currentLimits.branches) {
+			console.log(
+				`   branches: ${currentLimits.branches}% → ${newLimits.branches}%`,
+			);
+		}
+	}
+}
+
+runCoverage();


### PR DESCRIPTION
Move test coverage limits from hardcoded package.json args to a .test_coverage.json config file. The new test/run-coverage.js script reads limits from this file, runs c8 with them, and automatically updates the limits when actual coverage exceeds current thresholds.

This enables coverage ratcheting: once coverage improves, it cannot regress below the new level.