### PR TITLE
Use site.json domain in canonical URL tests

### DIFF
--- a/test/canonical-url.test.js
+++ b/test/canonical-url.test.js
@@ -1,9 +1,9 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { canonicalUrl } from "#utils/canonical-url.js";
+import siteData from "#data/site.json" with { type: "json" };
 
-// Site URL from site.json is https://example.chobble.com
-const SITE_URL = "https://example.chobble.com";
+const SITE_URL = siteData.url;
 
 describe("canonicalUrl", () => {
   it("joins site URL and page URL correctly", () => {


### PR DESCRIPTION
Replace hardcoded domain with dynamic import from site.json so tests stay in sync if the site URL changes.