### PR TITLE
Remove unnecessary try-catch blocks from own code

### DIFF
--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -15,7 +15,7 @@ const ALLOWED_TRY_CATCHES = new Set([
   "ecommerce-backend/server.js:213",
   "ecommerce-backend/server.js:289",
 
-  // ecommerce-backend/server.test.js - test assertions
+  // ecommerce-backend/server.test.js - test runner catching failures
   "ecommerce-backend/server.test.js:366",
 
   // src/assets/js/availability-calendar.js - fetch error handling
@@ -37,26 +37,6 @@ const ALLOWED_TRY_CATCHES = new Set([
   // Needed: localStorage is browser-side storage that can be corrupted by users,
   // extensions, or data migration issues. We don't control this input.
   "src/assets/js/cart-utils.js:11",
-
-  // test/checkout.test.js - checkout flow tests
-  "test/checkout.test.js:234",
-  "test/checkout.test.js:282",
-  "test/checkout.test.js:343",
-  "test/checkout.test.js:377",
-  "test/checkout.test.js:419",
-  "test/checkout.test.js:485",
-  "test/checkout.test.js:534",
-  "test/checkout.test.js:586",
-  "test/checkout.test.js:611",
-  "test/checkout.test.js:646",
-  "test/checkout.test.js:686",
-  "test/checkout.test.js:724",
-  "test/checkout.test.js:763",
-
-  // test/file-utils.test.js - file utility tests
-  "test/file-utils.test.js:84",
-  "test/file-utils.test.js:221",
-  "test/file-utils.test.js:264",
 
   // test/cpd.test.js - running external tool and capturing exit code
   "test/cpd.test.js:16",


### PR DESCRIPTION
- Update findTryCatches to only flag blocks with catch clauses
- try/finally (for cleanup) is now correctly ignored
- Remove 17 unnecessary entries from ALLOWED_TRY_CATCHES
- Add tests for try/finally exclusion and try/catch/finally detection