### PR TITLE
Reduce code duplication from 1.13% to 0.88%

### DIFF
--- a/src/_lib/build/theme-compiler.js
+++ b/src/_lib/build/theme-compiler.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { memoize } from "#utils/memoize.js";
+import { slugToTitle } from "#utils/slug-utils.js";
 
 // Get all theme files and their names
 const getThemeFiles = memoize(() => {
@@ -35,14 +36,6 @@ const extractRootVariables = (content) => {
   return rootMatch[1];
 };
 
-// Convert theme name to display name (e.g., "90s-computer" -> "90s Computer")
-const toDisplayName = (name) => {
-  return name
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-};
-
 // Generate compiled theme CSS for theme-switcher
 const generateThemeSwitcherContent = memoize(() => {
   const themes = getThemeFiles(); // Already sorted alphabetically
@@ -60,7 +53,7 @@ const generateThemeSwitcherContent = memoize(() => {
   // Generate theme list as CSS custom property for JavaScript access
   const themeList = ["default", ...themes.map((t) => t.name)];
   const displayNames = themes.map(
-    (theme) => `  --theme-${theme.name}-name: "${toDisplayName(theme.name)}";`,
+    (theme) => `  --theme-${theme.name}-name: "${slugToTitle(theme.name)}";`,
   );
 
   const metadata = `// Theme metadata for JavaScript access

--- a/src/_lib/utils/slug-utils.js
+++ b/src/_lib/utils/slug-utils.js
@@ -26,4 +26,11 @@ const buildPermalink = (data, dir) => {
 const buildPdfFilename = (businessName, menuSlug) =>
   `${slugify(businessName)}-${menuSlug}.pdf`;
 
-export { normaliseSlug, buildPermalink, buildPdfFilename };
+// Convert a slug to title case (e.g., "90s-computer" -> "90s Computer")
+const slugToTitle = (slug) =>
+  slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+export { normaliseSlug, buildPermalink, buildPdfFilename, slugToTitle };

--- a/src/assets/js/cart.js
+++ b/src/assets/js/cart.js
@@ -8,10 +8,10 @@ import {
   escapeHtml,
   formatPrice,
   getCart,
-  removeItem,
   renderQuantityControls,
   saveCart,
   updateCartIcon,
+  updateItemQuantity,
 } from "#assets/cart-utils.js";
 import Config from "#assets/config.js";
 import { onReady } from "#assets/on-ready.js";
@@ -139,28 +139,11 @@ const updateCartDisplay = () => {
   if (cartTotal) cartTotal.textContent = formatPrice(total);
 };
 
-// Update item quantity
+// Update item quantity using shared utility
 const updateQuantity = (itemName, quantity) => {
-  const cart = getCart();
-  const item = cart.find((item) => item.item_name === itemName);
-
-  if (item) {
-    if (quantity <= 0) {
-      removeItem(itemName);
-      updateCartDisplay();
-      updateCartCount();
-    } else {
-      if (item.max_quantity && quantity > item.max_quantity) {
-        alert(`The maximum quantity for this item is ${item.max_quantity}`);
-        item.quantity = item.max_quantity;
-      } else {
-        item.quantity = quantity;
-      }
-      saveCart(cart);
-      updateCartDisplay();
-      updateCartCount();
-    }
-  }
+  updateItemQuantity(itemName, quantity);
+  updateCartDisplay();
+  updateCartCount();
 };
 
 // Add item to cart

--- a/src/locations/locations.11tydata.js
+++ b/src/locations/locations.11tydata.js
@@ -1,4 +1,5 @@
 import strings from "#data/strings.js";
+import { slugToTitle } from "#utils/slug-utils.js";
 
 const locationDir = strings.location_permalink_dir;
 
@@ -22,15 +23,9 @@ export default {
       if (data.eleventyNavigation) return data.eleventyNavigation;
       if (data.parentLocation) {
         // Service-location: add as child of parent location
-        // Convert slug to title case for the parent navigation key
-        // e.g., "royston-vasey" → "Royston Vasey"
-        const parentTitle = data.parentLocation
-          .split("-")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(" ");
         return {
           key: data.title,
-          parent: parentTitle,
+          parent: slugToTitle(data.parentLocation),
           order: data.link_order || 0,
         };
       }

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -22,7 +22,7 @@ const ALLOWED_TRY_CATCHES = new Set([
   "src/assets/js/availability-calendar.js:132",
 
   // src/assets/js/cart.js - PayPal checkout fetch handling
-  "src/assets/js/cart.js:224",
+  "src/assets/js/cart.js:207",
 
   // src/_lib/media/image.js - image processing
   "src/_lib/media/image.js:74",


### PR DESCRIPTION
Extract slugToTitle utility to reduce duplication between theme-compiler
and locations.11tydata. Also refactor cart.js to reuse updateItemQuantity
from cart-utils instead of duplicating the quantity update logic.