### PR TITLE
Add tests for navigation.js and search.js to improve coverage

### DIFF
--- a/.test_coverage.json
+++ b/.test_coverage.json
@@ -1,5 +1,5 @@
 {
-	"lines": 94,
-	"functions": 91,
+	"lines": 95,
+	"functions": 92,
 	"branches": 94
 }


### PR DESCRIPTION
- Add 8 tests for navigationLinks collection callback covering:
  - Filtering items by eleventyNavigation presence
  - Sorting by order property
  - Default order of 999 for items without order
  - Alphabetical sorting by key/title when orders equal
  - Fallback to title when key is missing
  - Edge cases (empty collection, no nav items)

- Add 8 tests for search.js normaliseCategory function covering:
  - Null/undefined/empty input handling
  - Removing /categories/ path prefix
  - Removing .md file extension
  - Converting hyphens to spaces
  - Plain string handling
  - Category-derived keywords in products

Coverage improvements:
- navigation.js: 75.51% → 100%
- search.js: 86.41% → 100%
- Overall lines: 94.8% → 95.03%

Update coverage limits: lines 94% → 95%