### PR TITLE
Refactor render-snippet.test.js to meet test quality criteria

### DIFF
--- a/test/code-quality/test-hygiene.test.js
+++ b/test/code-quality/test-hygiene.test.js
@@ -76,8 +76,6 @@ const ALLOWED_TEST_FUNCTIONS = new Set([
   "countCamelCaseWords",
   "extractCamelCaseIdentifiers",
   "analyzeNamingConventions",
-  // render-snippet.test.js
-  "runTests",
   // scss.variables.test.js
   "extractUsedVariables",
   "extractDefinedVariables",


### PR DESCRIPTION
- Replace custom test runner with createTestRunner pattern
- Use standard test utilities (expectStrictEqual, expectTrue, expectFalse)
- Use createTempSnippetsDir/cleanupTempDir for temp file management
- Import renderSnippet directly from file-utils.js instead of via .eleventy.js
- Split all tests into individual test cases with clear descriptions
- Add tests for shortcode preprocessing (opening_times, recurring_events)
- Add edge case tests (empty content, whitespace, special characters)
- Remove custom mock config in favor of testing production functions directly
- Update test-hygiene whitelist to remove obsolete runTests entry