### PR TITLE
Refactor file to meet quality criteria

### DIFF
--- a/test/code-quality/test-quality.test.js
+++ b/test/code-quality/test-quality.test.js
@@ -22,28 +22,6 @@ import {
 // Exception Lists (grandfathered violations)
 // ============================================
 
-// Grandfathered asyncTest functions that need to be converted to sync
-const ASYNC_TEST_EXCEPTIONS = new Set([
-  "test/checkout.test.js:376", // cart-utils-escapeHtml-basic
-  "test/checkout.test.js:410", // cart-utils-updateCartIcon-shows-icon
-  "test/checkout.test.js:452", // cart-utils-updateCartIcon-hides-icon
-  "test/checkout.test.js:527", // cart-utils-updateItemQuantity-respects-max
-  "test/checkout.test.js:577", // cart-utils-renderQuantityControls-basic
-  "test/checkout.test.js:629", // cart-utils-renderQuantityControls-max-quantity
-  "test/checkout.test.js:654", // cart-utils-renderQuantityControls-escapes-html
-  "test/checkout.test.js:678", // cart-utils-attachQuantityHandlers-decrease
-  "test/checkout.test.js:718", // cart-utils-attachQuantityHandlers-increase
-  "test/checkout.test.js:758", // cart-utils-attachQuantityHandlers-input-change
-  "test/checkout.test.js:797", // cart-utils-attachRemoveHandlers-removes-item
-  "test/checkout.test.js:1366", // stripe-checkout-empty-cart-redirects-home
-]);
-
-// Grandfathered tautological patterns
-// Supports file-level ("test/file.js") or specific ("test/file.js:assignLine:assertLine")
-const TAUTOLOGICAL_EXCEPTIONS = new Set([
-  "test/checkout.test.js", // 2 tautological patterns to fix
-]);
-
 // Files that are allowed to have tests with "and" in names
 const AND_NAME_EXCEPTIONS = new Set([
   "test/theme-editor.test.js", // e2e tests that test workflows


### PR DESCRIPTION
The ASYNC_TEST_EXCEPTIONS and TAUTOLOGICAL_EXCEPTIONS variables were never used in the actual test logic and caused lint warnings. These exceptions became obsolete after previous PRs fixed the underlying violations in checkout.test.js (#215, #218).