### PR TITLE
Move HTML from JavaScript to template file

### DIFF
--- a/src/_includes/availability-calendar.html
+++ b/src/_includes/availability-calendar.html
@@ -10,4 +10,5 @@
     <p class="calendar-loading">Loading...</p>
   </div>
 </dialog>
+{% include "templates/calendar.html" %}
 {%- endif -%}

--- a/src/_includes/templates/calendar.html
+++ b/src/_includes/templates/calendar.html
@@ -1,0 +1,6 @@
+<template id="{{ selectors.IDS.CALENDAR_MONTH }}">
+  <div class="calendar-month">
+    <h3 data-field="title"></h3>
+    <div class="calendar-grid"></div>
+  </div>
+</template>

--- a/src/assets/js/availability-calendar.js
+++ b/src/assets/js/availability-calendar.js
@@ -2,6 +2,8 @@
 // Displays a 12-month calendar with unavailable dates greyed out
 
 import { onReady } from "#assets/on-ready.js";
+import { IDS } from "#assets/selectors.js";
+import { getTemplate } from "#assets/template.js";
 
 const MONTHS = [
   "January",
@@ -31,14 +33,22 @@ function getContent() {
 function showLoading() {
   const content = getContent();
   if (content) {
-    content.innerHTML = '<p class="calendar-loading">Loading...</p>';
+    content.innerHTML = "";
+    const p = document.createElement("p");
+    p.className = "calendar-loading";
+    p.textContent = "Loading...";
+    content.appendChild(p);
   }
 }
 
 function showError(message) {
   const content = getContent();
   if (content) {
-    content.innerHTML = `<p class="calendar-error">${message}</p>`;
+    content.innerHTML = "";
+    const p = document.createElement("p");
+    p.className = "calendar-error";
+    p.textContent = message;
+    content.appendChild(p);
   }
 }
 
@@ -52,15 +62,16 @@ function renderCalendar(unavailableDates) {
 
   const todayStr = formatDate(today);
 
-  let html = '<div class="calendar-months">';
+  content.innerHTML = "";
+  const container = document.createElement("div");
+  container.className = "calendar-months";
 
   for (let i = 0; i < 12; i++) {
     const monthDate = new Date(today.getFullYear(), today.getMonth() + i, 1);
-    html += renderMonth(monthDate, unavailableSet, todayStr);
+    container.appendChild(renderMonth(monthDate, unavailableSet, todayStr));
   }
 
-  html += "</div>";
-  content.innerHTML = html;
+  content.appendChild(container);
 }
 
 function renderMonth(monthDate, unavailableSet, todayStr) {
@@ -74,18 +85,24 @@ function renderMonth(monthDate, unavailableSet, todayStr) {
   let startDay = firstDay.getDay() - 1;
   if (startDay < 0) startDay = 6;
 
-  let html = `<div class="calendar-month">`;
-  html += `<h3>${MONTHS[month]} ${year}</h3>`;
-  html += `<div class="calendar-grid">`;
+  const monthTemplate = getTemplate(IDS.CALENDAR_MONTH);
+  monthTemplate.querySelector('[data-field="title"]').textContent =
+    `${MONTHS[month]} ${year}`;
+  const grid = monthTemplate.querySelector(".calendar-grid");
 
   // Day headers
   for (const day of DAYS) {
-    html += `<span class="calendar-day-header">${day}</span>`;
+    const header = document.createElement("span");
+    header.className = "calendar-day-header";
+    header.textContent = day;
+    grid.appendChild(header);
   }
 
   // Empty cells before first day
   for (let i = 0; i < startDay; i++) {
-    html += `<span class="calendar-day empty"></span>`;
+    const empty = document.createElement("span");
+    empty.className = "calendar-day empty";
+    grid.appendChild(empty);
   }
 
   // Days of month
@@ -95,16 +112,18 @@ function renderMonth(monthDate, unavailableSet, todayStr) {
     const isUnavailable = unavailableSet.has(dateStr);
     const isToday = dateStr === todayStr;
 
-    let classes = "calendar-day";
-    if (isPast) classes += " past";
-    if (isUnavailable && !isPast) classes += " unavailable";
-    if (isToday) classes += " today";
+    const dayEl = document.createElement("span");
+    dayEl.className = "calendar-day";
+    dayEl.textContent = day;
 
-    html += `<span class="${classes}">${day}</span>`;
+    if (isPast) dayEl.classList.add("past");
+    if (isUnavailable && !isPast) dayEl.classList.add("unavailable");
+    if (isToday) dayEl.classList.add("today");
+
+    grid.appendChild(dayEl);
   }
 
-  html += `</div></div>`;
-  return html;
+  return monthTemplate;
 }
 
 function formatDate(date) {

--- a/src/assets/js/selectors.js
+++ b/src/assets/js/selectors.js
@@ -5,6 +5,7 @@ const toKebab = (s) => s.toLowerCase().replace(/_/g, "-");
 
 export const IDS = Object.fromEntries(
   [
+    "CALENDAR_MONTH",
     "CART_ITEM",
     "QUOTE_CART_ITEM",
     "QUOTE_CHECKOUT_ITEM",

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -19,7 +19,7 @@ const ALLOWED_TRY_CATCHES = new Set([
   "ecommerce-backend/server.test.js:366",
 
   // src/assets/js/availability-calendar.js - fetch error handling
-  "src/assets/js/availability-calendar.js:132",
+  "src/assets/js/availability-calendar.js:151",
 
   // src/assets/js/cart.js - PayPal checkout fetch handling
   "src/assets/js/cart.js:209",
@@ -47,9 +47,6 @@ const ALLOWED_TRY_CATCHES = new Set([
 // Files that are allowed to contain HTML in JavaScript template literals.
 // These should be refactored over time to use external templates.
 const ALLOWED_HTML_IN_JS = new Set([
-  // Client-side JS - calendar display
-  "src/assets/js/availability-calendar.js",
-
   // Server-side Eleventy plugins generating HTML
   "src/_lib/eleventy/area-list.js",
   "src/_lib/eleventy/opening-times.js",

--- a/test/code-quality/template-selectors.test.js
+++ b/test/code-quality/template-selectors.test.js
@@ -59,6 +59,7 @@ function loadTemplate(filename) {
 }
 
 // Load all template files
+const calendarTemplates = loadTemplate("calendar.html");
 const cartTemplates = loadTemplate("cart.html");
 const galleryTemplates = loadTemplate("gallery.html");
 
@@ -67,7 +68,11 @@ describe("Template selector contracts", () => {
     for (const [key, id] of Object.entries(IDS)) {
       it(`template "${id}" (${key}) exists`, () => {
         let found = false;
-        for (const dom of [cartTemplates, galleryTemplates]) {
+        for (const dom of [
+          calendarTemplates,
+          cartTemplates,
+          galleryTemplates,
+        ]) {
           if (dom?.window.document.getElementById(id)) {
             found = true;
             break;
@@ -84,6 +89,7 @@ describe("Template selector contracts", () => {
 
 describe("Selector constants usage verification", () => {
   const jsFiles = [
+    "src/assets/js/availability-calendar.js",
     "src/assets/js/cart.js",
     "src/assets/js/quote.js",
     "src/assets/js/quote-checkout.js",
@@ -109,7 +115,7 @@ describe("Selector constants usage verification", () => {
 });
 
 describe("HTML templates use Liquid selectors for IDs", () => {
-  const templateFiles = ["cart.html", "gallery.html"];
+  const templateFiles = ["calendar.html", "cart.html", "gallery.html"];
 
   for (const filename of templateFiles) {
     const filepath = path.join(templatesDir, filename);


### PR DESCRIPTION
Refactor availability-calendar.js to avoid inline HTML strings:
- Use a single template for the month structure (has nested elements)
- Use document.createElement() for simple elements (spans, paragraphs)

This removes it from the HTML-in-JS exceptions list while avoiding over-engineering with excessive tiny templates.