### PR TITLE
Fix race condition in image cropping causing random build failures

### DIFF
--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -88,7 +88,7 @@ const U = {
     gcd = gcd(metadata.width, metadata.height);
     return `${metadata.width / gcd}/${metadata.height / gcd}`;
   },
-  cropImage: async (aspectRatio, sourcePath, metadata) => {
+  cropImage: memoize(async (aspectRatio, sourcePath, metadata) => {
     if (aspectRatio === null || aspectRatio === undefined) return sourcePath;
 
     const cachedPath = buildCropCachePath(sourcePath, aspectRatio);
@@ -101,7 +101,7 @@ const U = {
       .toFile(cachedPath);
 
     return cachedPath;
-  },
+  }),
   // Build div HTML using JSDOM for consistency
   makeDivHtml: async (
     classes,


### PR DESCRIPTION
Memoize the cropImage function to prevent concurrent calls from
racing to create the same cropped image file. Previously, when
Eleventy processed templates in parallel, multiple calls could
start writing the same crop file simultaneously, causing later
calls to read an incomplete file and fail with "Input Buffer is
empty" error.