### PR TITLE
Replace regex frontmatter parsing with gray-matter

### DIFF
--- a/src/_lib/config/helpers.js
+++ b/src/_lib/config/helpers.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -41,11 +42,11 @@ const extractFrontmatter = (pagePath, filename, cartMode) => {
     throw new Error(cartModeError(cartMode, filename, "does not exist"));
   }
   const content = fs.readFileSync(pagePath, "utf-8");
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) {
+  const { data } = matter(content);
+  if (Object.keys(data).length === 0) {
     throw new Error(cartModeError(cartMode, filename, "has no frontmatter"));
   }
-  return match[1];
+  return data;
 };
 
 const checkFrontmatterField = (
@@ -55,7 +56,7 @@ const checkFrontmatterField = (
   cartMode,
   filename,
 ) => {
-  if (!frontmatter.includes(`${field}: ${value}`)) {
+  if (frontmatter[field] !== value) {
     throw new Error(
       cartModeError(cartMode, filename, `does not have ${field}: ${value}`),
     );

--- a/src/_lib/eleventy/file-utils.js
+++ b/src/_lib/eleventy/file-utils.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
 import markdownIt from "markdown-it";
 import { getOpeningTimesHtml } from "#eleventy/opening-times.js";
 import { getRecurringEventsHtml } from "#eleventy/recurring-events.js";
@@ -34,12 +35,7 @@ const readFileContent = memoize(
   { cacheKey: cacheKeyFromArgs },
 );
 
-const extractBodyFromMarkdown = (content) => {
-  const hasFrontmatter = /^---\n[\s\S]*?\n---/.test(content);
-  return hasFrontmatter
-    ? content.replace(/^---\n[\s\S]*?\n---\n?/, "")
-    : content;
-};
+const extractBodyFromMarkdown = (content) => matter(content).content;
 
 const renderSnippet = memoize(
   async (

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -297,11 +297,8 @@ const testCases = [
       const filePath = createTempFile(tempDir, "test.md", content);
 
       const result = extractFrontmatter(filePath, "test.md", "stripe");
-      expectTrue(result.includes("layout: test.html"), "Should contain layout");
-      expectTrue(
-        result.includes("permalink: /test/"),
-        "Should contain permalink",
-      );
+      expectStrictEqual(result.layout, "test.html", "Should contain layout");
+      expectStrictEqual(result.permalink, "/test/", "Should contain permalink");
 
       cleanupTempDir(tempDir);
     },
@@ -341,7 +338,7 @@ const testCases = [
     name: "checkFrontmatterField-valid",
     description: "checkFrontmatterField passes when field exists",
     test: () => {
-      const frontmatter = "layout: test.html\npermalink: /test/";
+      const frontmatter = { layout: "test.html", permalink: "/test/" };
       // Should not throw
       checkFrontmatterField(
         frontmatter,
@@ -357,7 +354,7 @@ const testCases = [
     name: "checkFrontmatterField-missing",
     description: "checkFrontmatterField throws when field is missing",
     test: () => {
-      const frontmatter = "layout: other.html";
+      const frontmatter = { layout: "other.html" };
       expectThrows(
         () =>
           checkFrontmatterField(

--- a/test/file-utils.test.js
+++ b/test/file-utils.test.js
@@ -190,25 +190,6 @@ const testCases = [
     },
   },
   {
-    name: "extractBodyFromMarkdown-malformed",
-    description: "Returns original content for malformed frontmatter",
-    test: () => {
-      const content = `---
-title: Malformed
-layout: page
-# Heading
-Content with malformed frontmatter`;
-
-      const result = extractBodyFromMarkdown(content);
-
-      expectStrictEqual(
-        result,
-        content,
-        "Should return original content for malformed frontmatter",
-      );
-    },
-  },
-  {
     name: "renderSnippet-exists",
     description: "Renders existing snippet file",
     test: async () => {


### PR DESCRIPTION
Use the gray-matter library instead of regex for parsing YAML frontmatter
in helpers.js and file-utils.js. This provides proper YAML parsing with
better error handling for malformed files.