### PR TITLE
Deduplicate layout markup between item.html and property.html

### DIFF
--- a/src/_layouts/item.html
+++ b/src/_layouts/item.html
@@ -9,7 +9,11 @@ layout: base
     {% include "item-event-details.html" %}
   </div>
 
-  {% include "item-gallery.html" %}
+  {% if gallery_template %}
+    {% include gallery_template %}
+  {% else %}
+    {% include "item-gallery.html" %}
+  {% endif %}
 
   <div class="description">
     {% include "item-reviews-count.html" %}

--- a/src/_layouts/property.html
+++ b/src/_layouts/property.html
@@ -1,30 +1,5 @@
 ---
-layout: base
+layout: item
+gallery_template: property-gallery.html
 ---
-
-<section id="item">
-  <div class="title">
-    {% include "item-title.html" %}
-    {% include "item-event-details.html" %}
-  </div>
-
-  {% include "property-gallery.html" %}
-
-  <div class="description">
-    {% include "item-reviews-count.html" %}
-    {% include "product-options.html" %}
-    {% include "item-about-heading.html" %}
-    {% include "item-category-links.html" %}
-    {% include "item-event-categories.html" %}
-    {% include "etsy-buy-button.html" %}
-    {{ content }}
-    {% include "tabs.html" %}
-    {% include "item-map-section.html" %}
-    {% include "item-features-list.html" %}
-    {% include "item-specifications-list.html" %}
-    {% include "item-reviews-section.html" %}
-    {%- include "faq.html" -%}
-  </div>
-  {% include "item-event-products.html" %}
-  {% include "item-contact-section.html" %}
-</section>
+{{ content }}


### PR DESCRIPTION
Refactor property.html to extend item.html instead of duplicating
the entire layout structure. Use gallery_template variable to allow
child layouts to specify which gallery include to use.