### PR TITLE
Fix jscpd duplication warning in news-post.html

### DIFF
--- a/src/_includes/post-meta-author.html
+++ b/src/_includes/post-meta-author.html
@@ -1,0 +1,1 @@
+<address>By <a rel="author" href="{{ authorData.url }}">{{ authorData.data.title }}</a></address>

--- a/src/_includes/post-meta-date.html
+++ b/src/_includes/post-meta-date.html
@@ -1,0 +1,1 @@
+<time datetime="{{ page.date | date: '%Y-%m-%d' }}">{{ page.date | date: "%B %-d, %Y" }}</time>

--- a/src/_layouts/news-post.html
+++ b/src/_layouts/news-post.html
@@ -18,18 +18,18 @@ layout: base
     <a href="{{ authorData.url }}">{% image authorData.data.image, authorData.data.title, "80,160,240", "", "", "1/1" %}</a>
   </figure>
   <div>
-    <address>By <a rel="author" href="{{ authorData.url }}">{{ authorData.data.title }}</a></address>
-    <time datetime="{{ page.date | date: '%Y-%m-%d' }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+    {%- include "post-meta-author.html" -%}
+    {%- include "post-meta-date.html" -%}
   </div>
 </header>
 {%- elsif authorData -%}
 <header class="post-meta" role="doc-subtitle">
-  <address>By <a rel="author" href="{{ authorData.url }}">{{ authorData.data.title }}</a></address>
-  <time datetime="{{ page.date | date: '%Y-%m-%d' }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+  {%- include "post-meta-author.html" -%}
+  {%- include "post-meta-date.html" -%}
 </header>
 {%- else -%}
 <header class="post-meta" role="doc-subtitle">
-  <time datetime="{{ page.date | date: '%Y-%m-%d' }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+  {%- include "post-meta-date.html" -%}
 </header>
 {%- endif -%}
 


### PR DESCRIPTION
Extract repeated post meta elements (author address and date/time)
into reusable includes to eliminate code duplication flagged by jscpd.