### PR TITLE
Fix jscpd duplication in filtered-products and filtered-properties layouts

### DIFF
--- a/src/_includes/filtered-items-section.html
+++ b/src/_includes/filtered-items-section.html
@@ -1,0 +1,7 @@
+<div class="filtered-items">
+  {{ "icons/spinner.svg" | inline_asset }}
+  <div class="filtered-content">
+    {{- content -}}
+    {%- include "items.html", items: items -%}
+  </div>
+</div>

--- a/src/_layouts/filtered-products.html
+++ b/src/_layouts/filtered-products.html
@@ -6,10 +6,4 @@ no_index: true
 {%- assign currentFilters = filterPage.filters -%}
 {%- include "products-filter.html" -%}
 
-<div class="filtered-items">
-  {{ "icons/spinner.svg" | inline_asset }}
-  <div class="filtered-content">
-    {{- content -}}
-    {%- include "items.html", items: filterPage.products -%}
-  </div>
-</div>
+{%- include "filtered-items-section.html", items: filterPage.products -%}

--- a/src/_layouts/filtered-properties.html
+++ b/src/_layouts/filtered-properties.html
@@ -6,10 +6,4 @@ no_index: true
 {%- assign currentFilters = filterPage.filters -%}
 {%- include "properties-filter.html" -%}
 
-<div class="filtered-items">
-  {{ "icons/spinner.svg" | inline_asset }}
-  <div class="filtered-content">
-    {{- content -}}
-    {%- include "items.html", items: filterPage.properties -%}
-  </div>
-</div>
+{%- include "filtered-items-section.html", items: filterPage.properties -%}


### PR DESCRIPTION
Create shared filtered-items-section.html include to eliminate duplicate
code between the two filtered layouts.