### PR TITLE
Fix jscpd duplication between contact-form and quote-checkout

### DIFF
--- a/src/_includes/contact-form.html
+++ b/src/_includes/contact-form.html
@@ -1,24 +1,11 @@
 <noscript><p>JavaScript is required to submit this form.</p></noscript>
 {%- if config.form_target and config.form_target != "" -%}
-  <form
-    class="contact-form"
-    action="{{ config.form_target }}"
-    {% if config.botpoison_public_key and config.botpoison_public_key != "" -%}
-      data-botpoison-public-key="{{ config.botpoison_public_key }}"
-    {%- endif -%}
-  >
-    <input type="hidden" name="_redirect" value="{{ "/thank-you/" | canonicalUrl }}" />
-    <input type="hidden" name="_email.template.footer" value="false" />
-    <input
-      type="hidden"
-      name="_email.from"
-      value="{{ site.name }} contact form"
-    />
-    <input
-      type="hidden"
-      name="_email.subject"
-      value="New message from {{ site.name }} website contact form"
-    />
+  {%- include "form-open.html" -%}
+    {%- include "form-email-config.html",
+        redirect_path: "/thank-you/",
+        email_from_suffix: "contact form",
+        email_subject: "New message from {site_name} website contact form"
+    -%}
     {%- include "form-fields.html" -%}
     <button type="submit">{{ contactForm.submitButtonText }}</button>
   </form>

--- a/src/_includes/form-email-config.html
+++ b/src/_includes/form-email-config.html
@@ -1,0 +1,12 @@
+<input type="hidden" name="_redirect" value="{{ redirect_path | canonicalUrl }}" />
+<input type="hidden" name="_email.template.footer" value="false" />
+<input
+  type="hidden"
+  name="_email.from"
+  value="{{ site.name }} {{ email_from_suffix }}"
+/>
+<input
+  type="hidden"
+  name="_email.subject"
+  value="{{ email_subject | replace: '{site_name}', site.name }}"
+/>

--- a/src/_includes/form-open.html
+++ b/src/_includes/form-open.html
@@ -1,0 +1,7 @@
+<form
+  class="contact-form"
+  action="{{ config.form_target }}"
+  {% if config.botpoison_public_key and config.botpoison_public_key != "" -%}
+    data-botpoison-public-key="{{ config.botpoison_public_key }}"
+  {%- endif -%}
+>

--- a/src/_layouts/quote-checkout.html
+++ b/src/_layouts/quote-checkout.html
@@ -5,25 +5,12 @@ layout: base
 {{ content }}
 
 {%- if config.form_target and config.form_target != "" -%}
-  <form
-    class="contact-form"
-    action="{{ config.form_target }}"
-    {% if config.botpoison_public_key and config.botpoison_public_key != "" -%}
-      data-botpoison-public-key="{{ config.botpoison_public_key }}"
-    {%- endif -%}
-  >
-    <input type="hidden" name="_redirect" value="{{ "/quote-complete/" | canonicalUrl }}" />
-    <input type="hidden" name="_email.template.footer" value="false" />
-    <input
-      type="hidden"
-      name="_email.from"
-      value="{{ site.name }} quote request"
-    />
-    <input
-      type="hidden"
-      name="_email.subject"
-      value="New quote request from {{ site.name }}"
-    />
+  {%- include "form-open.html" -%}
+    {%- include "form-email-config.html",
+        redirect_path: "/quote-complete/",
+        email_from_suffix: "quote request",
+        email_subject: "New quote request from {site_name}"
+    -%}
     <input type="hidden" id="cart-items" name="cart_items" value="" />
 
     {%- assign skipShowOn = true -%}


### PR DESCRIPTION
Create shared includes for duplicated form markup:
- form-open.html: form opening tag with botpoison attribute
- form-email-config.html: hidden inputs for redirect, email config

Both contact-form.html and quote-checkout.html now use these shared
includes with parameterized values for their specific configurations.