### PR TITLE
Remove redundant try/catch exceptions for files with no try/catch

### DIFF
--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -25,20 +25,10 @@ const ALLOWED_TRY_CATCHES = new Set([
   // src/assets/js/cart.js - PayPal checkout fetch handling
   "src/assets/js/cart.js:209",
 
-  // src/_lib/media/image.js - image processing
-  "src/_lib/media/image.js:74",
-  "src/_lib/media/image.js:337",
-
   // src/assets/js/cart-utils.js - JSON parsing of localStorage data
   // Needed: localStorage is browser-side storage that can be corrupted by users,
   // extensions, or data migration issues. We don't control this input.
   "src/assets/js/cart-utils.js:11",
-
-  // test/cpd.test.js - running external tool and capturing exit code
-  "test/cpd.test.js:16",
-
-  // test/knip.test.js - running external tool and capturing exit code
-  "test/knip.test.js:16",
 ]);
 
 // ============================================


### PR DESCRIPTION
These exclusions referenced files that no longer contain any try/catch
blocks:
- src/_lib/media/image.js:74 and :337
- test/cpd.test.js:16
- test/knip.test.js:16