### PR TITLE
Remove cart.js from try/catch exceptions by using http.js

### DIFF
--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -22,9 +22,6 @@ const ALLOWED_TRY_CATCHES = new Set([
   // src/assets/js/http.js - centralized HTTP error handling (entire file)
   "src/assets/js/http.js",
 
-  // src/assets/js/cart.js - PayPal checkout fetch handling
-  "src/assets/js/cart.js:209",
-
   // src/assets/js/cart-utils.js - JSON parsing of localStorage data
   // Needed: localStorage is browser-side storage that can be corrupted by users,
   // extensions, or data migration issues. We don't control this input.


### PR DESCRIPTION
Refactored paypalCheckout to use postJson from http.js instead of raw
fetch with try/catch. The http.js module provides centralized error
handling that returns null on failure, allowing cart.js to use simple
null-checking instead of try/catch blocks.

Changes:
- Import postJson from http.js in cart.js
- Replace postSkus helper and try/catch block with postJson call
- Remove cart.js:209 from ALLOWED_TRY_CATCHES in exceptions