### PR TITLE
Refactor area-list to use Liquid template instead of JS HTML generation

### DIFF
--- a/src/_includes/area-list-shortcode.html
+++ b/src/_includes/area-list-shortcode.html
@@ -1,1 +1,1 @@
-{% areaList collections.location, prefix, suffix %}
+{%- include "area-list.html", locations: collections.location, prefix: prefix, suffix: suffix -%}

--- a/src/_includes/area-list.html
+++ b/src/_includes/area-list.html
@@ -1,0 +1,4 @@
+{%- assign areas = locations | prepareAreaList: page.url -%}
+{%- if areas.size > 0 -%}
+{{ prefix }}{%- for area in areas -%}<a href="{{ area.url }}#content">{{ area.name }}</a>{{ area.separator }}{%- endfor -%}{{ suffix }}
+{%- endif -%}

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -39,7 +39,6 @@ const ALLOWED_TRY_CATCHES = new Set([
 // These should be refactored over time to use external templates.
 const ALLOWED_HTML_IN_JS = new Set([
   // Server-side Eleventy plugins generating HTML
-  "src/_lib/eleventy/area-list.js",
   "src/_lib/eleventy/opening-times.js",
   "src/_lib/eleventy/recurring-events.js",
   "src/_lib/eleventy/js-config.js",


### PR DESCRIPTION
Move HTML generation from area-list.js to a pure Liquid template. This
removes the need for the ALLOWED_HTML_IN_JS exception for this file.

- Create area-list.html include with Liquid templating for link rendering
- Convert shortcode to two filters: filterTopLevelLocations, sortByNavigationKey
- Update area-list-shortcode.html to use the new include
- Remove locationToLink and formatAreaList functions (now handled by template)
- Update tests to verify filter registration instead of shortcode