### PR TITLE
Refactor server.test.js to use node:test module

### DIFF
--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -16,9 +16,6 @@ const ALLOWED_TRY_CATCHES = new Set([
   "ecommerce-backend/server.js:213",
   "ecommerce-backend/server.js:289",
 
-  // ecommerce-backend/server.test.js - test runner catching failures
-  "ecommerce-backend/server.test.js:366",
-
   // src/assets/js/http.js - centralized HTTP error handling (entire file)
   "src/assets/js/http.js",
 


### PR DESCRIPTION
Replace custom try/catch-based test runner with Node's built-in
node:test module (describe/it/before/after), which provides proper
error output when tests fail. This removes the need for the
error-swallowing try/catch that was exempted in ALLOWED_TRY_CATCHES.