### PR TITLE
Remove unused imports and parameters in code quality tests

### DIFF
--- a/test/code-quality/commented-code.test.js
+++ b/test/code-quality/commented-code.test.js
@@ -96,7 +96,7 @@ const findCommentedCode = (source, _relativePath) => {
   const rawLines = lines.map((l) => l.line);
 
   return lines
-    .filter(({ line, num }, i) => {
+    .filter(({ line }, i) => {
       if (isInsideTemplateLiteral(rawLines, i)) return false;
       const prevLine = i > 0 ? rawLines[i - 1] : "";
       const nextLine = i < rawLines.length - 1 ? rawLines[i + 1] : "";

--- a/test/code-quality/test-quality.test.js
+++ b/test/code-quality/test-quality.test.js
@@ -2,7 +2,6 @@ import {
   analyzeFiles,
   assertNoViolations,
   findPatterns,
-  scanLines,
 } from "#test/code-scanner.js";
 import {
   createTestRunner,

--- a/test/code-quality/try-catch-usage.test.js
+++ b/test/code-quality/try-catch-usage.test.js
@@ -3,7 +3,6 @@ import {
   analyzeFiles,
   assertNoViolations,
   combineFileLists,
-  toLines,
 } from "#test/code-scanner.js";
 import {
   createTestRunner,


### PR DESCRIPTION
- Remove unused 'num' destructuring in commented-code.test.js filter
- Remove unused 'scanLines' import in test-quality.test.js
- Remove unused 'toLines' import in try-catch-usage.test.js

Fixes biome linter warnings about unused code.