### PR TITLE
Improve categoryOrder.js test coverage to 100%

### DIFF
--- a/src/_data/categoryOrder.js
+++ b/src/_data/categoryOrder.js
@@ -2,8 +2,15 @@ import configJson from "#data/config.json" with { type: "json" };
 
 const DEFAULT_ORDER = ["content", "faqs", "subcategories", "products"];
 
-const configOrder = configJson.category_order;
+/**
+ * Computes the category order from a config value.
+ * Returns the config value if it's a non-empty array, otherwise DEFAULT_ORDER.
+ */
+const getCategoryOrder = (configOrder) =>
+  Array.isArray(configOrder) && configOrder.length > 0
+    ? configOrder
+    : DEFAULT_ORDER;
 
-export default Array.isArray(configOrder) && configOrder.length > 0
-  ? configOrder
-  : DEFAULT_ORDER;
+export { DEFAULT_ORDER, getCategoryOrder };
+
+export default getCategoryOrder(configJson.category_order);

--- a/test/category-order.test.js
+++ b/test/category-order.test.js
@@ -1,25 +1,30 @@
-import categoryOrder from "#data/categoryOrder.js";
-import { createTestRunner } from "#test/test-utils.js";
-
-const DEFAULT_ORDER = ["content", "faqs", "subcategories", "products"];
+import categoryOrder, {
+  DEFAULT_ORDER,
+  getCategoryOrder,
+} from "#data/categoryOrder.js";
+import {
+  createTestRunner,
+  expectDeepEqual,
+  expectTrue,
+} from "#test/test-utils.js";
 
 const testCases = [
+  // Default export tests (uses actual config)
   {
     name: "categoryOrder-is-array",
     description: "categoryOrder exports an array",
     test: () => {
-      if (!Array.isArray(categoryOrder)) {
-        throw new Error("categoryOrder should be an array");
-      }
+      expectTrue(Array.isArray(categoryOrder), "categoryOrder should be array");
     },
   },
   {
     name: "categoryOrder-not-empty",
     description: "categoryOrder is not empty",
     test: () => {
-      if (categoryOrder.length === 0) {
-        throw new Error("categoryOrder should not be empty");
-      }
+      expectTrue(
+        categoryOrder.length > 0,
+        "categoryOrder should have at least one element",
+      );
     },
   },
   {
@@ -27,10 +32,113 @@ const testCases = [
     description: "categoryOrder contains only valid section names",
     test: () => {
       for (const section of categoryOrder) {
-        if (!DEFAULT_ORDER.includes(section)) {
-          throw new Error(`Invalid section name: ${section}`);
-        }
+        expectTrue(
+          DEFAULT_ORDER.includes(section),
+          `Section "${section}" should be a valid section name`,
+        );
       }
+    },
+  },
+
+  // DEFAULT_ORDER constant tests
+  {
+    name: "default-order-has-expected-values",
+    description: "DEFAULT_ORDER contains the four expected section names",
+    test: () => {
+      expectDeepEqual(
+        DEFAULT_ORDER,
+        ["content", "faqs", "subcategories", "products"],
+        "DEFAULT_ORDER should have content, faqs, subcategories, products",
+      );
+    },
+  },
+
+  // getCategoryOrder function tests - covers all branches
+  {
+    name: "getCategoryOrder-returns-valid-array",
+    description: "getCategoryOrder returns the input when it is a valid array",
+    test: () => {
+      const customOrder = ["products", "content"];
+      const result = getCategoryOrder(customOrder);
+      expectDeepEqual(
+        result,
+        customOrder,
+        "Should return the custom order array",
+      );
+    },
+  },
+  {
+    name: "getCategoryOrder-returns-default-for-empty-array",
+    description: "getCategoryOrder returns DEFAULT_ORDER when input is empty",
+    test: () => {
+      const result = getCategoryOrder([]);
+      expectDeepEqual(
+        result,
+        DEFAULT_ORDER,
+        "Should return DEFAULT_ORDER for empty array",
+      );
+    },
+  },
+  {
+    name: "getCategoryOrder-returns-default-for-null",
+    description: "getCategoryOrder returns DEFAULT_ORDER when input is null",
+    test: () => {
+      const result = getCategoryOrder(null);
+      expectDeepEqual(
+        result,
+        DEFAULT_ORDER,
+        "Should return DEFAULT_ORDER for null",
+      );
+    },
+  },
+  {
+    name: "getCategoryOrder-returns-default-for-undefined",
+    description:
+      "getCategoryOrder returns DEFAULT_ORDER when input is undefined",
+    test: () => {
+      const result = getCategoryOrder(undefined);
+      expectDeepEqual(
+        result,
+        DEFAULT_ORDER,
+        "Should return DEFAULT_ORDER for undefined",
+      );
+    },
+  },
+  {
+    name: "getCategoryOrder-returns-default-for-string",
+    description: "getCategoryOrder returns DEFAULT_ORDER when input is string",
+    test: () => {
+      const result = getCategoryOrder("not-an-array");
+      expectDeepEqual(
+        result,
+        DEFAULT_ORDER,
+        "Should return DEFAULT_ORDER for string",
+      );
+    },
+  },
+  {
+    name: "getCategoryOrder-returns-default-for-object",
+    description: "getCategoryOrder returns DEFAULT_ORDER when input is object",
+    test: () => {
+      const result = getCategoryOrder({ order: ["products"] });
+      expectDeepEqual(
+        result,
+        DEFAULT_ORDER,
+        "Should return DEFAULT_ORDER for object",
+      );
+    },
+  },
+  {
+    name: "getCategoryOrder-returns-single-element-array",
+    description: "getCategoryOrder returns single-element arrays",
+    test: () => {
+      const singleElement = ["products"];
+      const result = getCategoryOrder(singleElement);
+      expectDeepEqual(
+        result,
+        singleElement,
+        "Should return single-element array",
+      );
     },
   },
 ];


### PR DESCRIPTION
Refactor module to export a testable getCategoryOrder function
that can be tested with various inputs. Add tests covering all
branches: valid arrays, empty arrays, null, undefined, and
non-array values.