### PR TITLE
Fix failing tests: use path alias instead of relative import

### DIFF
--- a/.jscpd_baseline.json
+++ b/.jscpd_baseline.json
@@ -1,3 +1,3 @@
 {
-	"percentageTokens": 1.02
+	"percentageTokens": 0.71
 }

--- a/test/utils/schema-helper.test.js
+++ b/test/utils/schema-helper.test.js
@@ -1,17 +1,17 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import {
+  createMockReview,
+  createPostSchemaData,
+  createProductSchemaData,
+  createSchemaData,
+} from "#test/test-utils.js";
+import {
   buildBaseMeta,
   buildOrganizationMeta,
   buildPostMeta,
   buildProductMeta,
 } from "#utils/schema-helper.js";
-import {
-  createMockReview,
-  createPostSchemaData,
-  createProductSchemaData,
-  createSchemaData,
-} from "../test-utils.js";
 
 describe("buildBaseMeta", () => {
   it("returns basic meta with url, title, and description", () => {


### PR DESCRIPTION
- Replace relative import '../test-utils.js' with '#test/test-utils.js'
  in schema-helper.test.js to comply with project import conventions
- Update jscpd baseline to reflect current duplication level (0.71%)