### PR TITLE
Replace fast-glob with Bun's native Glob API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,6 @@
         "@quasibit/eleventy-plugin-schema": "^1.11.1",
         "@sindresorhus/slugify": "^3.0.0",
         "@zachleat/heading-anchors": "^1.0.1",
-        "fast-glob": "^3.3.2",
         "gray-matter": "^4.0.3",
         "ical-generator": "^9.0.0",
         "json-to-pdf": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"@quasibit/eleventy-plugin-schema": "^1.11.1",
 		"@sindresorhus/slugify": "^3.0.0",
 		"@zachleat/heading-anchors": "^1.0.1",
-		"fast-glob": "^3.3.2",
 		"gray-matter": "^4.0.3",
 		"ical-generator": "^9.0.0",
 		"json-to-pdf": "^0.1.2",

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -256,10 +256,10 @@ async function processAndWrapImage({
   return returnElement ? await parseHtml(html, document) : html;
 }
 
-import fastglob from "fast-glob";
-
-const findImageFiles = (pattern = ["src/images/*.jpg"]) => {
-  return fastglob.sync(pattern);
+const findImageFiles = (patterns = ["src/images/*.jpg"]) => {
+  return patterns.flatMap((pattern) => [
+    ...new Bun.Glob(pattern).scanSync("."),
+  ]);
 };
 
 const createImagesCollection = (imageFiles) => {

--- a/src/_lib/media/unused-images.js
+++ b/src/_lib/media/unused-images.js
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import fastglob from "fast-glob";
 import matter from "gray-matter";
 
 const IMAGE_PATTERN = /\.(jpg|jpeg|png|gif|webp|svg)$/i;
@@ -48,7 +47,7 @@ export function configureUnusedImages(eleventyConfig) {
       return;
     }
 
-    const markdownFiles = fastglob.sync("**/*.md", { cwd: dir.input });
+    const markdownFiles = [...new Bun.Glob("**/*.md").scanSync(dir.input)];
 
     const usedImages = new Set(
       markdownFiles.flatMap((file) =>

--- a/test/build/scss.variables.test.js
+++ b/test/build/scss.variables.test.js
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import fg from "fast-glob";
 import { rootDir } from "#test/test-utils.js";
-
-const { globSync } = fg;
 
 // ============================================
 // Constants
@@ -91,7 +88,12 @@ const findUndefinedVariables = (used, defined) => {
 // Load data for tests
 // ============================================
 
-const scssFiles = globSync(`${rootDir}/${SCSS_DIR}/**/*.scss`);
+const scssFiles = [
+  ...new Bun.Glob("**/*.scss").scanSync({
+    cwd: `${rootDir}/${SCSS_DIR}`,
+    absolute: true,
+  }),
+];
 const usedVariables = extractUsedVariables(scssFiles);
 const definedVariables = extractDefinedVariables(`${rootDir}/${STYLE_FILE}`);
 const allDefinedVariables = extractAllDefinedVariables(scssFiles);

--- a/test/utils/strings.test.js
+++ b/test/utils/strings.test.js
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import fg from "fast-glob";
 import strings from "#data/strings.js";
 import baseStrings from "#data/strings-base.json" with { type: "json" };
 import { fs, srcDir } from "#test/test-utils.js";
@@ -12,10 +11,12 @@ const findStringsUsage = () => {
   const ignoreKeys = new Set(["js", "json", "test", "mjs"]);
 
   // Find all template/source files
-  const files = fg.sync("**/*.{html,md,js,mjs,liquid,njk}", {
-    cwd: srcDir,
-    absolute: true,
-  });
+  const files = [
+    ...new Bun.Glob("**/*.{html,md,js,mjs,liquid,njk}").scanSync({
+      cwd: srcDir,
+      absolute: true,
+    }),
+  ];
 
   const keys = new Set();
   const regex = /strings\.([a-z_]+)/g;


### PR DESCRIPTION
Removes the fast-glob dependency by migrating all usages to Bun.Glob:
- test/build/scss.variables.test.js: Use Bun.Glob().scanSync()
- test/utils/strings.test.js: Use Bun.Glob().scanSync()
- src/_lib/media/unused-images.js: Use Bun.Glob().scanSync()
- src/_lib/media/image.js: Use Bun.Glob with flatMap for array patterns