### PR TITLE
Refactor code to pure functional style

### DIFF
--- a/src/_lib/collections/products.js
+++ b/src/_lib/collections/products.js
@@ -1,5 +1,5 @@
 import { reviewsRedirects, withReviewsPage } from "#collections/reviews.js";
-import { findDuplicate } from "#utils/array-utils.js";
+import { findDuplicate, memberOf } from "#utils/array-utils.js";
 import { sortItems } from "#utils/sorting.js";
 
 const processGallery = (gallery) => {
@@ -47,12 +47,10 @@ const getProductsByCategory = (products, categorySlug) => {
 const getProductsByCategories = (products, categorySlugs) => {
   if (!products || !categorySlugs?.length) return [];
 
-  const categorySet = new Set(categorySlugs);
+  const isSelectedCategory = memberOf(categorySlugs);
 
   return products
-    .filter((product) =>
-      product.data.categories?.some((cat) => categorySet.has(cat)),
-    )
+    .filter((product) => product.data.categories?.some(isSelectedCategory))
     .sort(sortItems);
 };
 

--- a/src/_lib/media/unused-images.js
+++ b/src/_lib/media/unused-images.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
+import { notMemberOf } from "#utils/array-utils.js";
 
 const IMAGE_PATTERN = /\.(jpg|jpeg|png|gif|webp|svg)$/i;
 const IMAGE_REF_PATTERN =
@@ -49,13 +50,11 @@ export function configureUnusedImages(eleventyConfig) {
 
     const markdownFiles = [...new Bun.Glob("**/*.md").scanSync(dir.input)];
 
-    const usedImages = new Set(
-      markdownFiles.flatMap((file) =>
-        extractImagesFromFile(path.join(dir.input, file), imageFiles),
-      ),
+    const usedImagesList = markdownFiles.flatMap((file) =>
+      extractImagesFromFile(path.join(dir.input, file), imageFiles),
     );
 
-    const unusedImages = imageFiles.filter((file) => !usedImages.has(file));
+    const unusedImages = imageFiles.filter(notMemberOf(usedImagesList));
 
     if (unusedImages.length > 0) {
       console.log("\n📸 Unused Images Report:");

--- a/src/_lib/utils/array-utils.js
+++ b/src/_lib/utils/array-utils.js
@@ -133,6 +133,55 @@ const findDuplicate = (items, getKey = (x) => x) => {
   return items.find((_, i) => keys.indexOf(keys[i]) !== i);
 };
 
+/**
+ * Create a membership predicate for efficient lookup
+ *
+ * Returns a predicate function that tests if a value is in the collection.
+ * Uses a Set internally for O(1) lookup performance.
+ *
+ * @param {Iterable} values - Values to check membership against
+ * @returns {Function} (value) => boolean
+ *
+ * @example
+ * const isWeekend = memberOf(['saturday', 'sunday']);
+ * isWeekend('saturday')  // true
+ * isWeekend('monday')    // false
+ *
+ * // Use with filter
+ * const validCodes = memberOf(['A1', 'B2', 'C3']);
+ * codes.filter(validCodes)  // only codes in the valid set
+ *
+ * // Use with some/every
+ * items.some(memberOf(allowedItems))
+ * items.every(memberOf(validValues))
+ */
+const memberOf = (values) => {
+  const set = new Set(values);
+  return (value) => set.has(value);
+};
+
+/**
+ * Create a negated membership predicate
+ *
+ * Returns a predicate function that tests if a value is NOT in the collection.
+ * Uses a Set internally for O(1) lookup performance.
+ *
+ * @param {Iterable} values - Values to exclude
+ * @returns {Function} (value) => boolean
+ *
+ * @example
+ * const isNotReserved = notMemberOf(['admin', 'root', 'system']);
+ * isNotReserved('user')   // true
+ * isNotReserved('admin')  // false
+ *
+ * // Use with filter to exclude items
+ * usernames.filter(notMemberOf(reservedNames))
+ */
+const notMemberOf = (values) => {
+  const set = new Set(values);
+  return (value) => !set.has(value);
+};
+
 export {
   chunk,
   compact,
@@ -142,6 +191,8 @@ export {
   join,
   listSeparator,
   map,
+  memberOf,
+  notMemberOf,
   pick,
   pipe,
   sort,

--- a/src/assets/js/availability-calendar.js
+++ b/src/assets/js/availability-calendar.js
@@ -6,6 +6,7 @@ import { fetchJson } from "#assets/http.js";
 import { onReady } from "#assets/on-ready.js";
 import { IDS } from "#assets/selectors.js";
 import { getTemplate } from "#assets/template.js";
+import { memberOf } from "#utils/array-utils.js";
 
 const MONTHS = [
   "January",
@@ -75,16 +76,15 @@ const createEmptyCells = (count) =>
     createElement("span", "calendar-day empty"),
   );
 
-const createDayCells = (year, month, daysInMonth, unavailableSet, todayStr) =>
+const createDayCells = (year, month, daysInMonth, isUnavailable, todayStr) =>
   Array.from({ length: daysInMonth }, (_, i) => {
     const day = i + 1;
     const dateStr = formatDate(new Date(year, month, day));
-    const isUnavailable = unavailableSet.has(dateStr);
-    const className = getDayClasses(dateStr, todayStr, isUnavailable);
+    const className = getDayClasses(dateStr, todayStr, isUnavailable(dateStr));
     return createElement("span", className, String(day));
   });
 
-const renderMonth = (monthDate, unavailableSet, todayStr) => {
+const renderMonth = (monthDate, isUnavailable, todayStr) => {
   const year = monthDate.getFullYear();
   const month = monthDate.getMonth();
   const firstDay = new Date(year, month, 1);
@@ -100,7 +100,7 @@ const renderMonth = (monthDate, unavailableSet, todayStr) => {
   const allCells = [
     ...createDayHeaders(),
     ...createEmptyCells(startDay),
-    ...createDayCells(year, month, daysInMonth, unavailableSet, todayStr),
+    ...createDayCells(year, month, daysInMonth, isUnavailable, todayStr),
   ];
   grid.replaceChildren(...allCells);
 
@@ -116,14 +116,14 @@ const renderCalendar = (unavailableDates) => {
   const content = getContent();
   if (!content) return;
 
-  const unavailableSet = new Set(unavailableDates);
+  const isUnavailable = memberOf(unavailableDates);
   const today = getToday();
   const todayStr = formatDate(today);
 
   const months = Array.from({ length: 12 }, (_, i) =>
     renderMonth(
       new Date(today.getFullYear(), today.getMonth() + i, 1),
-      unavailableSet,
+      isUnavailable,
       todayStr,
     ),
   );

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -115,10 +115,9 @@ const ALLOWED_MUTABLE_CONST = new Set([
   "src/assets/js/theme-editor.js:462", // vars object built with property assignment
   "src/_lib/filters/item-filters.js:364", // redirects object built with property assignment
 
-  // Sets - being populated via add/mutation
-  "src/_lib/media/unused-images.js:52", // usedImages Set from array
-  "src/_lib/collections/products.js:50", // categorySet from array
-  "src/assets/js/availability-calendar.js:119", // unavailableSet from array
+  // Sets - internal implementation of functional utilities (created once, never mutated)
+  "src/_lib/utils/array-utils.js:159", // memberOf: Set for O(1) lookup predicate
+  "src/_lib/utils/array-utils.js:181", // notMemberOf: Set for O(1) lookup predicate
 
   // Maps - used as caches/indexes being populated via set
   "src/_lib/utils/memoize.js:5", // memoization cache

--- a/test/code-scanner.js
+++ b/test/code-scanner.js
@@ -4,6 +4,7 @@
  */
 import { expect } from "bun:test";
 import { fs, path, rootDir } from "#test/test-utils.js";
+import { notMemberOf } from "#utils/array-utils.js";
 
 // ============================================
 // Common patterns for skipping non-code lines
@@ -42,10 +43,8 @@ const toLines = (source) =>
 /**
  * Filter file list excluding certain paths.
  */
-const excludeFiles = (files, exclude = []) => {
-  const excludeSet = new Set(exclude);
-  return files.filter((f) => !excludeSet.has(f));
-};
+const excludeFiles = (files, exclude = []) =>
+  files.filter(notMemberOf(exclude));
 
 /**
  * Combine multiple file lists, optionally excluding some.

--- a/test/utils/array-utils.test.js
+++ b/test/utils/array-utils.test.js
@@ -4,6 +4,8 @@ import {
   compact,
   findDuplicate,
   listSeparator,
+  memberOf,
+  notMemberOf,
   pick,
 } from "#utils/array-utils.js";
 
@@ -127,5 +129,96 @@ describe("array-utils", () => {
     const duplicate = findDuplicate(options, (opt) => opt.days);
     expect(duplicate.days).toBe(1);
     expect(duplicate.price).toBe(15); // It's the second occurrence
+  });
+
+  // ============================================
+  // memberOf Tests
+  // ============================================
+  test("memberOf returns true for values in collection", () => {
+    const isWeekend = memberOf(["saturday", "sunday"]);
+    expect(isWeekend("saturday")).toBe(true);
+    expect(isWeekend("sunday")).toBe(true);
+  });
+
+  test("memberOf returns false for values not in collection", () => {
+    const isWeekend = memberOf(["saturday", "sunday"]);
+    expect(isWeekend("monday")).toBe(false);
+    expect(isWeekend("friday")).toBe(false);
+  });
+
+  test("memberOf works with filter", () => {
+    const validCodes = memberOf(["A1", "B2", "C3"]);
+    const codes = ["A1", "X9", "B2", "Z0", "C3"];
+    expect(codes.filter(validCodes)).toEqual(["A1", "B2", "C3"]);
+  });
+
+  test("memberOf works with some", () => {
+    const hasFruit = memberOf(["apple", "banana", "orange"]);
+    expect(["carrot", "banana", "potato"].some(hasFruit)).toBe(true);
+    expect(["carrot", "broccoli", "potato"].some(hasFruit)).toBe(false);
+  });
+
+  test("memberOf works with every", () => {
+    const isDigit = memberOf([
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+    ]);
+    expect(["1", "2", "3"].every(isDigit)).toBe(true);
+    expect(["1", "a", "3"].every(isDigit)).toBe(false);
+  });
+
+  test("memberOf works with numbers", () => {
+    const isPrime = memberOf([2, 3, 5, 7, 11, 13]);
+    expect(isPrime(7)).toBe(true);
+    expect(isPrime(4)).toBe(false);
+  });
+
+  test("memberOf handles empty collection", () => {
+    const isEmpty = memberOf([]);
+    expect(isEmpty("anything")).toBe(false);
+  });
+
+  // ============================================
+  // notMemberOf Tests
+  // ============================================
+  test("notMemberOf returns true for values not in collection", () => {
+    const isNotReserved = notMemberOf(["admin", "root", "system"]);
+    expect(isNotReserved("user")).toBe(true);
+    expect(isNotReserved("guest")).toBe(true);
+  });
+
+  test("notMemberOf returns false for values in collection", () => {
+    const isNotReserved = notMemberOf(["admin", "root", "system"]);
+    expect(isNotReserved("admin")).toBe(false);
+    expect(isNotReserved("root")).toBe(false);
+  });
+
+  test("notMemberOf works with filter to exclude items", () => {
+    const isNotExcluded = notMemberOf(["spam", "trash"]);
+    const folders = ["inbox", "spam", "drafts", "trash", "sent"];
+    expect(folders.filter(isNotExcluded)).toEqual(["inbox", "drafts", "sent"]);
+  });
+
+  test("notMemberOf handles empty collection", () => {
+    const isNotEmpty = notMemberOf([]);
+    expect(isNotEmpty("anything")).toBe(true);
+  });
+
+  test("notMemberOf is the logical inverse of memberOf", () => {
+    const values = ["a", "b", "c"];
+    const isMember = memberOf(values);
+    const isNotMember = notMemberOf(values);
+
+    ["a", "b", "c", "d", "e"].forEach((v) => {
+      expect(isNotMember(v)).toBe(!isMember(v));
+    });
   });
 });


### PR DESCRIPTION
Introduce memberOf and notMemberOf functions that create efficient O(1) lookup predicates from arrays. These encapsulate the common pattern of creating a Set for membership testing.

Refactored:
- products.js: getProductsByCategories now uses memberOf
- availability-calendar.js: isUnavailable now uses memberOf predicate
- unused-images.js: uses notMemberOf to filter unused images
- code-scanner.js: excludeFiles now uses notMemberOf

Removed 3 entries from ALLOWED_MUTABLE_CONST (replaced by memberOf usage) Added 2 entries for the internal Set creation in the new utilities