### PR TITLE
Unify duplicate analyze functions into analyzeWithAllowlist

### DIFF
--- a/test/code-quality/method-aliasing.test.js
+++ b/test/code-quality/method-aliasing.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
-  analyzeFiles,
+  analyzeWithAllowlist,
   assertNoViolations,
   isCommentLine,
   scanLines,
@@ -81,21 +81,6 @@ const findAliases = (source) => {
   });
 };
 
-/**
- * Analyze all JS files for method aliasing.
- */
-const analyzeMethodAliasing = () =>
-  analyzeFiles(SRC_JS_FILES(), (source, relativePath) =>
-    findAliases(source).map((hit) => ({
-      file: relativePath,
-      line: hit.lineNumber,
-      code: hit.line,
-      newName: hit.newName,
-      originalName: hit.originalName,
-      location: `${relativePath}:${hit.lineNumber}`,
-    })),
-  );
-
 describe("method-aliasing", () => {
   test("Detects simple method aliasing", () => {
     const source = `const originalFn = (x) => x * 2;
@@ -165,7 +150,10 @@ const empty = null;
   });
 
   test("No method aliasing in source files", () => {
-    const violations = analyzeMethodAliasing();
+    const { violations } = analyzeWithAllowlist({
+      findFn: findAliases,
+      files: SRC_JS_FILES,
+    });
     assertNoViolations(violations, {
       message: "method alias(es)",
       fixHint:

--- a/test/code-quality/test-hygiene.test.js
+++ b/test/code-quality/test-hygiene.test.js
@@ -143,12 +143,10 @@ const ALLOWED_TEST_FUNCTIONS = new Set([
   // method-aliasing.test.js - analysis helpers
   "parseAlias",
   "findAliases",
-  "analyzeMethodAliasing",
   // short-circuit-order.test.js - analysis helpers
   "buildPattern",
   "hasSuboptimalOrder",
   "findSuboptimalOrder",
-  "analyzeShortCircuitOrder",
 ]);
 
 // Pattern to identify true function declarations (not methods or callbacks)

--- a/test/code-scanner.js
+++ b/test/code-scanner.js
@@ -237,12 +237,12 @@ const createCodeChecker = (config) => {
  *
  * @param {object} config
  * @param {function} config.findFn - Function (source) => Array of hits with lineNumber, line, and optional extra fields
- * @param {Set<string>} config.allowlist - Set of "file:line" or "file" entries to allow
+ * @param {Set<string>} [config.allowlist] - Set of "file:line" or "file" entries to allow (defaults to empty Set)
  * @param {string[]|function} [config.files] - File list or function returning file list (defaults to empty array)
  * @returns {{ violations: Array, allowed: Array }}
  */
 const analyzeWithAllowlist = (config) => {
-  const { findFn, allowlist, files = [] } = config;
+  const { findFn, allowlist = new Set(), files = [] } = config;
   const fileList = typeof files === "function" ? files() : files;
 
   const results = analyzeFiles(fileList, (source, relativePath) =>


### PR DESCRIPTION
Remove analyzeMethodAliasing and analyzeShortCircuitOrder functions which
were nearly identical - both called analyzeFiles with the same mapping
pattern. Now use analyzeWithAllowlist directly in the tests instead.

Also make allowlist parameter default to empty Set in analyzeWithAllowlist
to simplify call sites that don't need exceptions.