### PR TITLE
Remove 8 overly defensive null checks from ALLOWED_NULL_CHECKS

### DIFF
--- a/src/_lib/collections/menus.js
+++ b/src/_lib/collections/menus.js
@@ -27,15 +27,11 @@ const buildCategoryItemMap = memoize((items) =>
   buildReverseIndex(items, getItemCategories),
 );
 
-const getCategoriesByMenu = (categories, menuSlug) => {
-  if (!categories) return [];
-  return buildMenuCategoryMap(categories).get(menuSlug) || [];
-};
+const getCategoriesByMenu = (categories, menuSlug) =>
+  buildMenuCategoryMap(categories).get(menuSlug) || [];
 
-const getItemsByCategory = (items, categorySlug) => {
-  if (!items) return [];
-  return buildCategoryItemMap(items).get(categorySlug) || [];
-};
+const getItemsByCategory = (items, categorySlug) =>
+  buildCategoryItemMap(items).get(categorySlug) || [];
 
 const configureMenus = (eleventyConfig) => {
   eleventyConfig.addFilter("getCategoriesByMenu", getCategoriesByMenu);

--- a/src/_lib/collections/products.js
+++ b/src/_lib/collections/products.js
@@ -34,12 +34,10 @@ const createProductsCollection = (collectionApi) => {
   return products.map(addGallery);
 };
 
-const getProductsByCategory = (products, categorySlug) => {
-  if (!products) return [];
-  return products
+const getProductsByCategory = (products, categorySlug) =>
+  products
     .filter((product) => product.data.categories?.includes(categorySlug))
     .sort(sortItems);
-};
 
 /**
  * Get unique products that belong to any of the given categories
@@ -54,12 +52,10 @@ const getProductsByCategories = (products, categorySlugs) => {
     .sort(sortItems);
 };
 
-const getProductsByEvent = (products, eventSlug) => {
-  if (!products) return [];
-  return products
+const getProductsByEvent = (products, eventSlug) =>
+  products
     .filter((product) => product.data.events?.includes(eventSlug))
     .sort(sortItems);
-};
 
 const getFeaturedProducts = (products) =>
   products?.filter((p) => p.data.featured) || [];

--- a/src/_lib/collections/search.js
+++ b/src/_lib/collections/search.js
@@ -31,10 +31,8 @@ const buildProductKeywordMap = memoize((products) =>
   buildReverseIndex(products, getProductKeywords),
 );
 
-const getAllKeywords = (products) => {
-  if (!products) return [];
-  return [...buildProductKeywordMap(products).keys()].sort();
-};
+const getAllKeywords = (products) =>
+  [...buildProductKeywordMap(products).keys()].sort();
 
 const getProductsByKeyword = (products, keyword) => {
   if (!products || !keyword) return [];

--- a/src/_lib/collections/tags.js
+++ b/src/_lib/collections/tags.js
@@ -9,10 +9,8 @@ import {
 
 const notNullish = (x) => x !== null && x !== undefined;
 
-const extractTags = (collection) => {
-  if (!collection) return [];
-
-  return pipe(
+const extractTags = (collection) =>
+  pipe(
     filter((page) => page.url && !page.data?.no_index),
     flatMap((page) => page.data?.tags || []),
     filter(notNullish),
@@ -21,7 +19,6 @@ const extractTags = (collection) => {
     unique,
     sort((a, b) => a.localeCompare(b)),
   )(collection);
-};
 
 const configureTags = (eleventyConfig) => {
   eleventyConfig.addFilter("tags", extractTags);

--- a/src/_lib/filters/item-filters.js
+++ b/src/_lib/filters/item-filters.js
@@ -135,7 +135,6 @@ const itemMatchesFilters = (item, filters) => {
  * Get items matching the given filters
  */
 const getItemsByFilters = (items, filters) => {
-  if (!items) return [];
   if (!filters || Object.keys(filters).length === 0) {
     return items.slice().sort(sortItems);
   }
@@ -184,8 +183,6 @@ const countMatchingItems = (items, itemAttrMap, filters) => {
  * recurse to later keys, so each path is generated exactly once.
  */
 const generateFilterCombinations = memoize((items) => {
-  if (!items) return [];
-
   const allAttributes = getAllFilterAttributes(items);
   const attributeKeys = Object.keys(allAttributes);
 

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -197,18 +197,10 @@ const ALLOWED_NULL_CHECKS = new Set([
   "src/_lib/filters/item-filters.js:33", // filterAttributes
   "src/_lib/filters/item-filters.js:62", // attrs
   "src/_lib/filters/item-filters.js:107", // path
-  "src/_lib/filters/item-filters.js:138", // items
-  "src/_lib/filters/item-filters.js:187", // items
   "src/_lib/collections/products.js:6", // gallery
-  "src/_lib/collections/products.js:38", // products
-  "src/_lib/collections/products.js:58", // products
-  "src/_lib/collections/products.js:83", // options
-  "src/_lib/collections/menus.js:31", // categories
-  "src/_lib/collections/menus.js:36", // items
+  "src/_lib/collections/products.js:79", // options
   "src/_lib/collections/search.js:9", // category
-  "src/_lib/collections/search.js:35", // products
   "src/_lib/collections/reviews.js:101", // name
-  "src/_lib/collections/tags.js:13", // collection
   "src/_lib/collections/navigation.js:12", // collection
   "src/_lib/collections/navigation.js:18", // result
   "src/_lib/utils/schema-helper.js:7", // imageInput

--- a/test/collections/menus.test.js
+++ b/test/collections/menus.test.js
@@ -49,20 +49,6 @@ describe("menus", () => {
     expect(result).toEqual([]);
   });
 
-  test("Handles null categories gracefully", () => {
-    const result = getCategoriesByMenu(null, "lunch");
-
-    expect(result).toHaveLength(0);
-    expect(result).toEqual([]);
-  });
-
-  test("Handles undefined categories gracefully", () => {
-    const result = getCategoriesByMenu(undefined, "lunch");
-
-    expect(result).toHaveLength(0);
-    expect(result).toEqual([]);
-  });
-
   test("Skips categories without menus property", () => {
     const categories = [
       {
@@ -166,20 +152,6 @@ describe("menus", () => {
 
   test("Handles empty items array", () => {
     const result = getItemsByCategory([], "appetizers");
-
-    expect(result).toHaveLength(0);
-    expect(result).toEqual([]);
-  });
-
-  test("Handles null items gracefully", () => {
-    const result = getItemsByCategory(null, "appetizers");
-
-    expect(result).toHaveLength(0);
-    expect(result).toEqual([]);
-  });
-
-  test("Handles undefined items gracefully", () => {
-    const result = getItemsByCategory(undefined, "appetizers");
 
     expect(result).toHaveLength(0);
     expect(result).toEqual([]);

--- a/test/collections/products.test.js
+++ b/test/collections/products.test.js
@@ -275,10 +275,6 @@ describe("products", () => {
     expectResultTitles(result, ["Product 1", "Product 3"]);
   });
 
-  test("Returns empty array for null products", () => {
-    expect(getProductsByEvent(null, "sale")).toEqual([]);
-  });
-
   test("Creates SKU mapping from products with options", () => {
     const mockProducts = [
       {

--- a/test/collections/search.test.js
+++ b/test/collections/search.test.js
@@ -12,9 +12,7 @@ import {
 } from "#test/test-utils.js";
 
 describe("search", () => {
-  test("Returns empty array for null/undefined/empty products", () => {
-    expect(getAllKeywords(null)).toEqual([]);
-    expect(getAllKeywords(undefined)).toEqual([]);
+  test("Returns empty array for empty products array", () => {
     expect(getAllKeywords([])).toEqual([]);
   });
 

--- a/test/filters/item-filters.test.js
+++ b/test/filters/item-filters.test.js
@@ -350,12 +350,6 @@ describe("item-filters", () => {
     expect(normalize("Size: Large!")).toBe("sizelarge");
   });
 
-  // getItemsByFilters with null/empty items
-  test("Returns empty array for null items", () => {
-    expect(getItemsByFilters(null, { type: "cottage" })).toEqual([]);
-    expect(getItemsByFilters(undefined, {})).toEqual([]);
-  });
-
   test("Returns all items sorted when no filters provided", () => {
     const items = [
       {
@@ -796,11 +790,6 @@ describe("item-filters", () => {
   });
 
   // generateFilterCombinations edge cases
-  test("Returns empty array for null/undefined items", () => {
-    expect(generateFilterCombinations(null)).toEqual([]);
-    expect(generateFilterCombinations(undefined)).toEqual([]);
-  });
-
   test("Returns empty array when items have no filter attributes", () => {
     const items = [{ data: { title: "No attrs" } }];
     expect(generateFilterCombinations(items)).toEqual([]);


### PR DESCRIPTION
Remove null checks on Eleventy filter parameters that always receive
valid arrays from collections. These checks were overly defensive since:
- Collections always return arrays (never null/undefined)
- getFilteredByTag() returns [] for empty results

Removed null checks from:
- getProductsByCategory, getProductsByEvent (products.js)
- getCategoriesByMenu, getItemsByCategory (menus.js)
- getAllKeywords (search.js)
- extractTags (tags.js)
- getItemsByFilters, generateFilterCombinations (item-filters.js)

Also removed corresponding tests that verified the null-handling behavior.