### PR TITLE
Refactor item-filters.test.js using functional builders

### DIFF
--- a/test/code-quality/test-hygiene.test.js
+++ b/test/code-quality/test-hygiene.test.js
@@ -28,6 +28,8 @@ const ALLOWED_TEST_FUNCTIONS = new Set([
   "createProduct",
   "createCollectionItem",
   "createPropertyReviewFixture",
+  // item-filters.test.js - mock eleventy config with getters
+  "mockConfig",
   // checkout.test.js - template rendering and mocks
   "renderTemplate",
   "createCheckoutPage",


### PR DESCRIPTION
Replace duplicated test data patterns with composable builder functions:
- attr(name, value): Creates filter attribute objects
- item(title, ...attrs): Creates items with filter_attributes
- items(tuples): Creates multiple items from [title, ...attrs] tuples
- pages(paths): Creates validPages from path strings
- filterData(def): Builds filterData from a definition object using pipe/reduce
- mockConfig(): Creates mock Eleventy config with collection/filter getters
- testFilterConfig(): Shared config factory for createFilterConfig tests
- typeSizeFilterData(): Shared filter data for buildFilterUIData tests

This reduces line count by 137 lines while improving readability and making
the test fixtures more declarative.