### PR TITLE
Refactor news tests using functional methods

### DIFF
--- a/test/code-quality/test-hygiene.test.js
+++ b/test/code-quality/test-hygiene.test.js
@@ -148,6 +148,15 @@ const ALLOWED_TEST_FUNCTIONS = new Set([
   "buildPattern",
   "hasSuboptimalOrder",
   "findSuboptimalOrder",
+  // news.test.js - functional test fixture builders
+  "newsPost",
+  "teamMember",
+  "getPostMeta",
+  "getContentHtml",
+  "extractImages",
+  "expectAuthorElements",
+  "expectTimeElement",
+  "expectMetaStructure",
 ]);
 
 // Pattern to identify true function declarations (not methods or callbacks)


### PR DESCRIPTION
- Add newsPost() and teamMember() builders for test fixtures
- Add getPostMeta() and getContentHtml() DOM helpers
- Add extractImages() using pipe/filter for automatic image extraction
- Add expectMetaStructure(), expectAuthorElements(), expectTimeElement() assertion helpers to reduce duplication
- Update test-hygiene allowlist with new helper functions

Reduces code duplication and aligns with functional patterns used in item-filters.test.js and recurring-events.test.js.