### PR TITLE
Refactor test-site-factory with functional paradigms

### DIFF
--- a/test/test-site-factory.js
+++ b/test/test-site-factory.js
@@ -21,6 +21,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
 import { Window } from "happy-dom";
+import { filter, flatMap, map, pipe, unique } from "#utils/array-utils.js";
 import { memoize } from "#utils/memoize.js";
 
 // JSDOM-compatible wrapper for happy-dom
@@ -37,7 +38,29 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, "..");
 
-// Memoized helpers for caching expensive operations on template source files
+// -----------------------------------------------------------------------------
+// Curried Path Utilities
+// -----------------------------------------------------------------------------
+
+/** Create a path joiner curried on the base directory */
+const inDir =
+  (base) =>
+  (...segments) =>
+    path.join(base, ...segments);
+
+/** Get the first path segment (collection name) */
+const getCollection = (filePath) => filePath.split("/")[0];
+
+/** Check if filename matches any of the given extensions */
+const hasExtension =
+  (...exts) =>
+  (filename) =>
+    exts.some((ext) => filename.endsWith(ext));
+
+// -----------------------------------------------------------------------------
+// Memoized Helpers - Cache expensive operations on template source files
+// -----------------------------------------------------------------------------
+
 const getCachedDirExists = memoize((dir) => fs.existsSync(dir));
 
 const getCachedJsonFile = memoize((filePath) =>
@@ -55,223 +78,285 @@ const getCachedDirList = memoize((dir) =>
       })),
 );
 
+// -----------------------------------------------------------------------------
+// Pure Utility Functions
+// -----------------------------------------------------------------------------
+
 const randomId = () => Math.random().toString(36).slice(2, 10);
 
+// -----------------------------------------------------------------------------
+// Curried File Operations - Enable composition and partial application
+// -----------------------------------------------------------------------------
+
+/** Ensure directory exists (side effect, but curried for composition) */
 const ensureDir = (dir) => {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
+  return dir;
 };
 
-const copyFile = (src, dest) => {
-  ensureDir(path.dirname(dest));
-  fs.copyFileSync(src, dest);
-};
-
-const writeJson = (filePath, data) => {
-  ensureDir(path.dirname(filePath));
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
-};
-
-const createMarkdownFile = (
-  dir,
-  filename,
-  { frontmatter = {}, content = "" },
-) => {
+/** Curried file writer: writeToDir(dir)(filename, content) */
+const writeToDir = (dir) => (filename, content) => {
   const filePath = path.join(dir, filename);
   ensureDir(path.dirname(filePath));
-  fs.writeFileSync(filePath, matter.stringify(content, frontmatter));
+  fs.writeFileSync(filePath, content);
   return filePath;
 };
 
-const copyDirFiles = (src, dest, filter = () => true) => {
-  const entries = getCachedDirList(src);
-  for (const entry of entries) {
-    if (entry.isFile && filter(entry.name)) {
-      copyFile(path.join(src, entry.name), path.join(dest, entry.name));
-    }
-  }
-};
+/** Curried JSON writer: writeJsonToDir(dir)(filename, data) */
+const writeJsonToDir = (dir) => (filename, data) =>
+  writeToDir(dir)(filename, JSON.stringify(data, null, 2));
 
-const copy11tyDataFiles = (templateSrc, srcDir, collection) => {
+/** Curried file copier: copyToDir(destDir)(srcPath, destName) */
+const copyToDir =
+  (destDir) =>
+  (srcPath, destName = path.basename(srcPath)) => {
+    const destPath = path.join(destDir, destName);
+    ensureDir(path.dirname(destPath));
+    fs.copyFileSync(srcPath, destPath);
+    return destPath;
+  };
+
+/** Create markdown file from content specification */
+const createMarkdownFile =
+  (dir) =>
+  (filename, { frontmatter = {}, content = "" }) => {
+    const write = writeToDir(dir);
+    return write(filename, matter.stringify(content, frontmatter));
+  };
+
+// -----------------------------------------------------------------------------
+// Directory Operations - Functional patterns for bulk operations
+// -----------------------------------------------------------------------------
+
+/** Copy files from src to dest that match the filter predicate */
+const copyDirFiles = (src, dest, filterFn = () => true) =>
+  pipe(
+    () => getCachedDirList(src),
+    filter((entry) => entry.isFile && filterFn(entry.name)),
+    map((entry) => {
+      const copy = copyToDir(dest);
+      return copy(path.join(src, entry.name), entry.name);
+    }),
+  )();
+
+/** Copy 11ty data files for a collection */
+const copy11tyDataFiles = (templateSrc, srcDir) => (collection) =>
   copyDirFiles(
     path.join(templateSrc, collection),
     path.join(srcDir, collection),
-    (f) => f.endsWith(".11tydata.js") || f.endsWith(".json"),
+    hasExtension(".11tydata.js", ".json"),
   );
-};
 
+/** Create symlinks for shared directories */
 const symlinkDirs = (templateSrc, srcDir, dirs) => {
-  for (const dir of dirs) {
-    const source = path.join(templateSrc, dir);
-    if (getCachedDirExists(source)) {
-      fs.symlinkSync(source, path.join(srcDir, dir));
-    }
+  for (const dir of dirs.filter((d) =>
+    getCachedDirExists(path.join(templateSrc, d)),
+  )) {
+    fs.symlinkSync(path.join(templateSrc, dir), path.join(srcDir, dir));
   }
 };
+
+// -----------------------------------------------------------------------------
+// Data Directory Setup - Compose data file operations
+// -----------------------------------------------------------------------------
 
 const setupDataDir = (templateSrc, srcDir, options) => {
   const dataSource = path.join(templateSrc, "_data");
   const dataTarget = path.join(srcDir, "_data");
+  const writeData = writeToDir(dataTarget);
+  const writeJson = writeJsonToDir(dataTarget);
+
+  // Copy base data files
   copyDirFiles(dataSource, dataTarget);
 
+  // Merge config with source config
   if (options.config) {
-    const configPath = path.join(dataTarget, "config.json");
-    const sourceConfigPath = path.join(dataSource, "config.json");
-    const existing = getCachedJsonFile(sourceConfigPath) || {};
-    writeJson(configPath, { ...existing, ...options.config });
+    const existing =
+      getCachedJsonFile(path.join(dataSource, "config.json")) || {};
+    writeJson("config.json", { ...existing, ...options.config });
   }
 
+  // Write custom strings module
   if (options.strings) {
-    const content = `export default ${JSON.stringify(options.strings, null, 2)};`;
-    fs.writeFileSync(path.join(dataTarget, "strings.js"), content);
+    writeData(
+      "strings.js",
+      `export default ${JSON.stringify(options.strings, null, 2)};`,
+    );
   }
 
+  // Write additional data files
   if (options.dataFiles) {
     for (const { filename, data } of options.dataFiles) {
-      writeJson(path.join(dataTarget, filename), data);
+      writeJson(filename, data);
     }
   }
 };
 
-const createContentFiles = (templateSrc, srcDir, files) => {
-  const seenCollections = new Set();
+// -----------------------------------------------------------------------------
+// Content Creation - Functional accumulation pattern
+// -----------------------------------------------------------------------------
 
-  for (const file of files || []) {
-    const collection = file.path.split("/")[0];
-    if (!seenCollections.has(collection)) {
-      seenCollections.add(collection);
-      copy11tyDataFiles(templateSrc, srcDir, collection);
-    }
-    createMarkdownFile(srcDir, file.path, {
+/** Extract unique collections from file list using functional composition */
+const extractCollections = pipe(
+  map(({ path: filePath }) => getCollection(filePath)),
+  unique,
+);
+
+/** Create content files and return collections touched */
+const createContentFiles = (templateSrc, srcDir, files = []) => {
+  const collections = extractCollections(files);
+  const copyDataFiles = copy11tyDataFiles(templateSrc, srcDir);
+  const writeMarkdown = createMarkdownFile(srcDir);
+
+  // Copy data files for each collection (side effect)
+  for (const collection of collections) {
+    copyDataFiles(collection);
+  }
+
+  // Create markdown files (side effect)
+  for (const file of files) {
+    writeMarkdown(file.path, {
       frontmatter: file.frontmatter || {},
       content: file.content || "",
     });
   }
 
-  return seenCollections;
+  return collections;
 };
 
-const ensureIndexPage = (templateSrc, srcDir, files, seenCollections) => {
-  const hasIndex = files?.some(
+/** Ensure an index page exists */
+const ensureIndexPage = (templateSrc, srcDir, files = [], collections) => {
+  const hasIndex = files.some(
     (f) => f.path === "pages/index.md" || f.frontmatter?.permalink === "/",
   );
+
   if (hasIndex) return;
 
-  if (!seenCollections.has("pages")) {
-    copy11tyDataFiles(templateSrc, srcDir, "pages");
+  if (!collections.includes("pages")) {
+    copy11tyDataFiles(templateSrc, srcDir)("pages");
   }
-  createMarkdownFile(srcDir, "pages/index.md", {
+
+  createMarkdownFile(srcDir)("pages/index.md", {
     frontmatter: { title: "Test Site", layout: "page", permalink: "/" },
     content: "# Test Site",
   });
 };
 
-const createSiteObject = (siteId, siteDir, srcDir, outputDir) => ({
-  id: siteId,
-  dir: siteDir,
-  srcDir,
-  outputDir,
+// -----------------------------------------------------------------------------
+// Image Handling - Normalize and copy with functional patterns
+// -----------------------------------------------------------------------------
 
-  async build() {
-    const result = spawnSync(
-      "bun",
-      ["./node_modules/@11ty/eleventy/cmd.cjs", "--quiet"],
-      {
-        cwd: siteDir,
-        stdio: "pipe",
-        encoding: "utf-8",
-      },
-    );
-    if (result.status !== 0) {
-      const error = new Error(
-        `Eleventy build failed: ${result.stderr || result.stdout}`,
-      );
-      error.stdout = result.stdout;
-      error.stderr = result.stderr;
-      throw error;
-    }
-    return result.stdout;
-  },
+/** Normalize image spec to { src, dest } object */
+const normalizeImageSpec = (img) =>
+  typeof img === "string"
+    ? { src: path.join(rootDir, "src/images", img), dest: img }
+    : {
+        src: img.src.startsWith("/") ? img.src : path.join(rootDir, img.src),
+        dest: img.dest,
+      };
 
-  getOutput(filePath) {
-    const fullPath = path.join(outputDir, filePath);
-    if (!fs.existsSync(fullPath)) {
-      throw new Error(`Output file not found: ${filePath}`);
-    }
-    return fs.readFileSync(fullPath, "utf-8");
-  },
+/** Copy test images to site's images directory */
+const copyTestImages = (srcDir, images = []) => {
+  if (images.length === 0) return;
 
-  getDoc(filePath) {
-    return new DOM(this.getOutput(filePath)).window.document;
-  },
+  const imagesDir = ensureDir(path.join(srcDir, "images"));
+  const copyImage = copyToDir(imagesDir);
 
-  hasOutput(filePath) {
-    return fs.existsSync(path.join(outputDir, filePath));
-  },
-
-  listOutputFiles() {
-    const files = [];
-    const walk = (dir, prefix = "") => {
-      for (const entry of fs.readdirSync(dir)) {
-        const fullPath = path.join(dir, entry);
-        const rel = path.join(prefix, entry);
-        fs.statSync(fullPath).isDirectory()
-          ? walk(fullPath, rel)
-          : files.push(rel);
-      }
-    };
-    if (fs.existsSync(outputDir)) walk(outputDir);
-    return files;
-  },
-
-  addFile(relativePath, content) {
-    const fullPath = path.join(srcDir, relativePath);
-    ensureDir(path.dirname(fullPath));
-    fs.writeFileSync(fullPath, content);
-  },
-
-  addMarkdown(relativePath, opts) {
-    createMarkdownFile(srcDir, relativePath, opts);
-  },
-
-  cleanup() {
-    if (fs.existsSync(siteDir)) {
-      fs.rmSync(siteDir, { recursive: true, force: true });
-    }
-  },
-});
-
-/**
- * Copy images into test site's images directory.
- *
- * @param {string} srcDir - The test site's src directory
- * @param {Array} images - Array of image specs, each can be:
- *   - A string path (copies from src/images/ to same filename)
- *   - An object { src: "path/to/source.jpg", dest: "filename.jpg" }
- */
-const copyTestImages = (srcDir, images) => {
-  if (!images || images.length === 0) return;
-
-  const imagesDir = path.join(srcDir, "images");
-  ensureDir(imagesDir);
-
-  for (const img of images) {
-    if (typeof img === "string") {
-      // Simple string: copy from src/images/{img} to images/{img}
-      const srcPath = path.join(rootDir, "src/images", img);
-      const destPath = path.join(imagesDir, img);
-      fs.copyFileSync(srcPath, destPath);
-    } else {
-      // Object with src and dest
-      const srcPath = img.src.startsWith("/")
-        ? img.src
-        : path.join(rootDir, img.src);
-      const destPath = path.join(imagesDir, img.dest);
-      fs.copyFileSync(srcPath, destPath);
-    }
+  for (const { src, dest } of images.map(normalizeImageSpec)) {
+    copyImage(src, dest);
   }
 };
+
+// -----------------------------------------------------------------------------
+// Site Object Factory - Creates the test site interface
+// -----------------------------------------------------------------------------
+
+/** Recursively list all files in a directory (pure recursive approach) */
+const listFilesRecursive = (dir, prefix = "") =>
+  !fs.existsSync(dir)
+    ? []
+    : pipe(
+        () => fs.readdirSync(dir),
+        flatMap((entry) => {
+          const fullPath = path.join(dir, entry);
+          const relativePath = path.join(prefix, entry);
+          return fs.statSync(fullPath).isDirectory()
+            ? listFilesRecursive(fullPath, relativePath)
+            : [relativePath];
+        }),
+      )();
+
+/** Create the site object with all methods */
+const createSiteObject = (siteId, siteDir, srcDir, outputDir) => {
+  // Curried helper bound to output directory
+  const getOutputPath = inDir(outputDir);
+
+  return Object.freeze({
+    id: siteId,
+    dir: siteDir,
+    srcDir,
+    outputDir,
+
+    async build() {
+      const result = spawnSync(
+        "bun",
+        ["./node_modules/@11ty/eleventy/cmd.cjs", "--quiet"],
+        { cwd: siteDir, stdio: "pipe", encoding: "utf-8" },
+      );
+
+      if (result.status !== 0) {
+        const error = new Error(
+          `Eleventy build failed: ${result.stderr || result.stdout}`,
+        );
+        error.stdout = result.stdout;
+        error.stderr = result.stderr;
+        throw error;
+      }
+
+      return result.stdout;
+    },
+
+    getOutput(filePath) {
+      const fullPath = getOutputPath(filePath);
+      if (!fs.existsSync(fullPath)) {
+        throw new Error(`Output file not found: ${filePath}`);
+      }
+      return fs.readFileSync(fullPath, "utf-8");
+    },
+
+    getDoc(filePath) {
+      return new DOM(this.getOutput(filePath)).window.document;
+    },
+
+    hasOutput(filePath) {
+      return fs.existsSync(getOutputPath(filePath));
+    },
+
+    listOutputFiles() {
+      return listFilesRecursive(outputDir);
+    },
+
+    addFile(relativePath, content) {
+      writeToDir(srcDir)(relativePath, content);
+    },
+
+    addMarkdown(relativePath, opts) {
+      createMarkdownFile(srcDir)(relativePath, opts);
+    },
+
+    cleanup() {
+      if (fs.existsSync(siteDir)) {
+        fs.rmSync(siteDir, { recursive: true, force: true });
+      }
+    },
+  });
+};
+
+// -----------------------------------------------------------------------------
+// Main API Functions
+// -----------------------------------------------------------------------------
 
 /**
  * Create a test site with isolated content
@@ -285,6 +370,7 @@ const createTestSite = async (options = {}) => {
 
   fs.mkdirSync(srcDir, { recursive: true });
 
+  // Setup symlinks, data, and content
   symlinkDirs(templateSrc, srcDir, [
     "_lib",
     "_includes",
@@ -295,23 +381,15 @@ const createTestSite = async (options = {}) => {
   ]);
   setupDataDir(templateSrc, srcDir, options);
 
-  const seenCollections = createContentFiles(
-    templateSrc,
-    srcDir,
-    options.files,
-  );
-  ensureIndexPage(templateSrc, srcDir, options.files, seenCollections);
-
-  // Copy test images if specified
+  const collections = createContentFiles(templateSrc, srcDir, options.files);
+  ensureIndexPage(templateSrc, srcDir, options.files, collections);
   copyTestImages(srcDir, options.images);
 
-  copyFile(
-    path.join(rootDir, ".eleventy.js"),
-    path.join(siteDir, ".eleventy.js"),
-  );
+  // Copy config and create symlinks
+  copyToDir(siteDir)(path.join(rootDir, ".eleventy.js"), ".eleventy.js");
 
   const pkgJson = getCachedJsonFile(path.join(rootDir, "package.json"));
-  writeJson(path.join(siteDir, "package.json"), pkgJson);
+  writeJsonToDir(siteDir)("package.json", pkgJson);
 
   fs.symlinkSync(
     path.join(rootDir, "node_modules"),
@@ -323,21 +401,6 @@ const createTestSite = async (options = {}) => {
 
 /**
  * Create a test site, build it, run checks, and clean up automatically.
- *
- * Usage:
- *   await withTestSite({ files: [...] }, (site) => {
- *     const doc = site.getDoc('/test/index.html');
- *     expectTrue(doc.querySelector('ul') !== null);
- *   });
- *
- * With images:
- *   await withTestSite({
- *     files: [{ path: 'pages/test.md', content: '{% image "photo.jpg", "Alt" %}' }],
- *     images: [
- *       "party.jpg",  // copies src/images/party.jpg to images/party.jpg
- *       { src: "src/images/party.jpg", dest: "photo.jpg" }  // with rename
- *     ]
- *   }, (site) => { ... });
  */
 const withTestSite = async (options, fn) => {
   const site = await createTestSite(options);


### PR DESCRIPTION
- Introduce curried path utilities (inDir, hasExtension) for composable path operations
- Replace mutable Set with pipe/unique for immutable collection extraction
- Add curried file operations (writeToDir, writeJsonToDir, copyToDir, createMarkdownFile)
- Use pipe() for function composition in copyDirFiles and listFilesRecursive
- Normalize image specs with pure function before processing
- Freeze returned site object for immutability
- Replace forEach with for-of loops per linter requirements