### PR TITLE
Enforce bun-only package management

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "chobble-template",
 	"version": "1.0.0",
 	"type": "module",
+	"packageManager": "bun@1.2.13",
 	"imports": {
 		"#data/*": "./src/_data/*",
 		"#lib/*": "./src/_lib/*",
@@ -16,6 +17,7 @@
 		"#test/*": "./test/*"
 	},
 	"scripts": {
+		"preinstall": "node -e \"if(!process.env.npm_config_user_agent||!process.env.npm_config_user_agent.startsWith('bun')){console.error('\\n\\x1b[31mERROR: This project requires bun.\\x1b[0m\\nRun: bun install\\nInstall bun: https://bun.sh\\n');process.exit(1)}\"",
 		"build": "rm -rf _site && bun ./node_modules/@11ty/eleventy/cmd.cjs",
 		"serve": "rm -rf _site && bun ./node_modules/@11ty/eleventy/cmd.cjs --serve --incremental --quiet",
 		"test": "bun run lint && bun run cpd && bun run build --quiet && bun test/run-coverage.js",

--- a/test/code-quality/lockfile.test.js
+++ b/test/code-quality/lockfile.test.js
@@ -2,10 +2,22 @@ import { describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
 import { fs, rootDir } from "#test/test-utils.js";
 
+const forbiddenLockfiles = [
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "npm-shrinkwrap.json",
+];
+
 describe("lockfile", () => {
-  test("package-lock.json should not exist (this project uses bun)", () => {
-    const lockfilePath = resolve(rootDir, "package-lock.json");
-    const exists = fs.existsSync(lockfilePath);
-    expect(exists).toBe(false);
+  test("only bun.lock should exist (this project uses bun)", () => {
+    for (const lockfile of forbiddenLockfiles) {
+      const lockfilePath = resolve(rootDir, lockfile);
+      const exists = fs.existsSync(lockfilePath);
+      expect(exists).toBe(false);
+    }
+
+    const bunLockPath = resolve(rootDir, "bun.lock");
+    expect(fs.existsSync(bunLockPath)).toBe(true);
   });
 });


### PR DESCRIPTION
- Add packageManager field to package.json
- Add preinstall script that blocks npm/yarn/pnpm with clear error
- Expand lockfile test to check all competing lock files