### PR TITLE
Break up news post template into components

### DIFF
--- a/src/_includes/news-post-gallery.html
+++ b/src/_includes/news-post-gallery.html
@@ -1,0 +1,6 @@
+{% if gallery %}
+  {% for image in gallery %}
+    {%- capture alt_text -%}{%- include "get-alt-text.html" -%}{%- endcapture -%}
+    {% image image, alt_text, config.products.gallery_image_widths %}
+  {% endfor %}
+{% endif %}

--- a/src/_includes/news-post-header.html
+++ b/src/_includes/news-post-header.html
@@ -1,0 +1,6 @@
+<h2>
+  <a href="/{{ strings.news_permalink_dir }}/">News</a>
+  {%- if subtitle and subtitle != "" %}
+    › {{ subtitle | escape }}
+  {%- endif -%}
+</h2>

--- a/src/_includes/news-post-meta.html
+++ b/src/_includes/news-post-meta.html
@@ -1,0 +1,24 @@
+{%- if authorSlug -%}
+  {%- assign authorData = collections.team | where: "fileSlug", authorSlug | first -%}
+{%- endif -%}
+
+{%- if authorData and authorData.data.image -%}
+<header class="post-meta with-thumbnail" role="doc-subtitle">
+  <figure>
+    <a href="{{ authorData.url }}">{% image authorData.data.image, authorData.data.title, "80,160,240", "", "", "1/1" %}</a>
+  </figure>
+  <div>
+    {%- include "post-meta-author.html" -%}
+    {%- include "post-meta-date.html" -%}
+  </div>
+</header>
+{%- elsif authorData -%}
+<header class="post-meta" role="doc-subtitle">
+  {%- include "post-meta-author.html" -%}
+  {%- include "post-meta-date.html" -%}
+</header>
+{%- else -%}
+<header class="post-meta" role="doc-subtitle">
+  {%- include "post-meta-date.html" -%}
+</header>
+{%- endif -%}

--- a/src/_layouts/news-post.html
+++ b/src/_layouts/news-post.html
@@ -2,43 +2,10 @@
 layout: base
 ---
 
-<h2>
-  <a href="/{{ strings.news_permalink_dir }}/">News</a>
-  {%- if subtitle and subtitle != "" %}
-    › {{ subtitle | escape }}
-  {%- endif -%}
-</h2>
+{% include "news-post-header.html" %}
 
-{%- if authorSlug -%}
-  {%- assign authorData = collections.team | where: "fileSlug", authorSlug | first -%}
-{%- endif -%}
-
-{%- if authorData and authorData.data.image -%}
-<header class="post-meta with-thumbnail" role="doc-subtitle">
-  <figure>
-    <a href="{{ authorData.url }}">{% image authorData.data.image, authorData.data.title, "80,160,240", "", "", "1/1" %}</a>
-  </figure>
-  <div>
-    {%- include "post-meta-author.html" -%}
-    {%- include "post-meta-date.html" -%}
-  </div>
-</header>
-{%- elsif authorData -%}
-<header class="post-meta" role="doc-subtitle">
-  {%- include "post-meta-author.html" -%}
-  {%- include "post-meta-date.html" -%}
-</header>
-{%- else -%}
-<header class="post-meta" role="doc-subtitle">
-  {%- include "post-meta-date.html" -%}
-</header>
-{%- endif -%}
+{% include "news-post-meta.html" %}
 
 {{ content }}
 
-{% if gallery %}
-  {% for image in gallery %}
-    {%- capture alt_text -%}{%- include "get-alt-text.html" -%}{%- endcapture -%}
-    {% image image, alt_text, config.products.gallery_image_widths %}
-  {% endfor %}
-{% endif %}
+{% include "news-post-gallery.html" %}


### PR DESCRIPTION
Break up the news-post layout into smaller, reusable chunks:
- news-post-header.html: News breadcrumb and subtitle
- news-post-meta.html: Author info and date display
- news-post-gallery.html: Image gallery loop