### PR TITLE
Limit test coverage checks to main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Run tests
         run: bun run test
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
 
       - name: Check for coverage changes
         id: coverage_changes
@@ -34,7 +36,7 @@ jobs:
           fi
 
       - name: Commit and push coverage changes
-        if: steps.coverage_changes.outputs.has_changes == 'true'
+        if: steps.coverage_changes.outputs.has_changes == 'true' && github.ref_name == 'main'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/test/run-coverage.js
+++ b/test/run-coverage.js
@@ -219,8 +219,8 @@ function runCoverage() {
 }
 
 function ratchetLimits(currentLimits, actual) {
-  // Only ratchet on CI to avoid local cache differences affecting thresholds
-  if (!process.env.CI) {
+  // Only ratchet on CI and main branch to avoid local cache differences and non-main branches
+  if (!process.env.CI || process.env.GITHUB_REF_NAME !== "main") {
     return;
   }
 


### PR DESCRIPTION
- Only ratchet up coverage thresholds when merging to main branch
- Pass github.ref_name to run-coverage.js via environment variable
- Add branch check to workflow commit step
- Prevents non-main branches from triggering auto-commits