### PR TITLE
Inline single-use functions and remove file

### DIFF
--- a/src/_lib/utils/slug-utils.js
+++ b/src/_lib/utils/slug-utils.js
@@ -29,9 +29,12 @@ const buildPdfFilename = (businessName, menuSlug) =>
   `${slugify(businessName)}-${menuSlug}.pdf`;
 
 // Convert a slug to title case (e.g., "90s-computer" -> "90s Computer")
-const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
 const slugToTitle = (slug) =>
-  pipe(split("-"), map(capitalize), join(" "))(slug);
+  pipe(
+    split("-"),
+    map((word) => word.charAt(0).toUpperCase() + word.slice(1)),
+    join(" "),
+  )(slug);
 
 export {
   slugify,

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -232,7 +232,6 @@ const ALLOWED_SINGLE_USE_FUNCTIONS = new Set([
   "src/_lib/media/unused-images.js",
   "src/_lib/utils/dom-builder.js",
   "src/_lib/utils/schema-helper.js",
-  "src/_lib/utils/slug-utils.js",
   "src/assets/js/availability-calendar.js",
   "src/assets/js/cart-utils.js",
   "src/assets/js/cart.js",


### PR DESCRIPTION
Remove capitalize single-use function by inlining it directly into the map call in slugToTitle, allowing removal from ALLOWED_SINGLE_USE_FUNCTIONS.