### PR TITLE
Inline single-use functions and remove file

### DIFF
--- a/src/assets/js/selectors.js
+++ b/src/assets/js/selectors.js
@@ -1,8 +1,6 @@
 // Template selector constants
 // IDs for <template> elements cloned by JavaScript
 
-const toKebab = (s) => s.toLowerCase().replace(/_/g, "-");
-
 export const IDS = Object.fromEntries(
   [
     "CALENDAR_MONTH",
@@ -11,5 +9,5 @@ export const IDS = Object.fromEntries(
     "QUOTE_CHECKOUT_ITEM",
     "GALLERY_NAV_PREV",
     "GALLERY_NAV_NEXT",
-  ].map((k) => [k, `${toKebab(k)}-template`]),
+  ].map((k) => [k, `${k.toLowerCase().replace(/_/g, "-")}-template`]),
 );

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -241,7 +241,6 @@ const ALLOWED_SINGLE_USE_FUNCTIONS = new Set([
   "src/assets/js/quote.js",
   "src/assets/js/scroll-fade.js",
   "src/assets/js/search.js",
-  "src/assets/js/selectors.js",
   "src/assets/js/shuffle-properties.js",
   "src/assets/js/slider.js",
   "src/assets/js/stripe-checkout.js",


### PR DESCRIPTION
The toKebab function was only called once in the file, making it a candidate for inlining. This improves readability by keeping the transformation logic inline with its single usage point.