### PR TITLE
Redirect npm test to use bun instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"preinstall": "node -e \"if(!process.env.npm_config_user_agent||!process.env.npm_config_user_agent.startsWith('bun')){console.error('\\n\\x1b[31mERROR: This project requires bun.\\x1b[0m\\nRun: bun install\\nInstall bun: https://bun.sh\\n');process.exit(1)}\"",
 		"build": "rm -rf _site && bun ./node_modules/@11ty/eleventy/cmd.cjs",
 		"serve": "rm -rf _site && bun ./node_modules/@11ty/eleventy/cmd.cjs --serve --incremental --quiet",
-		"test": "node -e \"if(process.env.npm_lifecycle_event){console.error('\\n\\x1b[31mERROR: This project uses bun.\\x1b[0m\\nRun: bun test\\nInstall bun: https://bun.sh\\n'); process.exit(1)}\" && bun run lint && bun run cpd && bun run build --quiet && bun test/run-coverage.js",
+		"test": "node -e \"if(process.env.npm_config_user_agent && !process.env.npm_config_user_agent.startsWith('bun')){console.error('\\n\\x1b[31mERROR: This project uses bun.\\x1b[0m\\nRun: bun test\\nInstall bun: https://bun.sh\\n'); process.exit(1)}\" && bun run lint && bun run cpd && bun run build --quiet && bun test/run-coverage.js",
 		"test:unit": "bun test --concurrent --timeout 30000",
 		"cpd": "jscpd",
 		"knip": "knip",


### PR DESCRIPTION
Update the test script to immediately error and direct users to use bun test instead of npm test, maintaining consistency with the bun-only project setup.