### PR TITLE
Inline single-use functions and remove file

### DIFF
--- a/src/_lib/eleventy/external-links.js
+++ b/src/_lib/eleventy/external-links.js
@@ -17,26 +17,25 @@ const externalLinkFilter = (url, config) => {
   return getExternalLinkAttributes(url, config);
 };
 
-const shouldSkipTransform = (content, config) =>
-  !content ||
-  !content.includes("<a") ||
-  !config?.externalLinksTargetBlank ||
-  (!content.includes("http://") && !content.includes("https://"));
-
-const applyExternalAttrs = (link) => {
-  link.setAttribute("target", "_blank");
-  link.setAttribute("rel", "noopener noreferrer");
-};
-
 const transformExternalLinks = async (content, config) => {
-  if (shouldSkipTransform(content, config)) return content;
+  if (
+    !content ||
+    !content.includes("<a") ||
+    !config?.externalLinksTargetBlank ||
+    (!content.includes("http://") && !content.includes("https://"))
+  ) {
+    return content;
+  }
 
   const JSDOM = await loadJSDOM();
   const dom = new JSDOM(content);
   const { document } = dom.window;
 
   for (const link of document.querySelectorAll("a[href]")) {
-    if (isExternalUrl(link.getAttribute("href"))) applyExternalAttrs(link);
+    if (isExternalUrl(link.getAttribute("href"))) {
+      link.setAttribute("target", "_blank");
+      link.setAttribute("rel", "noopener noreferrer");
+    }
   }
 
   return dom.serialize();

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -220,7 +220,6 @@ const ALLOWED_SINGLE_USE_FUNCTIONS = new Set([
   "src/_lib/collections/navigation.js",
   "src/_lib/collections/products.js",
   "src/_lib/collections/search.js",
-  "src/_lib/eleventy/external-links.js",
   "src/_lib/eleventy/file-utils.js",
   "src/_lib/eleventy/js-config.js",
   "src/_lib/eleventy/pdf.js",


### PR DESCRIPTION
- Inline shouldSkipTransform function directly into transformExternalLinks
- Inline applyExternalAttrs function directly into transformExternalLinks loop
- Remove external-links.js from ALLOWED_SINGLE_USE_FUNCTIONS
- All tests pass (38 external-links tests, 14 single-use-functions tests)