### PR TITLE
Use aliases in test infrastructure file exclusions

### DIFF
--- a/test/code-quality/relative-paths.test.js
+++ b/test/code-quality/relative-paths.test.js
@@ -9,13 +9,13 @@ const IMPORT_PATH_REGEX = /from\s+["']([^"']+)["']/;
 describe("relative-paths", () => {
   // Create checkers inside describe block to ensure imports are resolved
   const testInfrastructureFiles = [
-    "test/test-utils.js",
-    "test/test-site-factory.js",
-    "test/run-coverage.js",
-    "test/build-profiling.js",
-    "test/code-scanner.js",
-    "test/setup.js",
-    "test/ensure-deps.js",
+    "#test/test-utils.js",
+    "#test/test-site-factory.js",
+    "#test/run-coverage.js",
+    "#test/build-profiling.js",
+    "#test/code-scanner.js",
+    "#test/setup.js",
+    "#test/ensure-deps.js",
   ];
 
   const { find: findRelativeImports, analyze: analyzeRelativeImports } =
@@ -37,7 +37,7 @@ describe("relative-paths", () => {
       files: ALL_JS_FILES(),
       excludeFiles: [
         THIS_FILE,
-        "src/_lib/paths.js",
+        "#lib/paths.js",
         ...testInfrastructureFiles,
       ],
     });

--- a/test/code-scanner.js
+++ b/test/code-scanner.js
@@ -7,6 +7,34 @@ import { fs, path, rootDir } from "#test/test-utils.js";
 import { notMemberOf } from "#utils/array-utils.js";
 import { omit } from "#utils/object-entries.js";
 
+/**
+ * Resolve import aliases to file paths.
+ * Maps package.json imports like #test/* to actual paths.
+ */
+const resolveAlias = (importPath) => {
+  const aliasMap = {
+    "#test/": "test/",
+    "#lib/": "src/_lib/",
+    "#collections/": "src/_lib/collections/",
+    "#config/": "src/_lib/config/",
+    "#filters/": "src/_lib/filters/",
+    "#eleventy/": "src/_lib/eleventy/",
+    "#build/": "src/_lib/build/",
+    "#media/": "src/_lib/media/",
+    "#utils/": "src/_lib/utils/",
+    "#assets/": "src/assets/js/",
+    "#data/": "src/_data/",
+  };
+
+  for (const [alias, realPath] of Object.entries(aliasMap)) {
+    if (importPath.startsWith(alias)) {
+      return importPath.replace(alias, realPath);
+    }
+  }
+
+  return importPath;
+};
+
 // Standard fields returned by find functions (everything else is extra data)
 const STANDARD_HIT_FIELDS = ["lineNumber", "line"];
 const omitStandardFields = omit(STANDARD_HIT_FIELDS);
@@ -60,9 +88,12 @@ const toLines = (source) =>
 
 /**
  * Filter file list excluding certain paths.
+ * Resolves aliases in exclude list before filtering.
  */
-const excludeFiles = (files, exclude = []) =>
-  files.filter(notMemberOf(exclude));
+const excludeFiles = (files, exclude = []) => {
+  const resolvedExclude = exclude.map(resolveAlias);
+  return files.filter(notMemberOf(resolvedExclude));
+};
 
 /**
  * Combine multiple file lists, optionally excluding some.
@@ -367,6 +398,8 @@ const createViolation = (reasonFn) => (context) => ({
 });
 
 export {
+  // Alias resolution
+  resolveAlias,
   // Common patterns
   COMMENT_LINE_PATTERNS,
   isCommentLine,


### PR DESCRIPTION
Replace relative paths with import aliases (#test/*, #lib/*) in test configuration files to maintain consistency with the rest of the codebase. Added resolveAlias function to code-scanner to handle alias-to-path resolution in file exclusion lists.