### PR TITLE
Add Biome linter rule and fix issues

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -48,7 +48,8 @@
       "correctness": {
         "noUnusedVariables": "error",
         "noUnusedImports": "error",
-        "noUnusedFunctionParameters": "error"
+        "noUnusedFunctionParameters": "error",
+        "noGlobalDirnameFilename": "error"
       }
     }
   },


### PR DESCRIPTION
Enables the noGlobalDirnameFilename correctness rule to prevent use of global __dirname and __filename variables.