### PR TITLE
Reduce complexity threshold and refactor methods

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -85,7 +85,7 @@
             "noExcessiveCognitiveComplexity": {
               "level": "error",
               "options": {
-                "maxAllowedComplexity": 50
+                "maxAllowedComplexity": 45
               }
             }
           },


### PR DESCRIPTION
- Lower maxAllowedComplexity threshold from 50 to 45 for test files
- Refactor processChar function to reduce cognitive complexity by:
  - Extracting condition checks into helper functions (isStringDelimiter, isTemplateDelimiter, etc)
  - Extracting brace handling into separate handlers (handleOpeningBrace, handleClosingBrace)
  - Simplifying nested conditionals with early returns
  - Using pure functional patterns with focused, single-responsibility helpers

This improves code readability and maintainability while passing stricter complexity rules.