### PR TITLE
Create PRs for coverage ratchets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
 
 permissions:
   contents: write


### PR DESCRIPTION
Changes the test workflow to create PRs for coverage exception updates instead of pushing directly to main, avoiding branch protection conflicts.