### PR TITLE
Create PRs for coverage ratchets and run tests on PRs

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -51,6 +51,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     permissions:
       contents: write
+      pull-requests: write
 
   deploy-neocities:
     name: Deploy to Neocities


### PR DESCRIPTION
## Summary
- Changes test workflow to create PRs for coverage exception updates instead of pushing directly to main (avoids branch protection conflicts)
- Adds `pull_request` trigger to test workflow so PRs get the required status check
- Adds `pull-requests: write` permission to allow PR creation