### PR TITLE
Simplify ALLOWED_OBJECT_MUTATION to single string

### DIFF
--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -192,10 +192,7 @@ const ALLOWED_LET = new Set([
 
 // Files that use obj[key] = value for object mutation.
 // Prefer functional patterns: reduce with spread, Object.fromEntries, toObject, etc.
-const ALLOWED_OBJECT_MUTATION = new Set([
-  // Browser-side image lazy loading - setting DOM element attributes
-  "src/assets/js/autosizes.js:123", // img[attribute] = img.getAttribute
-]);
+const ALLOWED_OBJECT_MUTATION = "src/assets/js/autosizes.js:123"; // Browser-side image lazy loading - setting DOM element attributes (img[attribute] = img.getAttribute)
 
 // ============================================
 // Null check exceptions (if (!x) patterns)

--- a/test/code-quality/object-mutation.test.js
+++ b/test/code-quality/object-mutation.test.js
@@ -33,7 +33,7 @@ const { find: findObjectMutation } = createCodeChecker({
 const analyzeObjectMutation = () =>
   analyzeWithAllowlist({
     findFn: findObjectMutation,
-    allowlist: ALLOWED_OBJECT_MUTATION,
+    allowlist: new Set([ALLOWED_OBJECT_MUTATION]),
     files: SRC_JS_FILES,
   });
 
@@ -98,7 +98,7 @@ obj[ key ] = value;
   // Exception validation tests
   test("ALLOWED_OBJECT_MUTATION entries still exist and match pattern", () => {
     const stale = validateExceptions(
-      ALLOWED_OBJECT_MUTATION,
+      new Set([ALLOWED_OBJECT_MUTATION]),
       OBJECT_MUTATION_PATTERN,
     );
     if (stale.length > 0) {


### PR DESCRIPTION
Change ALLOWED_OBJECT_MUTATION from a Set with one entry to a single string constant, since there's only one remaining path. Update object-mutation.test.js to wrap the string in a Set where needed for compatibility with the allowlist functions.