### PR TITLE
Enforce precommit script for code agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit.*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run precommit"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Configures a PreToolUse hook that runs `bun run precommit` before any git commit command. If the precommit checks fail, the commit will be blocked.