### PR TITLE
Fix product options display for hire mode

### DIFF
--- a/src/_includes/list-item-cart-button.html
+++ b/src/_includes/list-item-cart-button.html
@@ -1,9 +1,15 @@
 {%- if config.cart_mode and item.data.cart_attributes -%}
+  {%- assign mode = item.data.product_mode | default: config.product_mode -%}
   {%- if item.data.options.size == 1 -%}
     <button
       class="add-to-cart"
       data-item="{{ item.data.cart_attributes }}"
     >Add to Cart</button>
+  {%- elsif mode == "hire" -%}
+    <button
+      class="add-to-cart"
+      data-item="{{ item.data.cart_attributes }}"
+    >Add To Quote</button>
   {%- else -%}
     <a href="{{ item.url }}#content" class="button">Select Options</a>
   {%- endif -%}


### PR DESCRIPTION
…tions"

For products with product_mode: hire, the options relate to dates rather than selectable choices. Changed the button to show "Add To Quote" for hire products with multiple options, maintaining the add-to-cart functionality while providing clearer messaging for hire products.