### PR TITLE
Align quote price beside form when sidebar missing

### DIFF
--- a/src/_layouts/quote-checkout.html
+++ b/src/_layouts/quote-checkout.html
@@ -5,6 +5,7 @@ layout: base
 {{ content }}
 
 {%- if config.form_target and config.form_target != "" -%}
+<div class="quote-layout">
   {%- include "form-open.html" -%}
     {%- include "form-email-config.html",
         redirect_path: "/quote-complete/",
@@ -13,11 +14,12 @@ layout: base
     -%}
     <input type="hidden" id="cart-items" name="cart_items" value="" />
     <input type="hidden" id="hire_days" name="hire_days" value="" />
-    <div id="quote-price-container" style="display: none"></div>
 
     {%- include "quote-form-steps.html" -%}
     {%- include "templates/quote-price.html" -%}
   </form>
+  <aside id="quote-price-container" class="quote-sidebar" style="display: none"></aside>
+</div>
 {%- else -%}
   {%- include "formspark-missing.html" -%}
 {%- endif -%}

--- a/src/_layouts/quote.html
+++ b/src/_layouts/quote.html
@@ -6,20 +6,24 @@ layout: base
 
 {%- include "templates/quote-steps-progress.html", completed_steps: 0 -%}
 
-<noscript
-  ><p>JavaScript is required to view and manage your quote cart.</p></noscript
->
-<div id="quote-cart" class="quote-cart">
-  <div class="quote-cart-empty" style="display: none">
-    <p>
-      Your cart is empty. <a href="/products/">Browse products</a> to add items.
-    </p>
+<div class="quote-layout">
+  <div class="quote-main">
+    <noscript
+      ><p>JavaScript is required to view and manage your quote cart.</p></noscript
+    >
+    <div id="quote-cart" class="quote-cart">
+      <div class="quote-cart-empty" style="display: none">
+        <p>
+          Your cart is empty. <a href="/products/">Browse products</a> to add items.
+        </p>
+      </div>
+      <div class="quote-cart-items"></div>
+      <div class="quote-cart-actions" style="display: none">
+        <a href="/checkout/" class="button">Continue to Enquiry</a>
+      </div>
+    </div>
   </div>
-  <div class="quote-cart-items"></div>
-  <div id="quote-price-container" style="display: none"></div>
-  <div class="quote-cart-actions" style="display: none">
-    <a href="/checkout/" class="button">Continue to Enquiry</a>
-  </div>
+  <aside id="quote-price-container" class="quote-sidebar" style="display: none"></aside>
 </div>
 
 {% include "templates/quote-price.html" %}

--- a/src/css/cart.scss
+++ b/src/css/cart.scss
@@ -396,3 +396,31 @@ dialog.cart-overlay {
     }
   }
 }
+
+// Quote layout - side-by-side on larger screens when no right sidebar
+body.one-column {
+  @include breakpoints.up("md") {
+    .quote-layout {
+      display: flex;
+      gap: 2rem;
+      align-items: flex-start;
+    }
+
+    .quote-main,
+    .quote-layout > form {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .quote-sidebar {
+      width: 16rem;
+      flex-shrink: 0;
+      position: sticky;
+      top: 1rem;
+
+      .quote-price {
+        margin-top: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
When right-content.md doesn't exist (one-column layout), display the quote-price sidebar to the right of the quote/checkout forms using flexbox at the md breakpoint and above.

- Wrap quote form content in .quote-layout flexbox container
- Move #quote-price-container to .quote-sidebar aside element
- Add responsive CSS that activates only for body.one-column at md+