### PR TITLE
Refactor duplicated code using pipe utility

### DIFF
--- a/test/unit/code-quality/test-hygiene.test.js
+++ b/test/unit/code-quality/test-hygiene.test.js
@@ -33,6 +33,9 @@ const ALLOWED_TEST_FUNCTIONS = new Set([
   "createSchemaData",
   // quote-steps.test.js - test fixture factory
   "createQuoteStepsHtml",
+  // theme-editor.test.js - functional test helpers
+  "roundTripTheme",
+  "testScopedEntry",
   // item-filters.test.js - mock eleventy config with getters
   "mockConfig",
   // checkout.test.js - template rendering and mocks


### PR DESCRIPTION
Add roundTripTheme and testScopedEntry helpers to eliminate code duplication detected by jscpd. Uses curried pattern consistent with existing *-utils.js functional paradigms.