### PR TITLE
Use expectObjectProps utility across codebase

### DIFF
--- a/test/unit/build/pdf.test.js
+++ b/test/unit/build/pdf.test.js
@@ -4,7 +4,10 @@ import {
   configurePdf,
   createMenuPdfTemplate,
 } from "#eleventy/pdf.js";
-import { createMockEleventyConfig } from "#test/test-utils.js";
+import {
+  createMockEleventyConfig,
+  expectObjectProps,
+} from "#test/test-utils.js";
 
 // Helper to create mock menu
 const createMockMenu = (slug, title, subtitle = null) => ({
@@ -59,8 +62,10 @@ describe("pdf", () => {
 
       const result = buildMenuPdfData(menu, categories, items);
 
-      expect(result.menuTitle).toBe("Lunch Menu");
-      expect(result.subtitle).toBe("Served 11am-3pm");
+      expectObjectProps({
+        menuTitle: "Lunch Menu",
+        subtitle: "Served 11am-3pm",
+      })(result);
       expect(result.categories).toHaveLength(2);
       expect(result.categories[0].name).toBe("Appetizers");
     });
@@ -72,8 +77,10 @@ describe("pdf", () => {
 
       const result = buildMenuPdfData(menu, categories, items);
 
-      expect(result.menuTitle).toBe("Dinner Menu");
-      expect(result.subtitle).toBe("");
+      expectObjectProps({
+        menuTitle: "Dinner Menu",
+        subtitle: "",
+      })(result);
     });
 
     test("Only includes categories that belong to the menu", () => {
@@ -125,10 +132,11 @@ describe("pdf", () => {
 
       const result = buildMenuPdfData(menu, categories, items);
 
-      const item = result.categories[0].items[0];
-      expect(item.name).toBe("Spring Rolls");
-      expect(item.price).toBe("$8.99");
-      expect(item.description).toBe("Crispy and delicious");
+      expectObjectProps({
+        name: "Spring Rolls",
+        price: "$8.99",
+        description: "Crispy and delicious",
+      })(result.categories[0].items[0]);
     });
 
     test("Dietary symbols are joined correctly", () => {
@@ -173,8 +181,10 @@ describe("pdf", () => {
 
       const result = buildMenuPdfData(menu, categories, items);
 
-      expect(result.hasDietaryKeys).toBe(false);
-      expect(result.dietaryKeyString).toBe("");
+      expectObjectProps({
+        hasDietaryKeys: false,
+        dietaryKeyString: "",
+      })(result);
     });
 
     test("Same dietary key from multiple items appears only once", () => {

--- a/test/unit/filters/item-filters.test.js
+++ b/test/unit/filters/item-filters.test.js
@@ -16,6 +16,7 @@ import {
 import {
   item as baseItem,
   collectionApi,
+  expectObjectProps,
   expectResultTitles,
 } from "#test/test-utils.js";
 import { map, pipe, reduce } from "#utils/array-utils.js";
@@ -139,10 +140,12 @@ describe("item-filters", () => {
 
     const result = buildDisplayLookup(testItems);
 
-    expect(result["pet-friendly"]).toBe("Pet Friendly");
-    expect(result.yes).toBe("Yes");
-    expect(result.type).toBe("Type");
-    expect(result.cottage).toBe("Cottage");
+    expectObjectProps({
+      "pet-friendly": "Pet Friendly",
+      yes: "Yes",
+      type: "Type",
+      cottage: "Cottage",
+    })(result);
   });
 
   test("First capitalization wins for duplicate keys", () => {
@@ -153,8 +156,10 @@ describe("item-filters", () => {
 
     const result = buildDisplayLookup(testItems);
 
-    expect(result["pet-friendly"]).toBe("Pet Friendly");
-    expect(result.yes).toBe("YES");
+    expectObjectProps({
+      "pet-friendly": "Pet Friendly",
+      yes: "YES",
+    })(result);
   });
 
   test("Handles items without filter_attributes", () => {
@@ -162,8 +167,10 @@ describe("item-filters", () => {
 
     const result = buildDisplayLookup(testItems);
 
-    expect(result.size).toBe("Size");
-    expect(result.large).toBe("Large");
+    expectObjectProps({
+      size: "Size",
+      large: "Large",
+    })(result);
   });
 
   // filterToPath tests

--- a/test/unit/frontend/checkout.test.js
+++ b/test/unit/frontend/checkout.test.js
@@ -19,7 +19,7 @@ import {
   updateCartIcon,
   updateItemQuantity,
 } from "#public/utils/cart-utils.js";
-import { fs, path, rootDir } from "#test/test-utils.js";
+import { expectObjectProps, fs, path, rootDir } from "#test/test-utils.js";
 
 // ============================================
 // Template Rendering
@@ -1041,9 +1041,11 @@ describe("checkout", () => {
     const select = doc.querySelector(".product-options-select");
     const firstOption = select.options[0];
 
-    expect(firstOption.disabled).toBe(true);
-    expect(firstOption.value).toBe("");
-    expect(firstOption.selected).toBe(true);
+    expectObjectProps({
+      disabled: true,
+      value: "",
+      selected: true,
+    })(firstOption);
   });
 
   test("Select options have index values and button has consolidated data", async () => {

--- a/test/unit/frontend/config.test.js
+++ b/test/unit/frontend/config.test.js
@@ -80,9 +80,11 @@ describe("config", () => {
       },
     };
     const result = getProducts(configData);
-    expect(result.item_widths).toBe("100,200");
-    expect(result.gallery_thumb_widths).toBe(undefined);
-    expect(result.custom_field).toBe("value");
+    expectObjectProps({
+      item_widths: "100,200",
+      gallery_thumb_widths: undefined,
+      custom_field: "value",
+    })(result);
   });
 
   test("getProducts keeps all truthy values", () => {
@@ -96,9 +98,11 @@ describe("config", () => {
       },
     };
     const result = getProducts(configData);
-    expect(result.a).toBe("string");
-    expect(result.b).toBe(123);
-    expect(result.c).toBe(true);
+    expectObjectProps({
+      a: "string",
+      b: 123,
+      c: true,
+    })(result);
     expect(result.d).toEqual([]);
     expect(result.e).toEqual({});
   });
@@ -162,8 +166,10 @@ describe("config", () => {
     const filePath = createTempFile(tempDir, "test.md", content);
 
     const result = extractFrontmatter(filePath, "test.md", "stripe");
-    expect(result.layout).toBe("test.html");
-    expect(result.permalink).toBe("/test/");
+    expectObjectProps({
+      layout: "test.html",
+      permalink: "/test/",
+    })(result);
 
     cleanupTempDir(tempDir);
   });

--- a/test/unit/frontend/form-helpers.test.js
+++ b/test/unit/frontend/form-helpers.test.js
@@ -4,7 +4,7 @@ import {
   getFieldTemplate,
   processContactForm,
 } from "#config/form-helpers.js";
-import { expectProp } from "#test/test-utils.js";
+import { expectObjectProps, expectProp } from "#test/test-utils.js";
 
 const expectTemplates = expectProp("template");
 
@@ -135,8 +135,10 @@ describe("form-helpers", () => {
         fields: [{ name: "test", type: "text" }],
       };
       const result = processContactForm(data);
-      expect(result.submitButtonText).toBe("Send Message");
-      expect(result.successMessage).toBe("Thanks!");
+      expectObjectProps({
+        submitButtonText: "Send Message",
+        successMessage: "Thanks!",
+      })(result);
     });
 
     test("does not mutate original data", () => {

--- a/test/unit/utils/array-utils.test.js
+++ b/test/unit/utils/array-utils.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { expectObjectProps } from "#test/test-utils.js";
 import {
   chunk,
   compact,
@@ -130,8 +131,10 @@ describe("array-utils", () => {
     ];
 
     const duplicate = findDuplicate(options, (opt) => opt.days);
-    expect(duplicate.days).toBe(1);
-    expect(duplicate.price).toBe(15); // It's the second occurrence
+    expectObjectProps({
+      days: 1,
+      price: 15, // It's the second occurrence
+    })(duplicate);
   });
 
   // ============================================

--- a/test/unit/utils/dom-builder.test.js
+++ b/test/unit/utils/dom-builder.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { expectObjectProps } from "#test/test-utils.js";
 import {
   createElement,
   createHtml,
@@ -96,8 +97,10 @@ describe("dom-builder", () => {
     const doc = await getSharedDocument();
     const element = await createElement("span", { id: "test" }, "Content", doc);
 
-    expect(element.ownerDocument).toBe(doc);
-    expect(element.id).toBe("test");
+    expectObjectProps({
+      ownerDocument: doc,
+      id: "test",
+    })(element);
   });
 
   // ============================================
@@ -170,8 +173,10 @@ describe("dom-builder", () => {
     const doc = await getSharedDocument();
     const element = await parseHtml('<span id="test">Test</span>', doc);
 
-    expect(element.ownerDocument).toBe(doc);
-    expect(element.id).toBe("test");
+    expectObjectProps({
+      ownerDocument: doc,
+      id: "test",
+    })(element);
   });
 
   // ============================================

--- a/test/unit/utils/grouping.test.js
+++ b/test/unit/utils/grouping.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { expectObjectProps } from "#test/test-utils.js";
 import {
   buildFirstOccurrenceLookup,
   buildReverseIndex,
@@ -108,8 +109,10 @@ describe("grouping", () => {
       item.attrs.map((a) => [a.slug, a.display]),
     );
 
-    expect(lookup.red).toBe("Red");
-    expect(lookup.blue).toBe("Blue");
+    expectObjectProps({
+      red: "Red",
+      blue: "Blue",
+    })(lookup);
   });
 
   test("Handles items that produce multiple key-value pairs", () => {
@@ -127,9 +130,11 @@ describe("grouping", () => {
       item.attrs.map((a) => [a.k, a.v]),
     );
 
-    expect(lookup.a).toBe(1);
-    expect(lookup.b).toBe(2);
-    expect(lookup.c).toBe(3);
+    expectObjectProps({
+      a: 1,
+      b: 2,
+      c: 3,
+    })(lookup);
   });
 
   test("Returns empty object for empty items array", () => {

--- a/test/unit/utils/schema-helper.test.js
+++ b/test/unit/utils/schema-helper.test.js
@@ -4,6 +4,7 @@ import {
   createPostSchemaData,
   createProductSchemaData,
   createSchemaData,
+  expectObjectProps,
 } from "#test/test-utils.js";
 import {
   buildBaseMeta,
@@ -143,8 +144,10 @@ describe("buildBaseMeta", () => {
 
     const result = buildBaseMeta(data);
 
-    expect(result.customField).toBe("custom value");
-    expect(result.anotherField).toBe(123);
+    expectObjectProps({
+      customField: "custom value",
+      anotherField: 123,
+    })(result);
   });
 });
 
@@ -154,8 +157,10 @@ describe("buildProductMeta", () => {
 
     const result = buildProductMeta(data);
 
-    expect(result.name).toBe("Test Product");
-    expect(result.brand).toBe("Test Store");
+    expectObjectProps({
+      name: "Test Product",
+      brand: "Test Store",
+    })(result);
   });
 
   test("includes offers when price is provided", () => {

--- a/test/unit/utils/strings.test.js
+++ b/test/unit/utils/strings.test.js
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import strings from "#data/strings.js";
 import baseStrings from "#data/strings-base.json" with { type: "json" };
-import { createExtractor, srcDir } from "#test/test-utils.js";
+import {
+  createExtractor,
+  expectObjectProps,
+  srcDir,
+} from "#test/test-utils.js";
 
 // File extensions to ignore (from imports like "./strings.js")
 const IGNORE_KEYS = new Set(["js", "json", "test", "mjs"]);
@@ -14,9 +18,11 @@ describe("strings", () => {
   });
 
   test("Returns values from strings-base.json", () => {
-    expect(strings.product_name).toBe("Products");
-    expect(strings.location_name).toBe("Locations");
-    expect(strings.event_name).toBe("Events");
+    expectObjectProps({
+      product_name: "Products",
+      location_name: "Locations",
+      event_name: "Events",
+    })(strings);
   });
 
   test("Every strings.X usage in codebase has a default in strings-base.json", () => {


### PR DESCRIPTION
Replace consecutive expect(obj.prop).toBe() calls with the declarative expectObjectProps helper across 10 test files. This reduces boilerplate and improves test readability by consolidating property assertions.