### PR TITLE
Clean up unnecessary null checks in codebase

### DIFF
--- a/src/_lib/collections/products.js
+++ b/src/_lib/collections/products.js
@@ -3,7 +3,6 @@ import { filterMap, findDuplicate, memberOf } from "#utils/array-utils.js";
 import { sortItems } from "#utils/sorting.js";
 
 const processGallery = (gallery) => {
-  if (!gallery) return gallery;
   if (Array.isArray(gallery)) return gallery;
   return Object.values(gallery);
 };

--- a/src/_lib/collections/search.js
+++ b/src/_lib/collections/search.js
@@ -6,7 +6,6 @@ import { memoize } from "#utils/memoize.js";
  * Handles full paths like "/categories/premium-widgets.md"
  */
 const normaliseCategory = (category) => {
-  if (!category) return "";
   return category
     .replace(/^\/categories\//, "")
     .replace(/\.md$/, "")

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -250,9 +250,7 @@ const ALLOWED_NULL_CHECKS = new Set([
   "src/_lib/filters/item-filters.js:33", // filterAttributes
   "src/_lib/filters/item-filters.js:62", // attrs
   "src/_lib/filters/item-filters.js:102", // path
-  "src/_lib/collections/products.js:6", // gallery
-  "src/_lib/collections/products.js:72", // options
-  "src/_lib/collections/search.js:9", // category
+  "src/_lib/collections/products.js:71", // options
   "src/_lib/collections/reviews.js:88", // name
   "src/_lib/collections/navigation.js:13", // collection
   "src/_lib/collections/navigation.js:19", // result

--- a/test/unit/collections/products.test.js
+++ b/test/unit/collections/products.test.js
@@ -35,11 +35,6 @@ const option = (sku, name, unit_price, max_quantity = null) => ({
 });
 
 describe("products", () => {
-  test("Returns null/undefined gallery unchanged", () => {
-    expect(processGallery(null)).toBe(null);
-    expect(processGallery(undefined)).toBe(undefined);
-  });
-
   test("Converts object galleries to arrays of filenames", () => {
     const input = {
       0: "image1.jpg",

--- a/test/unit/collections/search.test.js
+++ b/test/unit/collections/search.test.js
@@ -147,11 +147,6 @@ describe("search", () => {
     );
   });
 
-  test("Returns empty string for null/undefined/empty inputs", () => {
-    expect(normaliseCategory(null)).toBe("");
-    expect(normaliseCategory("")).toBe("");
-  });
-
   test("Extracts keywords from product categories", () => {
     const products = [
       {


### PR DESCRIPTION
Investigated all null checks in the specified list and removed 2 that were clearly defensive code:

1. src/_lib/collections/products.js:6 (processGallery)
   - Caller already checks if (item.data.gallery) before calling
   - Defensive null check was testing a situation that never happens

2. src/_lib/collections/search.js:9 (normaliseCategory)
   - Only called via .map(normaliseCategory) on array elements
   - Array elements are strings, not null

Also removed corresponding tests that were testing these impossible code paths.

The remaining 9 null checks in the list are legitimate:
- filterAttributes, attrs, path: handle optional frontmatter data
- options: products may not have options
- name: reviews may not have names
- collection, result: handle template lookups and Array.find() results
- reference, url: handle optional data from frontmatter/navigation

All precommit checks pass.