### PR TITLE
Fix diffByFile to skip non-array entries from current (exceptions)

### DIFF
--- a/test/run-coverage.js
+++ b/test/run-coverage.js
@@ -32,7 +32,7 @@ const diffByFile = (setOp) => (current, allowed) =>
   pipe(
     Object.entries,
     filterMap(
-      ([file]) => allowed[file] !== true,
+      ([file, lines]) => Array.isArray(lines) && allowed[file] !== true,
       ([file, lines]) => {
         const diff = setOp(toSet(allowed[file]))(lines);
         return diff.length > 0 ? [file, diff] : null;


### PR DESCRIPTION
The filterMap predicate only checked if allowed[file] was not true,
but didn't validate that lines from current was actually an array.
When ratchetExceptions passes exceptions as current, entries like
"file.js": true would cause filter() to receive a boolean instead
of an array, triggering "arr.filter is not a function".