### PR TITLE
Move single-use functions to their callers

### DIFF
--- a/src/_data/altTagsLookup.js
+++ b/src/_data/altTagsLookup.js
@@ -3,11 +3,7 @@ import { toObject } from "#utils/object-entries.js";
 
 // Pre-compute a filename -> alt text lookup map
 // This avoids O(n) loops in templates when looking up alt text
-const toFilenameEntry = (entry) => [
+export default toObject(altTags?.images || [], (entry) => [
   entry.path.split("/").pop(),
   entry.alt || "",
-];
-
-const buildLookup = () => toObject(altTags?.images || [], toFilenameEntry);
-
-export default buildLookup();
+]);

--- a/src/_data/metaComputed.js
+++ b/src/_data/metaComputed.js
@@ -4,44 +4,39 @@ import metaData from "#data/meta.json" with { type: "json" };
 import siteData from "#data/site.json" with { type: "json" };
 import { IMAGES_DIR } from "#lib/paths.js";
 
-const getLogoUrl = () => {
-  const logoPath = join(IMAGES_DIR, "logo.png");
-  return fs.existsSync(logoPath) ? `${siteData.url}/images/logo.png` : null;
-};
-
-const getUniqueFounders = () => {
-  const founders = metaData.organization?.founders || [];
-  return [...new Map(founders.map((f) => [f.name, f])).values()];
-};
-
-const getSameAs = () => {
-  const urls = Object.values(siteData.socials || {});
-  return [...new Set(urls.filter((url) => url && !url.startsWith("/")))];
-};
-
-const buildSiteMeta = (logoUrl) => ({
-  name: siteData.name,
-  description: siteData.description,
-  url: siteData.url,
-  ...(logoUrl && { logo: { src: logoUrl, width: 512, height: 512 } }),
-});
-
-const buildOrganization = (logoUrl) => ({
-  name: siteData.name,
-  url: siteData.url,
-  description: metaData.organization?.description || siteData.description,
-  ...(logoUrl && { logo: logoUrl }),
-  ...metaData.organization,
-  founders: getUniqueFounders(),
-  sameAs: getSameAs(),
-});
-
 export default function () {
-  const logoUrl = getLogoUrl();
+  const logoPath = join(IMAGES_DIR, "logo.png");
+  const logoUrl = fs.existsSync(logoPath)
+    ? `${siteData.url}/images/logo.png`
+    : null;
+
+  const founders = metaData.organization?.founders || [];
+  const uniqueFounders = [
+    ...new Map(founders.map((f) => [f.name, f])).values(),
+  ];
+
+  const urls = Object.values(siteData.socials || {});
+  const sameAs = [
+    ...new Set(urls.filter((url) => url && !url.startsWith("/"))),
+  ];
+
   return {
-    site: buildSiteMeta(logoUrl),
+    site: {
+      name: siteData.name,
+      description: siteData.description,
+      url: siteData.url,
+      ...(logoUrl && { logo: { src: logoUrl, width: 512, height: 512 } }),
+    },
     language: metaData.language || "en-GB",
     image: { src: `${siteData.url}/images/placeholder.jpg` },
-    organization: buildOrganization(logoUrl),
+    organization: {
+      name: siteData.name,
+      url: siteData.url,
+      description: metaData.organization?.description || siteData.description,
+      ...(logoUrl && { logo: logoUrl }),
+      ...metaData.organization,
+      founders: uniqueFounders,
+      sameAs,
+    },
   };
 }

--- a/src/_lib/public/ui/quote-steps-progress.js
+++ b/src/_lib/public/ui/quote-steps-progress.js
@@ -4,19 +4,15 @@ import { onReady } from "#public/utils/on-ready.js";
 import { IDS } from "#public/utils/selectors.js";
 import { getTemplate } from "#public/utils/template.js";
 
-function createIndicator(step, index) {
-  const template = getTemplate(IDS.QUOTE_STEP_INDICATOR, document);
-  const li = template.querySelector("li");
-  li.dataset.step = index;
-  li.querySelector('[data-name="name"]').textContent = step.name;
-  li.querySelector('[data-name="index"]').textContent = step.number;
-  return li;
-}
-
 export function renderStepProgress(container, steps, completedSteps) {
   const ul = document.createElement("ul");
   for (const [index, step] of steps.entries()) {
-    ul.appendChild(createIndicator(step, index));
+    const template = getTemplate(IDS.QUOTE_STEP_INDICATOR, document);
+    const li = template.querySelector("li");
+    li.dataset.step = index;
+    li.querySelector('[data-name="name"]').textContent = step.name;
+    li.querySelector('[data-name="index"]').textContent = step.number;
+    ul.appendChild(li);
   }
   container.innerHTML = "";
   container.appendChild(ul);

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -216,7 +216,7 @@ const ALLOWED_NULL_CHECKS = new Set([
   "src/_lib/public/theme/theme-editor.js:284", // target
   "src/_lib/public/theme/theme-editor.js:384", // borderOutput
   "src/_lib/public/cart/cart.js:136", // cartItems
-  "src/_lib/public/ui/shuffle-properties.js:49", // itemsList
+  "src/_lib/public/ui/shuffle-properties.js:13", // itemsList
   "src/_lib/public/cart/quote.js:49", // container
   "src/_lib/public/ui/gallery.js:20", // imageLink
   "src/_lib/public/ui/gallery.js:30", // fullImage
@@ -276,9 +276,7 @@ const ALLOWED_NULL_CHECKS = new Set([
 // Remove files from this list as you refactor them.
 const ALLOWED_SINGLE_USE_FUNCTIONS = new Set([
   "ecommerce-backend/server.js",
-  "src/_data/altTagsLookup.js",
   "src/_data/eleventyComputed.js",
-  "src/_data/metaComputed.js",
   "src/_lib/build/scss.js",
   "src/_lib/collections/categories.js",
   "src/_lib/collections/menus.js",
@@ -287,8 +285,8 @@ const ALLOWED_SINGLE_USE_FUNCTIONS = new Set([
   "src/_lib/collections/search.js",
   "src/_lib/eleventy/responsive-tables.js",
   "src/_lib/filters/item-filters.js",
-  "src/_lib/utils/dom-builder.js",
-  "src/_lib/utils/lazy-loader.js",
+  "src/_lib/utils/dom-builder.js", // Kept separate to manage complexity
+  "src/_lib/utils/lazy-loader.js", // Kept separate to manage complexity
   "src/_lib/public/ui/availability-calendar.js",
   "src/_lib/public/utils/cart-utils.js",
   "src/_lib/public/cart/cart.js",
@@ -298,10 +296,8 @@ const ALLOWED_SINGLE_USE_FUNCTIONS = new Set([
   "src/_lib/public/utils/quote-price-utils.js",
   "src/_lib/public/cart/quote.js",
   "src/_lib/public/cart/quote-steps.js",
-  "src/_lib/public/ui/quote-steps-progress.js",
   "src/_lib/public/ui/scroll-fade.js",
   "src/_lib/public/ui/search.js",
-  "src/_lib/public/ui/shuffle-properties.js",
   "src/_lib/public/ui/slider.js",
   "src/_lib/public/cart/stripe-checkout.js",
   "src/_lib/public/theme/theme-editor-lib.js",


### PR DESCRIPTION
Moved several single-use helper functions inline to reduce indirection and improve code clarity:

- altTagsLookup.js: Inlined toFilenameEntry and buildLookup
- metaComputed.js: Inlined getLogoUrl, getUniqueFounders, getSameAs, buildSiteMeta, and buildOrganization
- quote-steps-progress.js: Inlined createIndicator
- shuffle-properties.js: Inlined all helper functions (nextRandom, swapIndices, shuffleArray, getSeed, isPropertyPage, initPropertyShuffle)

Updated ALLOWED_SINGLE_USE_FUNCTIONS exceptions:
- Removed 4 files that were successfully refactored
- Kept dom-builder.js and lazy-loader.js due to complexity constraints

Updated ALLOWED_NULL_CHECKS line number for shuffle-properties.js after refactoring moved the null check.

Result: -30 lines, improved code clarity by reducing unnecessary function abstractions while maintaining cognitive complexity limits.