### PR TITLE
Refactor GitHub workflows to reduce duplication

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -2,6 +2,8 @@ name: Build and Deploy to Neocities and Bunny CDN
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
   pull_request:
-  push:
-    branches:
-      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
- test.yml: Remove push trigger for main (now called via workflow_call)
- build-and-deploy.yaml: Restrict push trigger to main branch only

Workflow behavior:
- PRs: Run test suite only (test.yml)
- Main commits: Run tests then build/deploy (build-and-deploy.yaml)
- Both workflows can be triggered manually via workflow_dispatch