### PR TITLE
Limit deployments to main branch only

### DIFF
--- a/.github/workflows/add-skus.yml
+++ b/.github/workflows/add-skus.yml
@@ -2,6 +2,8 @@ name: Add SKUs to Products
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "src/products/**"
   workflow_dispatch:


### PR DESCRIPTION
Prevent deployments from being triggered when products are modified on feature branches. SKU generation and subsequent build/deploy now only runs when changes are pushed to main.