### PR TITLE
Restore accidentally deleted type definitions

### DIFF
--- a/src/_lib/collections/reviews.js
+++ b/src/_lib/collections/reviews.js
@@ -112,6 +112,9 @@ const reviewerAvatar = (name) => {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 };
 
+/**
+ * Default reviews truncate limit when not configured
+ */
 const DEFAULT_REVIEWS_LIMIT = 10;
 
 /** Map item to redirect data */
@@ -137,6 +140,11 @@ const reviewsFactory =
 
 /**
  * Factory: items with enough reviews for a separate /reviews page
+ * @param {string} tag - The tag to filter items by
+ * @param {string} reviewsField - The field to check for reviews
+ * @param {(item: any) => any} [processItem] - Optional function to transform items
+ * @param {number} [limitOverride] - Optional limit override for testing
+ * @returns {(collectionApi: any) => Array} Function that takes collectionApi and returns filtered items
  */
 const withReviewsPage = (
   tag,
@@ -154,6 +162,10 @@ const withReviewsPage = (
 
 /**
  * Factory: redirect data for items without enough reviews for a separate page
+ * @param {string} tag - The tag to filter items by
+ * @param {string} reviewsField - The field to check for reviews
+ * @param {number} [limitOverride] - Optional limit override for testing
+ * @returns {(collectionApi: any) => Array} Function that takes collectionApi and returns redirect data
  */
 const reviewsRedirects = (tag, reviewsField, limitOverride) =>
   reviewsFactory(


### PR DESCRIPTION
Re-add JSDoc comments for withReviewsPage, reviewsRedirects, and DEFAULT_REVIEWS_LIMIT that were accidentally removed in the deduplication refactoring (commit 777cd1b). These type annotations provide important documentation about parameter types and return values.