### PR TITLE
Reduce verbose output in customise-cms script

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -23,66 +23,27 @@ content:
       sort:
         - header_text
     fields:
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: header_text
-        type: string
-        label: Header Text
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: body
-        label: Body
-        type: code
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: eleventyNavigation
-        label: Navigation
-        type: object
+      - { name: eleventyNavigation, label: Navigation, type: object }
         fields:
-          - name: key
-            type: string
-          - name: order
-            type: number
-          - name: url
-            type: string
-      - name: layout
-        type: string
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+          - { name: key, type: string }
+          - { name: order, type: number }
+      - { name: layout, type: string }
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: products
@@ -91,42 +52,25 @@ content:
     type: collection
     subfolders: false
     fields:
-      - name: title
-        type: string
-        label: Title
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: categories
-        label: Categories
-        type: reference
+      - { name: title, type: string, label: Title }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: categories, label: Categories, type: reference }
         options:
           collection: categories
           multiple: true
           search: title
           value: "{path}"
           label: "{title}"
-      - name: events
-        label: Events
-        type: reference
+      - { name: events, label: Events, type: reference }
         options:
           collection: events
           multiple: true
           search: title
           value: "{path}"
           label: "{title}"
-      - name: options
-        label: Product Options
-        type: object
-        list: true
+      - { name: options, label: Product Options, type: object, list: true }
         fields:
-          - name: name
-            type: string
-            label: Option Name
-            required: true
+          - { name: name, type: string, label: Option Name, required: true }
           - name: max_quantity
             type: number
             label: Max Quantity
@@ -135,101 +79,41 @@ content:
             type: number
             label: Unit Price (£)
             required: true
-          - name: days
-            type: number
-            label: Days (for hire products)
-      - name: etsy_url
-        label: Etsy URL
-        type: string
-      - name: body
-        label: Body
-        type: code
+          - { name: days, type: number, label: Days (for hire products) }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: features
-        type: string
-        label: Features
-        list: true
+      - { name: features, type: string, label: Features, list: true }
       - name: filter_attributes
         label: Filter Attributes
         type: object
         list: true
         fields:
-          - name: name
-            type: string
-            label: Name
-            required: true
-          - name: value
-            type: string
-            label: Value
-            required: true
-      - name: header_text
-        type: string
-        label: Header Text
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+          - { name: name, type: string, label: Name, required: true }
+          - { name: value, type: string, label: Value, required: true }
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
-      - name: specs
-        label: Specifications
-        type: object
-        list: true
+      - { name: specs, label: Specifications, type: object, list: true }
         fields:
-          - name: name
-            type: string
-            label: Name
-            required: true
-          - name: value
-            type: string
-            label: Value
-            required: true
-      - name: tabs
-        label: Tabs
-        type: object
-        list: true
+          - { name: name, type: string, label: Name, required: true }
+          - { name: value, type: string, label: Value, required: true }
+      - { name: tabs, label: Tabs, type: object, list: true }
         fields:
-          - name: title
-            type: string
-            label: Title
-            required: true
-          - name: body
-            label: Body
-            type: code
+          - { name: title, type: string, label: Title, required: true }
+          - { name: body, label: Body, type: code }
             options:
               language: markdown
             required: true
@@ -240,63 +124,25 @@ content:
     subfolders: false
     filename: "{primary}.md"
     fields:
-      - name: title
-        type: string
-        label: Title
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: body
-        label: Body
-        type: code
+      - { name: title, type: string, label: Title }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: featured
-        type: boolean
-        label: Featured
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: header_text
-        type: string
-        label: Header Text
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+      - { name: featured, type: boolean, label: Featured }
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: news
@@ -305,69 +151,31 @@ content:
     type: collection
     subfolders: false
     fields:
-      - name: title
-        type: string
-        label: Title
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: date
-        label: Date
-        type: date
-      - name: author
-        label: Author
-        type: reference
+      - { name: title, type: string, label: Title }
+      - { name: date, label: Date, type: date }
+      - { name: author, label: Author, type: reference }
         options:
           collection: team
           multiple: false
           search: title
           value: "{path}"
           label: "{title}"
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: body
-        label: Body
-        type: code
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: header_text
-        type: string
-        label: Header Text
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: events
@@ -386,75 +194,34 @@ content:
       sort:
         - title
     fields:
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: title
-        type: string
-        label: Title
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: event_date
-        label: Event Date
-        type: date
-        required: false
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: title, type: string, label: Title }
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: event_date, label: Event Date, type: date, required: false }
       - name: recurring_date
         type: string
         label: Recurring Date (e.g. "Every Friday at 2 PM")
         required: false
-      - name: event_location
-        type: string
-        label: Event Location
+      - { name: event_location, type: string, label: Event Location }
       - name: map_embed_src
         type: string
         label: Map Embed URL
         required: false
-      - name: body
-        label: Body
-        type: code
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: header_text
-        type: string
-        label: Header Text
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: team
@@ -464,52 +231,20 @@ content:
     subfolders: false
     filename: "{primary}.md"
     fields:
-      - name: title
-        type: string
-        label: Title
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: snippet
-        type: string
-        label: Role
-      - name: image
-        type: image
-        label: Profile Image
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: body
-        label: Biography
-        type: code
+      - { name: title, type: string, label: Title }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: snippet, type: string, label: Role }
+      - { name: image, type: image, label: Profile Image }
+      - { name: body, label: Biography, type: code }
         options:
           language: markdown
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: reviews
@@ -518,55 +253,26 @@ content:
     type: collection
     subfolders: false
     fields:
-      - name: name
-        type: string
-        label: Name
-      - name: url
-        type: string
-        label: URL
-      - name: rating
-        type: number
-        label: Rating
-      - name: thumbnail
-        type: image
-        label: Reviewer Photo
-      - name: body
-        label: Body
-        type: code
+      - { name: name, type: string, label: Name }
+      - { name: url, type: string, label: URL }
+      - { name: rating, type: number, label: Rating }
+      - { name: thumbnail, type: image, label: Reviewer Photo }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: products
-        label: Products
-        type: reference
+      - { name: products, label: Products, type: reference }
         options:
           collection: products
           multiple: true
           search: title
           value: "{path}"
           label: "{title}"
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
   - name: locations
     label: Locations
     path: src/locations
@@ -581,63 +287,31 @@ content:
       sort:
         - title
     fields:
-      - name: title
-        type: string
-        label: Title
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: categories
-        label: Categories
-        type: reference
+      - { name: title, type: string, label: Title }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: categories, label: Categories, type: reference }
         options:
           collection: categories
           multiple: true
           search: title
           value: "{path}"
           label: "{title}"
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: body
-        label: Body
-        type: code
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: properties
@@ -656,100 +330,43 @@ content:
       sort:
         - title
     fields:
-      - name: title
-        type: string
-        label: Title
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: featured
-        type: boolean
-        label: Featured
-      - name: locations
-        label: Locations
-        type: reference
+      - { name: title, type: string, label: Title }
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: featured, type: boolean, label: Featured }
+      - { name: locations, label: Locations, type: reference }
         options:
           collection: locations
           multiple: true
           search: title
           value: "{path}"
           label: "{title}"
-      - name: bedrooms
-        type: number
-        label: Bedrooms
-      - name: bathrooms
-        type: number
-        label: Bathrooms
-      - name: sleeps
-        type: number
-        label: Sleeps
-      - name: price_per_night
-        type: number
-        label: Price Per Night
-      - name: features
-        type: string
-        label: Features
-        list: true
-      - name: body
-        label: Body
-        type: code
+      - { name: bedrooms, type: number, label: Bedrooms }
+      - { name: bathrooms, type: number, label: Bathrooms }
+      - { name: sleeps, type: number, label: Sleeps }
+      - { name: price_per_night, type: number, label: Price Per Night }
+      - { name: features, type: string, label: Features, list: true }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
-      - name: specs
-        label: Specifications
-        type: object
-        list: true
+      - { name: specs, label: Specifications, type: object, list: true }
         fields:
-          - name: name
-            type: string
-            label: Name
-            required: true
-          - name: value
-            type: string
-            label: Value
-            required: true
+          - { name: name, type: string, label: Name, required: true }
+          - { name: value, type: string, label: Value, required: true }
   - name: guides
     label: Guides
     path: src/guides
@@ -757,60 +374,24 @@ content:
     subfolders: false
     filename: "{primary}.md"
     fields:
-      - name: title
-        type: string
-        label: Title
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: body
-        label: Body
-        type: code
+      - { name: title, type: string, label: Title }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: header_text
-        type: string
-        label: Header Text
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: menus
@@ -819,60 +400,25 @@ content:
     type: collection
     subfolders: false
     fields:
-      - name: title
-        type: string
-        label: Title
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: order
-        type: number
-        label: Order
-      - name: header_image
-        type: image
-        label: Header Image
-      - name: subtitle
-        type: string
-        label: Subtitle
-      - name: body
-        label: Body
-        type: code
+      - { name: title, type: string, label: Title }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: order, type: number, label: Order }
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: meta_title
-        type: string
-        label: Meta Title
-        maxlength: 55
+      - { name: meta_title, type: string, label: Meta Title, maxlength: 55 }
       - name: meta_description
         type: string
         label: Meta Description
         maxlength: 155
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: menu-categories
@@ -881,55 +427,26 @@ content:
     type: collection
     subfolders: false
     fields:
-      - name: name
-        type: string
-        label: Name
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: order
-        type: number
-        label: Order
-      - name: menus
-        label: Menus
-        type: reference
+      - { name: name, type: string, label: Name }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: order, type: number, label: Order }
+      - { name: menus, label: Menus, type: reference }
         options:
           collection: menus
           multiple: true
           search: title
           value: "{path}"
           label: "{title}"
-      - name: body
-        label: Body
-        type: code
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: menu-items
@@ -938,64 +455,29 @@ content:
     type: collection
     subfolders: false
     fields:
-      - name: name
-        type: string
-        label: Name
-      - name: thumbnail
-        type: image
-        label: Thumbnail
-      - name: price
-        type: string
-        label: Price
-      - name: is_vegan
-        type: boolean
-        label: Is Vegan
-      - name: is_gluten_free
-        type: boolean
-        label: Is Gluten Free
-      - name: menu_categories
-        label: Menu Categories
-        type: reference
+      - { name: name, type: string, label: Name }
+      - { name: thumbnail, type: image, label: Thumbnail }
+      - { name: price, type: string, label: Price }
+      - { name: is_vegan, type: boolean, label: Is Vegan }
+      - { name: is_gluten_free, type: boolean, label: Is Gluten Free }
+      - { name: menu_categories, label: Menu Categories, type: reference }
         options:
           collection: menu-categories
           multiple: true
           search: name
           value: "{path}"
           label: "{name}"
-      - name: description
-        type: string
-        label: Description
-      - name: body
-        label: Body
-        type: code
+      - { name: description, type: string, label: Description }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
-      - name: permalink
-        type: string
-        label: Permalink
-      - name: redirect_from
-        type: string
-        label: Redirect From
-        list: true
-      - name: faqs
-        label: FAQs
-        type: object
-        list: true
+      - { name: permalink, type: string, label: Permalink }
+      - { name: redirect_from, type: string, label: Redirect From, list: true }
+      - { name: faqs, label: FAQs, type: object, list: true }
         fields:
-          - name: question
-            type: string
-            label: Question
-            required: true
-          - name: answer
-            type: string
-            label: Answer
-            required: true
-          - name: order
-            type: number
-            label: Order
-      - name: gallery
-        type: image
-        label: Gallery
+          - { name: question, type: string, label: Question, required: true }
+          - { name: answer, type: string, label: Answer, required: true }
+      - { name: gallery, type: image, label: Gallery }
         options:
           multiple: true
   - name: snippets
@@ -1005,12 +487,8 @@ content:
     subfolders: false
     filename: "{primary}.md"
     fields:
-      - name: name
-        type: string
-        label: Name
-      - name: body
-        label: Body
-        type: code
+      - { name: name, type: string, label: Name }
+      - { name: body, label: Body, type: code }
         options:
           language: markdown
   - name: homepage
@@ -1039,119 +517,52 @@ content:
     type: file
     path: src/_data/site.json
     fields:
-      - name: name
-        type: string
-        label: Site Name
-      - name: url
-        type: string
-        label: Site URL
-      - name: opening_times
-        label: Opening Times
-        type: object
-        list: true
+      - { name: name, type: string, label: Site Name }
+      - { name: url, type: string, label: Site URL }
+      - { name: opening_times, label: Opening Times, type: object, list: true }
         fields:
-          - name: day
-            type: string
-            label: Day
-            required: true
-          - name: hours
-            type: string
-            label: Hours
-            required: true
-      - name: socials
-        label: Social Media Links
-        type: object
+          - { name: day, type: string, label: Day, required: true }
+          - { name: hours, type: string, label: Hours, required: true }
+      - { name: socials, label: Social Media Links, type: object }
         fields:
-          - name: Github
-            type: string
-            label: Github
-          - name: Forgejo
-            type: string
-            label: Forgejo
-          - name: Facebook
-            type: string
-            label: Facebook
-          - name: Instagram
-            type: string
-            label: Instagram
-          - name: TikTok
-            type: string
-            label: TikTok
-          - name: Google
-            type: string
-            label: Google
-          - name: WhatsApp
-            type: string
-            label: WhatsApp
-          - name: RSS
-            type: string
-            label: RSS
-      - name: map_embed_src
-        type: string
-        label: Map Embed URL
+          - { name: Github, type: string, label: Github }
+          - { name: Forgejo, type: string, label: Forgejo }
+          - { name: Facebook, type: string, label: Facebook }
+          - { name: Instagram, type: string, label: Instagram }
+          - { name: TikTok, type: string, label: TikTok }
+          - { name: Google, type: string, label: Google }
+          - { name: WhatsApp, type: string, label: WhatsApp }
+          - { name: RSS, type: string, label: RSS }
+      - { name: map_embed_src, type: string, label: Map Embed URL }
   - name: meta
     label: Meta Configuration
     type: file
     path: src/_data/meta.json
     fields:
-      - name: language
-        type: string
-        label: Language Code
-        default: en-GB
-      - name: organization
-        label: Organization
-        type: object
+      - { name: language, type: string, label: Language Code, default: en-GB }
+      - { name: organization, label: Organization, type: object }
         fields:
-          - name: description
-            type: string
-            label: Organization Description
-          - name: legalName
-            type: string
-            label: Legal Name
-          - name: foundingDate
-            type: string
-            label: Founding Date
-          - name: founders
-            label: Founders
-            type: object
-            list: true
+          - { name: description, type: string, label: Organization Description }
+          - { name: legalName, type: string, label: Legal Name }
+          - { name: foundingDate, type: string, label: Founding Date }
+          - { name: founders, label: Founders, type: object, list: true }
             fields:
-              - name: name
-                type: string
-                label: Name
-          - name: address
-            label: Address
-            type: object
+              - { name: name, type: string, label: Name }
+          - { name: address, label: Address, type: object }
             fields:
-              - name: streetAddress
-                type: string
-                label: Street Address
-              - name: addressLocality
-                type: string
-                label: City
-              - name: addressRegion
-                type: string
-                label: Region/State
-              - name: postalCode
-                type: string
-                label: Postal Code
-              - name: addressCountry
-                type: string
-                label: Country Code
+              - { name: streetAddress, type: string, label: Street Address }
+              - { name: addressLocality, type: string, label: City }
+              - { name: addressRegion, type: string, label: Region/State }
+              - { name: postalCode, type: string, label: Postal Code }
+              - { name: addressCountry, type: string, label: Country Code }
           - name: contactPoint
             label: Contact Points
             type: object
             list: true
             fields:
-              - name: telephone
-                type: string
-                label: Telephone
-              - name: contactType
-                type: string
-                label: Contact Type
-              - name: areaServed
-                type: string
-                label: Area Served
+              - { name: telephone, type: string, label: Telephone }
+              - { name: contactType, type: string, label: Contact Type }
+              - { name: areaServed, type: string, label: Area Served }
               - name: availableLanguage
                 type: string
                 label: Available Languages
@@ -1161,13 +572,7 @@ content:
     type: file
     path: src/_data/alt-tags.json
     fields:
-      - name: images
-        type: object
-        list: true
+      - { name: images, type: object, list: true }
         fields:
-          - name: path
-            type: image
-            label: Image
-          - name: alt
-            type: string
-            label: Alt Text
+          - { name: path, type: image, label: Image }
+          - { name: alt, type: string, label: Alt Text }

--- a/scripts/customise-cms/compact-yaml.js
+++ b/scripts/customise-cms/compact-yaml.js
@@ -1,0 +1,155 @@
+/**
+ * YAML compaction utility
+ *
+ * Compacts multi-line YAML objects to single lines when they fit within 80 characters.
+ * For example, converts:
+ *   - name: foo
+ *     type: string
+ *     label: Foo
+ * To:
+ *   - { name: foo, type: string, label: Foo }
+ */
+
+/**
+ * Extract indentation level from a line
+ */
+const getIndent = (line) => {
+  const match = line.match(/^( *)/);
+  return match ? match[1].length : 0;
+};
+
+/**
+ * Check if a line should be skipped when converting to inline format
+ */
+const shouldSkipLine = (trimmed) => {
+  if (!trimmed || trimmed.startsWith("#")) return true;
+  if (trimmed === "-") return true;
+  if (trimmed.endsWith(":") && !trimmed.includes(": ")) return true;
+  return false;
+};
+
+/**
+ * Extract a key-value pair from a YAML line
+ */
+const extractKeyValue = (line) => {
+  const trimmed = line.trim();
+  const colonIndex = trimmed.indexOf(":");
+  if (colonIndex === -1) return null;
+
+  const key = trimmed.substring(0, colonIndex).trim();
+  const cleanKey = key.replace(/^-\s*/, "");
+  const value = trimmed.substring(colonIndex + 1).trim();
+
+  // Only return simple values (no nested structures)
+  if (!value || value.startsWith("[") || value.startsWith("{")) {
+    return null;
+  }
+
+  return { key: cleanKey, value };
+};
+
+/**
+ * Convert a YAML object (as lines) to inline format
+ * e.g., { name: foo, type: string, label: Foo }
+ */
+const objectToInline = (lines) => {
+  const pairs = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (shouldSkipLine(trimmed)) continue;
+
+    const pair = extractKeyValue(line);
+    if (pair) {
+      pairs.push(`${pair.key}: ${pair.value}`);
+    }
+  }
+
+  return pairs.length > 0 ? `{ ${pairs.join(", ")} }` : null;
+};
+
+/**
+ * Collect lines that belong to a YAML list item object
+ */
+const collectObjectLines = (lines, startIndex, listIndent) => {
+  const objectLines = [lines[startIndex]];
+  let j = startIndex + 1;
+
+  while (j < lines.length) {
+    const nextLine = lines[j];
+    const nextIndent = getIndent(nextLine);
+    const nextTrimmed = nextLine.trim();
+
+    // Stop if we've dedented back to list level or less
+    if (nextIndent <= listIndent && nextTrimmed) {
+      break;
+    }
+
+    // Stop at nested complex structures (lines ending with : that start new blocks)
+    if (nextTrimmed.endsWith(":") && nextIndent > listIndent) {
+      break;
+    }
+
+    objectLines.push(nextLine);
+    j++;
+  }
+
+  return { objectLines, nextIndex: j };
+};
+
+/**
+ * Try to create a compacted inline version of object lines
+ */
+const tryCompactLine = (objectLines, listIndent) => {
+  if (objectLines.length < 2) {
+    return null; // Single line, no benefit to compacting
+  }
+
+  const inlineVersion = objectToInline(objectLines);
+  if (!inlineVersion) {
+    return null; // Couldn't create inline version
+  }
+
+  const fullInlineLine = `${" ".repeat(listIndent)}- ${inlineVersion}`;
+
+  // Only use inline version if it stays under 80 chars
+  if (fullInlineLine.length <= 80) {
+    return fullInlineLine;
+  }
+
+  return null; // Line too long
+};
+
+/**
+ * Compact YAML by converting multi-line objects to inline format when appropriate
+ */
+export const compactYaml = (yamlString) => {
+  const lines = yamlString.split("\n");
+  const result = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const indent = getIndent(line);
+    const trimmed = line.trim();
+
+    // Look for list item start (- key: value pattern)
+    if (trimmed.startsWith("- ") && trimmed.includes(":")) {
+      const { objectLines, nextIndex } = collectObjectLines(lines, i, indent);
+      const compactedLine = tryCompactLine(objectLines, indent);
+
+      if (compactedLine) {
+        result.push(compactedLine);
+        i = nextIndex;
+      } else {
+        result.push(line);
+        i++;
+      }
+    } else {
+      result.push(line);
+      i++;
+    }
+  }
+
+  return result.join("\n");
+};

--- a/scripts/customise-cms/generate-full.js
+++ b/scripts/customise-cms/generate-full.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+
 /**
  * Generate Full .pages.yml Script
  *
@@ -8,6 +9,7 @@
  * Usage: bun run generate-pages-yml
  */
 
+import { compactYaml } from "#scripts/customise-cms/compact-yaml.js";
 import { createDefaultConfig } from "#scripts/customise-cms/config.js";
 import { generatePagesYaml } from "#scripts/customise-cms/generator.js";
 import { writePagesYaml } from "#scripts/customise-cms/writer.js";
@@ -18,7 +20,8 @@ const main = async () => {
   );
 
   const config = createDefaultConfig();
-  const yaml = generatePagesYaml(config);
+  let yaml = generatePagesYaml(config);
+  yaml = compactYaml(yaml);
 
   await writePagesYaml(yaml);
 

--- a/scripts/customise-cms/index.js
+++ b/scripts/customise-cms/index.js
@@ -10,6 +10,7 @@
  * on subsequent runs.
  */
 
+import { compactYaml } from "#scripts/customise-cms/compact-yaml.js";
 import { loadCmsConfig, saveCmsConfig } from "#scripts/customise-cms/config.js";
 import { generatePagesYaml } from "#scripts/customise-cms/generator.js";
 import { askQuestions } from "#scripts/customise-cms/prompts.js";
@@ -27,7 +28,8 @@ const main = async () => {
   }
 
   const config = await askQuestions(existingConfig);
-  const yaml = generatePagesYaml(config);
+  let yaml = generatePagesYaml(config);
+  yaml = compactYaml(yaml);
 
   await saveCmsConfig(config);
   await writePagesYaml(yaml);


### PR DESCRIPTION
Creates a new post-processing step that compacts multi-line YAML objects to single lines when they fit within 80 characters. For example, converts:

  - name: foo
    type: string
    label: Foo

to:

  - { name: foo, type: string, label: Foo }

This improves readability without requiring changes to existing schema generation code. The compaction:
- Only applies to objects that fit within 80 characters
- Preserves multi-line format for complex objects with nested structures
- Runs as a final processing step after YAML generation