### PR TITLE
Add src support to media customization

### DIFF
--- a/scripts/customise-cms/generator.js
+++ b/scripts/customise-cms/generator.js
@@ -510,6 +510,7 @@ export const generatePagesYaml = (config) => {
   const hasSrcFolder = config.hasSrcFolder ?? true;
   const customHomePage = config.customHomePage ?? false;
   const dataPath = getDataPath(hasSrcFolder);
+  const imagesPath = hasSrcFolder ? "src/images" : "images";
 
   // Build content array, conditionally including homepage
   const contentArray = [
@@ -522,9 +523,9 @@ export const generatePagesYaml = (config) => {
 
   const pagesConfig = {
     media: {
-      input: "src/images",
+      input: imagesPath,
       output: "/images",
-      path: "src/images",
+      path: imagesPath,
       categories: ["image"],
     },
     settings: {

--- a/test/unit/scripts/customise-cms.test.js
+++ b/test/unit/scripts/customise-cms.test.js
@@ -369,6 +369,29 @@ describe("customise-cms generator", () => {
     expect(yaml).toContain("name: pages");
   });
 
+  test("generatePagesYaml uses src paths when hasSrcFolder is true", () => {
+    const config = {
+      collections: ["pages"],
+      features: {
+        permalinks: false,
+        redirects: false,
+        faqs: false,
+        specs: false,
+        features: false,
+        galleries: false,
+      },
+      hasSrcFolder: true,
+    };
+    const yaml = generatePagesYaml(config);
+
+    expect(yaml).toContain("path: src/_data/site.json");
+    expect(yaml).toContain("path: src/_data/meta.json");
+    expect(yaml).toContain("path: src/_data/alt-tags.json");
+    expect(yaml).toContain("path: src/pages");
+    expect(yaml).toContain("input: src/images");
+    expect(yaml).toContain("path: src/images");
+  });
+
   test("generatePagesYaml adjusts paths when no src folder", () => {
     const config = {
       collections: ["pages"],
@@ -388,6 +411,8 @@ describe("customise-cms generator", () => {
     expect(yaml).toContain("path: _data/meta.json");
     expect(yaml).toContain("path: _data/alt-tags.json");
     expect(yaml).toContain("path: pages");
+    expect(yaml).toContain("input: images");
+    expect(yaml).toContain("path: images");
   });
 
   test("generatePagesYaml excludes homepage when customHomePage is true", () => {


### PR DESCRIPTION
The media configuration in generatePagesYaml was hardcoded to use "src/images" regardless of the hasSrcFolder setting. This meant that projects without a src folder would get incorrect media paths in their .pages.yml configuration.

Changes:
- Add imagesPath variable that uses "src/images" when hasSrcFolder is true, or "images" when false
- Use imagesPath for both media.input and media.path fields
- Add test to verify src paths are used when hasSrcFolder is true
- Update existing test to verify media paths adjust when no src folder

All 343 tests pass.