### PR TITLE
Handle undated events in collections

### DIFF
--- a/src/_layouts/events.html
+++ b/src/_layouts/events.html
@@ -29,3 +29,7 @@ layout: base
     <p>No past {{ strings.event_name | downcase }} to display.</p>
   {% endif %}
 {% endif %}
+
+{% if categorisedEvents.show.undated %}
+  {%- include "items.html", items: categorisedEvents.undated -%}
+{% endif %}

--- a/src/_lib/collections/events.js
+++ b/src/_lib/collections/events.js
@@ -12,7 +12,7 @@ const getFeaturedEvents = (events) =>
 const fromMap = (map, key, defaultVal = []) => map.get(key) ?? defaultVal;
 
 /**
- * Categorise events into upcoming, past, and regular groups
+ * Categorise events into upcoming, past, regular, and undated groups
  * Uses functional groupBy - no mutable objects or loops
  */
 export const categoriseEvents = memoize((events) => {
@@ -21,7 +21,7 @@ export const categoriseEvents = memoize((events) => {
 
   const grouped = groupBy(events, (event) => {
     if (event.data.recurring_date) return "regular";
-    if (!event.data.event_date) return null;
+    if (!event.data.event_date) return "undated";
     const date = new Date(event.data.event_date);
     date.setHours(0, 0, 0, 0);
     return date >= now ? "upcoming" : "past";
@@ -38,15 +38,18 @@ export const categoriseEvents = memoize((events) => {
       new Date(a.data.event_date).getTime(),
   )(fromMap(grouped, "past"));
   const regular = sort(sortItems)(fromMap(grouped, "regular"));
+  const undated = sort(sortItems)(fromMap(grouped, "undated"));
 
   return {
     upcoming,
     past,
     regular,
+    undated,
     show: {
       upcoming: upcoming.length > 0,
       regular: regular.length > 0,
       past: past.length > 0,
+      undated: undated.length > 0,
     },
   };
 });

--- a/test/unit/collections/events-utils.js
+++ b/test/unit/collections/events-utils.js
@@ -8,16 +8,21 @@ import { map } from "#utils/array-utils.js";
 
 /**
  * Assert event categorization counts
- * @param {Object} result - Result object with upcoming, past, regular arrays
+ * @param {Object} result - Result object with upcoming, past, regular, undated arrays
  * @param {Object} options - Expected counts
  * @param {number} options.upcoming - Expected upcoming events
  * @param {number} options.past - Expected past events
  * @param {number} options.regular - Expected regular events
+ * @param {number} options.undated - Expected undated events
  */
-const expectEventCounts = (result, { upcoming = 0, past = 0, regular = 0 }) => {
+const expectEventCounts = (
+  result,
+  { upcoming = 0, past = 0, regular = 0, undated = 0 },
+) => {
   expect(result.upcoming.length).toBe(upcoming);
   expect(result.past.length).toBe(past);
   expect(result.regular.length).toBe(regular);
+  expect(result.undated.length).toBe(undated);
 };
 
 /**
@@ -27,11 +32,13 @@ const expectEventCounts = (result, { upcoming = 0, past = 0, regular = 0 }) => {
  * @param {boolean} expected.upcoming - Should upcoming events be shown
  * @param {boolean} expected.regular - Should regular events be shown
  * @param {boolean} expected.past - Should past events be shown
+ * @param {boolean} expected.undated - Should undated events be shown
  */
-const expectShowState = (result, { upcoming, regular, past }) => {
+const expectShowState = (result, { upcoming, regular, past, undated }) => {
   expect(result.show.upcoming).toBe(upcoming);
   expect(result.show.regular).toBe(regular);
   expect(result.show.past).toBe(past);
+  expect(result.show.undated).toBe(undated);
 };
 
 /**
@@ -64,18 +71,21 @@ const formatDateString = (date) => date.toISOString().split("T")[0];
  * @param {Date} [options.date] - Explicit date for the event
  * @param {number} [options.daysOffset=30] - Days from today (positive=future, negative=past)
  * @param {string} [options.recurring] - Recurring date string (e.g., "Every Monday")
+ * @param {boolean} [options.undated] - Create event without date
  * @returns {Object} Event fixture with { data: { title, event_date|recurring_date, ... } }
  *
  * @example
  * createEvent({ title: "Summer Fest", daysOffset: 60 })
  * createEvent({ title: "Weekly Meetup", recurring: "Every Monday" })
  * createEvent({ title: "Past Event", daysOffset: -30 })
+ * createEvent({ title: "No Date Event", undated: true })
  */
 const createEvent = ({
   title,
   date,
   daysOffset = 30,
   recurring,
+  undated,
   ...extraData
 } = {}) => {
   if (recurring !== undefined) {
@@ -83,6 +93,15 @@ const createEvent = ({
       data: {
         title: title ?? "Recurring Event",
         recurring_date: recurring,
+        ...extraData,
+      },
+    };
+  }
+
+  if (undated) {
+    return {
+      data: {
+        title: title ?? "Undated Event",
         ...extraData,
       },
     };


### PR DESCRIPTION
Events that have neither event_date nor recurring_date are now categorised as "undated" instead of being dropped. These are displayed at the end of the events page without a heading.