### PR TITLE
Add TypeScript annotations to eliminate null checks

### DIFF
--- a/src/_lib/collections/reviews.js
+++ b/src/_lib/collections/reviews.js
@@ -55,11 +55,10 @@ const getRating = (reviews, slug, field) => {
 
 /**
  * Convert numeric rating to star emojis
+ * @param {number} rating - The numeric rating (1-5)
+ * @returns {string} Star emojis repeated by the rating count
  */
-const ratingToStars = (rating) => {
-  if (rating === null || rating === undefined) return "";
-  return "⭐️".repeat(rating);
-};
+const ratingToStars = (rating) => "⭐️".repeat(rating);
 
 /**
  * Predefined list of slightly dark colors for avatar backgrounds

--- a/test/unit/collections/reviews.test.js
+++ b/test/unit/collections/reviews.test.js
@@ -252,11 +252,6 @@ describe("reviews", () => {
     expect(ratingToStars(5)).toBe("⭐️⭐️⭐️⭐️⭐️");
   });
 
-  test("Returns empty string for null rating", () => {
-    expect(ratingToStars(null)).toBe("");
-    expect(ratingToStars(undefined)).toBe("");
-  });
-
   test("Extracts first and last initials from full name", () => {
     expect(getInitials("John Smith")).toBe("JS");
     expect(getInitials("Alice Bob Carol")).toBe("AC");


### PR DESCRIPTION
…fensive code

Added JSDoc type annotations to the ratingToStars function to declare it accepts a `number` rating parameter. Audited call sites to determine if null/undefined checks were necessary:

- Template guards the call with `if rating` before piping to ratingToStars
- getRating() returns number | null (never undefined)
- Null check tests were testing defensive code, not actual usage

Result: Removed the unnecessary null/undefined defensive check and simplified the function to a single expression. All tests pass.