### PR TITLE
Add PostToolUse hook for linting

### DIFF
--- a/.claude.json
+++ b/.claude.json
@@ -1,0 +1,8 @@
+{
+  "hooks": {
+    "postToolUse": {
+      "Write": "bun run lint || true",
+      "Edit": "bun run lint || true"
+    }
+  }
+}


### PR DESCRIPTION
Adds Claude Code hook that runs Biome linter after Write/Edit tool calls. Uses || true to show lint errors without blocking workflow.