### PR TITLE
Remove item-filters.js from ALLOWED_HTML_IN_JS exception

### DIFF
--- a/src/_includes/filter-description.html
+++ b/src/_includes/filter-description.html
@@ -1,0 +1,4 @@
+{%- for part in filterPage.filterDescription -%}
+  {%- if forloop.index0 > 0 -%}, {% endif -%}
+  {{ part.key }}: <strong>{{ part.value }}</strong>
+{%- endfor -%}

--- a/src/_lib/filters/item-filters.js
+++ b/src/_lib/filters/item-filters.js
@@ -253,14 +253,15 @@ const generateFilterCombinations = memoize((items) => {
 });
 
 /**
- * Build a filter description string from filters using display lookup
- * { size: "compact", type: "pro" } => "Size: compact, Type: pro"
+ * Build filter description parts from filters using display lookup
+ * Returns structured data for template rendering
+ * { size: "compact", type: "pro" } => [{ key: "Size", value: "compact" }, ...]
  */
 const buildFilterDescription = (filters, displayLookup) =>
-  mapEntries(
-    (key, value) =>
-      `${displayLookup[key]}: <strong>${displayLookup[value]}</strong>`,
-  )(filters).join(", ");
+  mapEntries((key, value) => ({
+    key: displayLookup[key],
+    value: displayLookup[value],
+  }))(filters);
 
 /**
  * Build pre-computed filter UI data for templates

--- a/src/pages/filtered-products.html
+++ b/src/pages/filtered-products.html
@@ -14,4 +14,4 @@ header_text: Search Results
 
 <h1>{{ strings.product_name }}</h1>
 
-<p>Showing {{ filterPage.count }} product{% if filterPage.count != 1 %}s{% endif %} matching: {{ filterPage.filterDescription }}</p>
+<p>Showing {{ filterPage.count }} product{% if filterPage.count != 1 %}s{% endif %} matching: {% include 'filter-description.html' %}</p>

--- a/src/pages/filtered-properties.html
+++ b/src/pages/filtered-properties.html
@@ -19,5 +19,5 @@ header_text: Search Results
   Showing
   <strong>{{ filterPage.count }}</strong>
   propert{% if filterPage.count == 1 %}y{% else %}ies{% endif %}
-  matching: {{ filterPage.filterDescription }}
+  matching: {% include 'filter-description.html' %}
 </p>

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -77,9 +77,6 @@ const ALLOWED_HTML_IN_JS = new Set([
 
   // Collections with embedded HTML/SVG
   "src/_lib/collections/reviews.js",
-
-  // Filters with HTML formatting
-  "src/_lib/filters/item-filters.js",
 ]);
 
 // ============================================

--- a/test/unit/filters/item-filters.test.js
+++ b/test/unit/filters/item-filters.test.js
@@ -271,7 +271,7 @@ describe("item-filters", () => {
   });
 
   // buildFilterDescription tests
-  test("Uses display lookup for human-readable descriptions", () => {
+  test("Returns structured data with display values for template rendering", () => {
     const filters = { "pet-friendly": "yes", type: "cottage" };
     const displayLookup = {
       "pet-friendly": "Pet Friendly",
@@ -282,8 +282,9 @@ describe("item-filters", () => {
 
     const result = buildFilterDescription(filters, displayLookup);
 
-    expect(result.includes("Pet Friendly: <strong>Yes</strong>")).toBe(true);
-    expect(result.includes("Type: <strong>Cottage</strong>")).toBe(true);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toContainEqual({ key: "Pet Friendly", value: "Yes" });
+    expect(result).toContainEqual({ key: "Type", value: "Cottage" });
   });
 
   // Integration test: URL generation with spaces


### PR DESCRIPTION
Refactor buildFilterDescription to return structured data instead of
HTML strings. Move HTML formatting to a new filter-description.html
template include, following separation of concerns principles.