### PR TITLE
Remove js-config.js from ALLOWED_HTML_IN_JS exception

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -32,7 +32,7 @@
     href="{{ page.url | canonicalUrl }}"
   >
 
-  {% jsConfigScript %}
+  {%- include "js-config-script.html" -%}
 
   <script
     type="module"

--- a/src/_includes/js-config-script.html
+++ b/src/_includes/js-config-script.html
@@ -1,0 +1,1 @@
+<script id="site-config" type="application/json">{{ config | jsConfigJson }}</script>

--- a/src/_lib/eleventy/js-config.js
+++ b/src/_lib/eleventy/js-config.js
@@ -1,25 +1,21 @@
-// Generates a JSON script tag with site config for JavaScript consumption
+// Generates JSON config for JavaScript consumption
 // Only includes keys that have non-null values
 
-import getConfig from "#data/config.js";
 import { toObject } from "#utils/object-entries.js";
 
 const JS_CONFIG_KEYS = ["cart_mode", "checkout_api_url", "product_mode"];
 
-// Core function to build the config script HTML - exported for use in tests
-export function buildJsConfigScript(config) {
+// Core function to build the config JSON - exported for use in tests
+export function buildJsConfigJson(config) {
   const jsConfig = toObject(
     JS_CONFIG_KEYS.filter((key) => config[key] != null),
     (key) => [key, config[key]],
   );
-  return `<script id="site-config" type="application/json">${JSON.stringify(jsConfig)}</script>`;
+  return JSON.stringify(jsConfig);
 }
 
 export function configureJsConfig(eleventyConfig) {
-  eleventyConfig.addShortcode("jsConfigScript", () => {
-    // Import config directly rather than relying on template context
-    // which may not be reliably available in all build contexts
-    const config = getConfig();
-    return buildJsConfigScript(config);
-  });
+  eleventyConfig.addFilter("jsConfigJson", (config) =>
+    buildJsConfigJson(config),
+  );
 }

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -72,7 +72,6 @@ const ALLOWED_HTML_IN_JS = new Set([
   // Server-side Eleventy plugins generating HTML
   "src/_lib/eleventy/opening-times.js",
   "src/_lib/eleventy/recurring-events.js",
-  "src/_lib/eleventy/js-config.js",
   "src/_lib/eleventy/responsive-tables.js",
 
   // Collections with embedded HTML/SVG
@@ -269,7 +268,7 @@ const ALLOWED_TEST_ONLY_EXPORTS = new Set([
   "src/_lib/eleventy/ical.js:configureICal",
   "src/_lib/eleventy/ical.js:eventIcal",
   "src/_lib/eleventy/ical.js:isOneOffEvent",
-  "src/_lib/eleventy/js-config.js:buildJsConfigScript",
+  "src/_lib/eleventy/js-config.js:buildJsConfigJson",
   "src/_lib/eleventy/js-config.js:configureJsConfig",
   "src/_lib/eleventy/layout-aliases.js:configureLayoutAliases",
   "src/_lib/eleventy/opening-times.js:configureOpeningTimes",

--- a/test/unit/frontend/checkout.test.js
+++ b/test/unit/frontend/checkout.test.js
@@ -5,7 +5,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { Window } from "happy-dom";
 import { Liquid } from "liquidjs";
-import { buildJsConfigScript } from "#eleventy/js-config.js";
+import { buildJsConfigJson } from "#eleventy/js-config.js";
 // Import actual cart utilities
 import {
   attachQuantityHandlers,
@@ -105,8 +105,8 @@ const createCheckoutPage = async (options = {}) => {
       ).replace(/^---[\s\S]*?---\s*/, "")
     : "";
 
-  // Build config script using the same function as the Eleventy shortcode
-  const configScript = buildJsConfigScript(config);
+  // Build config script using the same function as the Eleventy filter
+  const configScript = `<script id="site-config" type="application/json">${buildJsConfigJson(config)}</script>`;
 
   // Build complete HTML page using real templates
   const html = `


### PR DESCRIPTION
Refactor jsConfigScript shortcode to use an include template pattern:
- Move HTML template to src/_includes/js-config-script.html
- Convert shortcode to filter (jsConfigJson) that returns only JSON
- Update head.html to use the include instead of shortcode
- Update tests to work with the new filter API