### PR TITLE
Remove reviews.js from ALLOWED_HTML_IN_JS exception

### DIFF
--- a/src/_lib/collections/reviews.js
+++ b/src/_lib/collections/reviews.js
@@ -1,6 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import config from "#data/config.js";
+import { SRC_DIR } from "#lib/paths.js";
 import { filter, filterMap, map, pipe } from "#utils/array-utils.js";
 import { sortByDateDescending } from "#utils/sorting.js";
+
+// Load SVG template once at module initialization
+const AVATAR_SVG_TEMPLATE = readFileSync(
+  join(SRC_DIR, "assets", "icons", "reviewer-avatar.svg"),
+  "utf8",
+);
 
 /**
  * Creates the main reviews collection.
@@ -107,7 +116,10 @@ const reviewerAvatar = (name) => {
   );
   const color = AVATAR_COLORS[hash % AVATAR_COLORS.length];
   const initials = getInitials(name);
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><rect width="40" height="40" fill="${color}"/><text x="20" y="20" text-anchor="middle" dominant-baseline="central" fill="white" font-family="system-ui,sans-serif" font-size="16" font-weight="bold">${initials}</text></svg>`;
+  const svg = AVATAR_SVG_TEMPLATE.replace("{{color}}", color).replace(
+    "{{initials}}",
+    initials,
+  );
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 };
 

--- a/src/assets/icons/reviewer-avatar.svg
+++ b/src/assets/icons/reviewer-avatar.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><rect width="40" height="40" fill="{{color}}"/><text x="20" y="20" text-anchor="middle" dominant-baseline="central" fill="white" font-family="system-ui,sans-serif" font-size="16" font-weight="bold">{{initials}}</text></svg>

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -72,9 +72,6 @@ const ALLOWED_HTML_IN_JS = new Set([
   // Server-side Eleventy plugins generating HTML
   "src/_lib/eleventy/recurring-events.js",
   "src/_lib/eleventy/responsive-tables.js",
-
-  // Collections with embedded HTML/SVG
-  "src/_lib/collections/reviews.js",
 ]);
 
 // ============================================


### PR DESCRIPTION
Extract SVG template from reviews.js to a separate template file
(reviewer-avatar.svg) and use string replacement instead of inline
HTML template literal. This follows the pattern established in
previous refactors.