### PR TITLE
Remove responsive-tables.js from ALLOWED_HTML_IN_JS exception

### DIFF
--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -71,7 +71,6 @@ const ALLOWED_TRY_CATCHES = new Set([
 const ALLOWED_HTML_IN_JS = new Set([
   // Server-side Eleventy plugins generating HTML
   "src/_lib/eleventy/recurring-events.js",
-  "src/_lib/eleventy/responsive-tables.js",
 ]);
 
 // ============================================


### PR DESCRIPTION
The file uses DOM manipulation (document.createElement) instead of
HTML template literals, so it doesn't actually violate the check.