### PR TITLE
Use image-wrapper aspect-ratio style for masonry height calculation

### DIFF
--- a/src/_lib/public/masonry.js
+++ b/src/_lib/public/masonry.js
@@ -105,9 +105,24 @@ const measureReviewCard = (card, metrics) => {
   );
 };
 
+const parseAspectRatio = (el) => {
+  const match = (el.getAttribute("style") || "").match(
+    /aspect-ratio:\s*(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)/,
+  );
+  if (!match) return null;
+  const h = Number.parseFloat(match[2]);
+  return h > 0 ? Number.parseFloat(match[1]) / h : null;
+};
+
+const measureImageHeight = (card, colWidth) => {
+  const imageWrapper = card.querySelector(".image-wrapper");
+  if (!imageWrapper) return null;
+  const ratio = parseAspectRatio(imageWrapper);
+  return ratio ? colWidth / ratio : null;
+};
+
 const measureItemCard = (card, colWidth) => {
   const { gap, padX, contentWidth } = getCardMetrics(card, colWidth);
-  const img = card.querySelector(".image-link img");
   const heading = card.querySelector("h3");
   const paragraphs = [...card.querySelectorAll("p:not(.price)")].filter((p) =>
     p.textContent?.trim(),
@@ -119,7 +134,7 @@ const measureItemCard = (card, colWidth) => {
 
   return sumWithGaps(
     [
-      img ? colWidth / (img.width / img.height || 1.5) : null,
+      measureImageHeight(card, colWidth),
       heading ? elTextHeight(heading, contentWidth) : null,
       priceEl ? elTextHeight(priceEl, contentWidth) : null,
       ...paragraphs.map((p) => elTextHeight(p, contentWidth)),


### PR DESCRIPTION
Replace the crude img.width/img.height approximation with a precise parse
of the aspect-ratio CSS property hardcoded into .image-wrapper style tags.
If no aspect-ratio is present, return null (no image height contribution)
rather than guessing with a fallback ratio.

https://claude.ai/code/session_017pVZkDbouYqb66um1S8tWe