### PR TITLE
Add alternate background color for dark sections

### DIFF
--- a/src/css/_variables.scss
+++ b/src/css/_variables.scss
@@ -30,6 +30,7 @@ $color-hover-bg: rgba(0, 0, 0, 0.05) !default;
 
 // Dark section colors
 $color-dark-bg: #1f2937 !default;
+$color-dark-bg-alt: color.scale($color-dark-bg, $lightness: -15%) !default;
 $color-dark-text: #f9fafb !default;
 $color-dark-text-muted: #9ca3af !default;
 $color-dark-card-bg: #374151 !default;

--- a/src/css/design-system/_base.scss
+++ b/src/css/design-system/_base.scss
@@ -36,6 +36,7 @@
   --color-video-play-bg: #{$color-video-play-bg};
   --color-video-play-hover: #{$color-video-play-hover};
   --body-background: #{$color-bg};
+  --color-dark-bg-alt: #{$color-dark-bg-alt};
   --font-family-body: #{$font-sans};
   --font-family-heading: #{$font-sans};
   --font-family-mono: #{$font-mono};
@@ -352,6 +353,12 @@
   > section:nth-child(even),
   main > section:nth-child(even) {
     background: var(--body-background-alt);
+  }
+
+  // Even dark sections get alternate dark background
+  > section.dark:nth-child(even),
+  main > section.dark:nth-child(even) {
+    background: var(--color-dark-bg-alt);
   }
 }
 

--- a/src/css/design-system/_feature.scss
+++ b/src/css/design-system/_feature.scss
@@ -40,7 +40,12 @@
   }
 
   section.dark .feature {
-    --color-card-bg: #{$color-bg};
+    --color-card-bg: var(--color-dark-bg-alt);
+  }
+
+  > section.dark:nth-child(even) .feature,
+  main > section.dark:nth-child(even) .feature {
+    --color-card-bg: #{$color-dark-bg};
   }
 
   .feature {


### PR DESCRIPTION
## Summary
This PR adds support for alternating background colors in dark-themed sections, improving visual hierarchy and readability for dark mode layouts.

## Key Changes
- Added `$color-dark-bg-alt` variable in `_variables.scss` that derives a darker shade (15% less lightness) from the base dark background color
- Exposed the new color variable as a CSS custom property `--color-dark-bg-alt` in the design system
- Added styling rules to apply the alternate dark background to even-numbered dark sections, matching the existing pattern for light sections

## Implementation Details
- The alternate dark background color is calculated using Sass's `color.scale()` function with a `-15%` lightness adjustment, ensuring it's darker than the base dark background while maintaining color consistency
- The new rules follow the same selector pattern as existing alternating background logic, supporting both direct children and nested sections within `main`
- This creates visual separation between consecutive dark sections without requiring additional markup or class changes

https://claude.ai/code/session_01AU1dovtnj3yysVMRJNgd7G