### PR TITLE
Render content fallback when no content block exists

### DIFF
--- a/src/_layouts/design-system-base.html
+++ b/src/_layouts/design-system-base.html
@@ -31,6 +31,12 @@
     {%- endif -%}
     {%- if blocks -%}
       {%- include "design-system/blocks.html", blocks: blocks -%}
+      {%- assign has_content_block = blocks | where: "type", "content" | size -%}
+      {%- if has_content_block == 0 and content != "" -%}
+        <section><div class="container-wide">
+        {{- content -}}
+        </div></section>
+      {%- endif -%}
     {%- else -%}
       {{- content -}}
     {%- endif -%}


### PR DESCRIPTION
## Summary
Updated the design system base layout to render page content as a fallback when blocks are present but no explicit content block is defined.

## Key Changes
- Added logic to detect whether a content block exists within the blocks array
- When blocks are present but no content block is found, the page content is now rendered in a `<section>` wrapper with `container-wide` styling
- Preserves existing behavior of rendering content directly when no blocks are defined

## Implementation Details
- Uses Liquid's `where` filter to check for blocks with type "content"
- Only renders the content fallback if the content block count is 0 and content is not empty
- Maintains consistent markup structure with proper container wrapping for styled content output

https://claude.ai/code/session_01LCUgPsuQvctpyGhvz7yUgK