### PR TITLE
Strict types for src/_lib/eleventy/ical.js

### DIFF
--- a/scripts/strict-typecheck-ratchet.js
+++ b/scripts/strict-typecheck-ratchet.js
@@ -14,7 +14,7 @@ import { spawnSync } from "node:child_process";
 import { ROOT_DIR } from "#lib/paths.js";
 
 // Current baseline - lower this as you fix errors
-const CURRENT_ERROR_COUNT = 435;
+const CURRENT_ERROR_COUNT = 431;
 
 // Files that currently pass strict mode (must not regress)
 const STRICT_CLEAN_FILES = [
@@ -59,6 +59,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/eleventy/cache-buster.js",
   "src/_lib/eleventy/canonical-url.js",
   "src/_lib/eleventy/format-price.js",
+  "src/_lib/eleventy/ical.js",
   "src/_lib/eleventy/js-config.js",
   "src/_lib/eleventy/layout-aliases.js",
   "src/_lib/eleventy/opening-times.js",

--- a/src/_lib/eleventy/ical.js
+++ b/src/_lib/eleventy/ical.js
@@ -41,18 +41,19 @@ const eventIcal = (event) => {
 };
 
 /**
+ * @param {EleventyCollectionApi} collectionApi
+ * @returns {EventCollectionItem[]}
+ */
+const getOneOffEvents = (collectionApi) =>
+  collectionApi
+    .getFilteredByTag("events")
+    .filter((event) => event.data.event_date && !event.data.recurring_date);
+
+/**
  * Configure Eleventy iCal filters and collections
  * @param {*} eleventyConfig
  */
 export const configureICal = (eleventyConfig) => {
   eleventyConfig.addFilter("eventIcal", eventIcal);
-  eleventyConfig.addCollection(
-    "oneOffEvents",
-    /** @param {EleventyCollectionApi} collectionApi */
-    (collectionApi) =>
-      collectionApi.getFilteredByTag("events").filter(
-        /** @param {EventCollectionItem} event */
-        (event) => event.data.event_date && !event.data.recurring_date,
-      ),
-  );
+  eleventyConfig.addCollection("oneOffEvents", getOneOffEvents);
 };

--- a/src/_lib/eleventy/ical.js
+++ b/src/_lib/eleventy/ical.js
@@ -3,24 +3,17 @@ import { getConfig } from "#config/site-config.js";
 import site from "#data/site.json" with { type: "json" };
 import { canonicalUrl } from "#utils/canonical-url.js";
 
+/** @typedef {import("#lib/types").EventCollectionItem} EventCollectionItem */
+/** @typedef {import("#lib/types").EleventyCollectionApi} EleventyCollectionApi */
+
 /**
  * Generates iCal format for a one-off event
- * @param {Object} event - Event object
- * @param {Object} event.data - Event data
- * @param {string} event.data.ical_url - iCal URL (required for generating iCal)
- * @param {string} event.data.event_date - Event date
- * @param {string} event.data.title - Event title
- * @param {string} [event.data.subtitle] - Optional subtitle
- * @param {string} [event.data.meta_description] - Optional description
- * @param {string} [event.data.event_location] - Optional event location
- * @param {string} event.url - Event URL
+ * @param {EventCollectionItem} event
  * @returns {string|null} iCal string or null if no ical_url
  */
 const eventIcal = (event) => {
-  // Only generate iCal for one-off events (not recurring)
-  if (!event.data.ical_url) {
-    return null;
-  }
+  if (!event.data.ical_url) return null;
+  if (!event.data.event_date) return null;
 
   const timezone = getConfig().timezone;
   const calendar = ical({
@@ -49,13 +42,17 @@ const eventIcal = (event) => {
 
 /**
  * Configure Eleventy iCal filters and collections
- * @param {Object} eleventyConfig - Eleventy configuration object
+ * @param {*} eleventyConfig
  */
 export const configureICal = (eleventyConfig) => {
   eleventyConfig.addFilter("eventIcal", eventIcal);
-  eleventyConfig.addCollection("oneOffEvents", (collectionApi) =>
-    collectionApi
-      .getFilteredByTag("events")
-      .filter((event) => event.data.event_date && !event.data.recurring_date),
+  eleventyConfig.addCollection(
+    "oneOffEvents",
+    /** @param {EleventyCollectionApi} collectionApi */
+    (collectionApi) =>
+      collectionApi.getFilteredByTag("events").filter(
+        /** @param {EventCollectionItem} event */
+        (event) => event.data.event_date && !event.data.recurring_date,
+      ),
   );
 };

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -241,7 +241,7 @@ const ALLOWED_TEST_ONLY_EXPORTS = frozenSet([
 
 const ALLOWED_DATA_FALLBACKS = frozenSet([
   "src/_lib/collections/events.js:23",
-  "src/_lib/eleventy/ical.js:42",
+  "src/_lib/eleventy/ical.js:35",
 ]);
 
 // ============================================

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -145,6 +145,7 @@ const ALLOWED_SINGLE_USE_FUNCTIONS = frozenSet([
   "src/_lib/media/image-external.js", // External wrapper styles helper
   "src/_lib/media/image-utils.js", // buildImgAttributes, buildPictureAttributes - helper functions for prepareImageAttributes
   "src/_lib/eleventy/file-utils.js", // Filter callbacks extracted for strict type safety
+  "src/_lib/eleventy/ical.js", // Collection callback extracted for strict type safety
   "src/_lib/eleventy/style-bundle.js", // Options parsing helpers for type safety
   "src/_lib/eleventy/link-list.js", // Helpers kept separate for clarity
   "src/_lib/eleventy/html-transform.js", // Transform helpers kept separate to manage complexity

--- a/test/unit/eleventy/ical.test.js
+++ b/test/unit/eleventy/ical.test.js
@@ -1,16 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { configureICal } from "#eleventy/ical.js";
 import {
-  createMockEleventyConfig,
+  collectionApi,
   data,
   expectResultTitles,
+  withConfiguredMock,
 } from "#test/test-utils.js";
 
-// ============================================
-// Curried Data Factories
-// ============================================
-
-/** iCal event factory with url field support */
+/** iCal event factory matching EventCollectionItem shape */
 const icalEvent = (title, eventDate, icalUrl, url, extra = {}) => ({
   data: {
     title,
@@ -24,270 +21,186 @@ const icalEvent = (title, eventDate, icalUrl, url, extra = {}) => ({
 /** Event for oneOffEvents collection tests */
 const eventItem = data({})("title", "event_date", "recurring_date");
 
-/**
- * Helper to get the eventIcal filter via Eleventy registration
- */
-const getEventIcalFilter = () => {
-  const mockConfig = createMockEleventyConfig();
-  configureICal(mockConfig);
-  return mockConfig.filters.eventIcal;
-};
+// =============================================================================
+// eventIcal filter
+// =============================================================================
 
-describe("ical", () => {
-  // eventIcal - falsy ical_url handling (consolidated)
-  test("Returns null when ical_url is missing, undefined, or empty", () => {
-    const eventIcal = getEventIcalFilter();
-    const baseEvent = icalEvent(
-      "Test Event",
-      "2025-06-15",
-      null,
-      "/events/test/",
+describe("eventIcal filter", () => {
+  const { filters } = withConfiguredMock(configureICal)();
+  const eventIcal = filters.eventIcal;
+
+  test("returns null when ical_url is falsy", () => {
+    const noUrl = icalEvent("Test", "2025-06-15", null, "/events/test/");
+    expect(eventIcal(noUrl)).toBe(null);
+
+    const emptyUrl = icalEvent("Test", "2025-06-15", "", "/events/test/");
+    expect(eventIcal(emptyUrl)).toBe(null);
+  });
+
+  test("produces valid VCALENDAR wrapping a VEVENT", () => {
+    const result = eventIcal(
+      icalEvent("Expo", "2025-06-19", "/events/expo/expo.ics", "/events/expo/"),
     );
 
-    // No ical_url property
-    expect(eventIcal(baseEvent)).toBe(null);
+    expect(result).toContain("BEGIN:VCALENDAR");
+    expect(result).toContain("BEGIN:VEVENT");
+    expect(result).toContain("END:VEVENT");
+    expect(result).toContain("END:VCALENDAR");
+  });
 
-    // ical_url is undefined
-    expect(
-      eventIcal(
-        icalEvent("Test Event", "2025-06-15", undefined, "/events/test/"),
+  test("sets SUMMARY to the event title", () => {
+    const result = eventIcal(
+      icalEvent(
+        "Annual Conference",
+        "2025-08-15",
+        "/events/conf/conf.ics",
+        "/events/conf/",
       ),
-    ).toBe(null);
-
-    // ical_url is empty string
-    expect(
-      eventIcal(icalEvent("Test Event", "2025-06-15", "", "/events/test/")),
-    ).toBe(null);
-  });
-
-  // eventIcal - valid iCal generation
-  test("Generates iCal with required VCALENDAR and VEVENT blocks", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Summer Expo",
-      "2025-06-19",
-      "/events/summer-expo/summer-expo.ics",
-      "/events/summer-expo/",
     );
-    const result = eventIcal(event);
 
-    expect(result !== null).toBe(true);
-    expect(result.includes("BEGIN:VCALENDAR")).toBe(true);
-    expect(result.includes("END:VCALENDAR")).toBe(true);
-    expect(result.includes("BEGIN:VEVENT")).toBe(true);
-    expect(result.includes("END:VEVENT")).toBe(true);
+    expect(result).toContain("SUMMARY:Annual Conference");
   });
 
-  test("iCal SUMMARY field contains the event title", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Annual Conference",
-      "2025-08-15",
-      "/events/conference/conference.ics",
-      "/events/conference/",
+  test("includes LOCATION when event_location is provided", () => {
+    const result = eventIcal(
+      icalEvent("Meetup", "2025-09-01", "/events/m/m.ics", "/events/m/", {
+        event_location: "City Hall",
+      }),
     );
-    const result = eventIcal(event);
-    expect(result.includes("SUMMARY:Annual Conference")).toBe(true);
+
+    expect(result).toContain("LOCATION:City Hall");
   });
 
-  test("iCal LOCATION field is present when event_location exists", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Meetup",
-      "2025-09-01",
-      "/events/meetup/meetup.ics",
-      "/events/meetup/",
-      { event_location: "City Hall, Main Street" },
+  test("omits LOCATION line entirely when event_location is absent", () => {
+    const result = eventIcal(
+      icalEvent(
+        "Online Event",
+        "2025-09-15",
+        "/events/online/online.ics",
+        "/events/online/",
+      ),
     );
-    const result = eventIcal(event);
-    expect(result.includes("LOCATION:City Hall")).toBe(true);
+
+    expect(result).not.toContain("LOCATION:");
   });
 
-  test("iCal has empty LOCATION when event_location not provided", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Online Event",
-      "2025-09-15",
-      "/events/online/online.ics",
-      "/events/online/",
+  test("uses subtitle for DESCRIPTION when provided", () => {
+    const result = eventIcal(
+      icalEvent("Workshop", "2025-10-01", "/events/w/w.ics", "/events/w/", {
+        subtitle: "Learn new skills",
+      }),
     );
-    const result = eventIcal(event);
-    // When location is not provided, it will be empty string in output
-    expect(
-      result.includes("LOCATION:Online") ||
-        result.includes("LOCATION:Something"),
-    ).toBe(false);
+
+    expect(result).toContain("DESCRIPTION:Learn new skills");
   });
 
-  test("DESCRIPTION uses subtitle when provided", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Workshop",
-      "2025-10-01",
-      "/events/workshop/workshop.ics",
-      "/events/workshop/",
-      { subtitle: "Learn new skills today" },
+  test("falls back to meta_description when subtitle is absent", () => {
+    const result = eventIcal(
+      icalEvent("Seminar", "2025-10-15", "/events/s/s.ics", "/events/s/", {
+        meta_description: "A great seminar",
+      }),
     );
-    const result = eventIcal(event);
-    expect(result.includes("DESCRIPTION:Learn new skills today")).toBe(true);
+
+    expect(result).toContain("DESCRIPTION:A great seminar");
   });
 
-  test("DESCRIPTION falls back to meta_description when no subtitle", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Seminar",
-      "2025-10-15",
-      "/events/seminar/seminar.ics",
-      "/events/seminar/",
-      { meta_description: "A great seminar event" },
+  test("prefers subtitle over meta_description", () => {
+    const result = eventIcal(
+      icalEvent("Priority", "2025-10-20", "/events/p/p.ics", "/events/p/", {
+        subtitle: "Subtitle wins",
+        meta_description: "Meta loses",
+      }),
     );
-    const result = eventIcal(event);
-    expect(result.includes("DESCRIPTION:A great seminar event")).toBe(true);
+
+    expect(result).toContain("DESCRIPTION:Subtitle wins");
+    expect(result).not.toContain("Meta loses");
   });
 
-  test("subtitle is used when both subtitle and meta_description exist", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Priority Test",
-      "2025-10-20",
-      "/events/priority/priority.ics",
-      "/events/priority/",
-      { subtitle: "Subtitle wins", meta_description: "Meta description loses" },
+  test("formats as all-day event with VALUE=DATE", () => {
+    const result = eventIcal(
+      icalEvent(
+        "All Day",
+        "2025-06-19",
+        "/events/allday/allday.ics",
+        "/events/allday/",
+      ),
     );
-    const result = eventIcal(event);
-    expect(result.includes("DESCRIPTION:Subtitle wins")).toBe(true);
-    expect(result.includes("Meta description loses")).toBe(false);
+
+    expect(result).toContain("DTSTART;VALUE=DATE:20250619");
   });
 
-  test("iCal contains PRODID identifying the calendar producer", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Test",
-      "2025-12-01",
-      "/events/test/test.ics",
-      "/events/test/",
+  test("includes the event URL as a URI value", () => {
+    const result = eventIcal(
+      icalEvent(
+        "Public Event",
+        "2025-11-15",
+        "/events/public/public.ics",
+        "/events/public/",
+      ),
     );
-    const result = eventIcal(event);
-    expect(result.includes("PRODID:")).toBe(true);
-    expect(result.includes("//") && result.includes("//EN")).toBe(true);
+
+    expect(result).toContain("URL;VALUE=URI:");
+    expect(result).toContain("/events/public/");
   });
 
-  test("Event is formatted as all-day event with date (not datetime)", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "All Day Event",
-      "2025-06-19",
-      "/events/allday/allday.ics",
-      "/events/allday/",
+  test("handles special characters in title", () => {
+    const result = eventIcal(
+      icalEvent(
+        "Event with, comma & ampersand",
+        "2025-07-01",
+        "/events/special/special.ics",
+        "/events/special/",
+      ),
     );
-    const result = eventIcal(event);
-    expect(result.includes("DTSTART")).toBe(true);
-    // All-day events in ical-generator use VALUE=DATE format
-    expect(result.includes(";VALUE=DATE") || result.includes("20250619")).toBe(
-      true,
-    );
+
+    expect(result).toContain("comma");
+    expect(result).toContain("ampersand");
   });
+});
 
-  test("iCal URL field contains the event's canonical URL", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Public Event",
-      "2025-11-15",
-      "/events/public/public.ics",
-      "/events/public/",
-    );
-    const result = eventIcal(event);
-    expect(result.includes("URL")).toBe(true);
-    expect(result.includes("/events/public/")).toBe(true);
-  });
+// =============================================================================
+// oneOffEvents collection
+// =============================================================================
 
-  // configureICal tests
-  test("Configures eventIcal as an Eleventy filter", () => {
-    const mockConfig = createMockEleventyConfig();
+describe("oneOffEvents collection", () => {
+  const { collections } = withConfiguredMock(configureICal)();
+  const oneOffEvents = collections.oneOffEvents;
 
-    configureICal(mockConfig);
-
-    expect(typeof mockConfig.filters.eventIcal).toBe("function");
-  });
-
-  test("Configures oneOffEvents as an Eleventy collection", () => {
-    const mockConfig = createMockEleventyConfig();
-
-    configureICal(mockConfig);
-
-    expect(typeof mockConfig.collections.oneOffEvents).toBe("function");
-  });
-
-  test("oneOffEvents collection filters to only one-off events", () => {
-    const mockConfig = createMockEleventyConfig();
-    configureICal(mockConfig);
-
-    const allEvents = eventItem(
+  test("includes events with event_date and no recurring_date", () => {
+    const events = eventItem(
       ["One-off", "2025-06-15", undefined],
-      ["Recurring", undefined, "Every Monday"],
-      ["Both", "2025-06-16", "Weekly"],
       ["Another One-off", "2025-07-01", undefined],
-      ["No dates", undefined, undefined],
     );
-    allEvents.push({ data: {} });
 
-    const mockCollectionApi = {
-      getFilteredByTag: (tag) => {
-        expect(tag).toBe("events");
-        return allEvents;
-      },
-    };
-
-    const result = mockConfig.collections.oneOffEvents(mockCollectionApi);
-
+    const result = oneOffEvents(collectionApi(events));
     expectResultTitles(result, ["One-off", "Another One-off"]);
   });
 
-  test("oneOffEvents collection returns empty when no one-off events exist", () => {
-    const mockConfig = createMockEleventyConfig();
-    configureICal(mockConfig);
-
-    const allEvents = eventItem(
-      ["Recurring 1", undefined, "Every Monday"],
-      ["Recurring 2", undefined, "Weekly"],
+  test("excludes recurring events", () => {
+    const events = eventItem(
+      ["One-off", "2025-06-15", undefined],
+      ["Recurring", undefined, "Every Monday"],
+      ["Both dates", "2025-06-16", "Weekly"],
     );
 
-    const mockCollectionApi = {
-      getFilteredByTag: () => allEvents,
-    };
+    const result = oneOffEvents(collectionApi(events));
+    expectResultTitles(result, ["One-off"]);
+  });
 
-    const result = mockConfig.collections.oneOffEvents(mockCollectionApi);
+  test("excludes events with no dates at all", () => {
+    const events = eventItem(
+      ["Has date", "2025-06-15", undefined],
+      ["No dates", undefined, undefined],
+    );
 
+    const result = oneOffEvents(collectionApi(events));
+    expectResultTitles(result, ["Has date"]);
+  });
+
+  test("returns empty array when no one-off events exist", () => {
+    const events = eventItem(["Recurring", undefined, "Every Monday"]);
+
+    const result = oneOffEvents(collectionApi(events));
     expect(result).toEqual([]);
-  });
-
-  // Edge cases
-  test("iCal properly handles special characters in event title", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "Event with, comma & ampersand",
-      "2025-07-01",
-      "/events/special/special.ics",
-      "/events/special/",
-    );
-    const result = eventIcal(event);
-    expect(
-      result.includes("SUMMARY:") &&
-        result.includes("Event with") &&
-        result.includes("comma"),
-    ).toBe(true);
-  });
-
-  test("iCal parses standard ISO date format correctly", () => {
-    const eventIcal = getEventIcalFilter();
-    const event = icalEvent(
-      "ISO Date Event",
-      "2025-12-25",
-      "/events/christmas/christmas.ics",
-      "/events/christmas/",
-    );
-    const result = eventIcal(event);
-    expect(result.includes("DTSTART")).toBe(true);
-    expect(result.includes("20251225")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- **Rewrote `ical.test.js`** to fix multiple test quality violations, then **made `ical.js` strict-typecheck clean** (4 errors eliminated, `CURRENT_ERROR_COUNT` 435 → 431)

## Test quality fixes

The old `ical.test.js` had several violations of our test quality criteria:

| Issue | Before | After |
|-------|--------|-------|
| Obscured assertions | `.includes("X").toBe(true)` everywhere | `.toContain("X")` |
| Confusing logic | `result.includes("A") \|\| result.includes("B")).toBe(false)` | `.not.toContain("LOCATION:")` |
| Combined assertions | `result.includes("X") && result.includes("Y")` — can't tell which failed | Individual `expect()` per value |
| Redundant tests | "Configures eventIcal as an Eleventy filter" (registration-only) | Removed — implicitly covered |
| Ad-hoc mocks | Manual `createMockEleventyConfig()` + `configureICal()` in every test | `withConfiguredMock()` and `collectionApi()` helpers |

Reduced from 293 → 206 lines while maintaining 100% line/function coverage of `ical.js`.

## Strict type changes

- Replaced verbose `@param {Object} event` JSDoc (8 lines) with `EventCollectionItem` typedef
- Added `EleventyCollectionApi` typedef for collection callback parameter
- Typed `eleventyConfig` as `{*}` (matches pattern used by other strict-clean files like `recurring-events.js`)
- Added guard clause for missing `event_date` to satisfy `TS2769` (was passing `string | undefined` to `new Date()`)

## Compromises

- `eleventyConfig` typed as `{*}` rather than `import("@11ty/eleventy").UserConfig` — this matches the existing pattern in other strict-clean files and avoids pulling in complex Eleventy type definitions
- The `subtitle || meta_description` fallback on line 35 remains in the `ALLOWED_DATA_FALLBACKS` exception list — this is a legitimate priority chain for the iCal DESCRIPTION field, not a bug-masking fallback

## Test plan

- [x] `bun test test/unit/eleventy/ical.test.js` — 15 pass, 0 fail, 100% coverage
- [x] `bun run tsc --noEmit -p tsconfig.strict.json` — 0 errors for `ical.js`
- [x] `bun run precommit` — all checks pass (lint, typecheck, strict ratchet, cpd)
- [x] Note: `reviews.test.js:226` has a pre-existing flaky failure under concurrency (reproduces on clean main branch)

https://claude.ai/code/session_01GBjaZpMByyW8YWEpuzDSrw