### PR TITLE
Enhance marquee-images with JS cloning and optional link support

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -287,6 +287,7 @@ components:
         fields:
           - { name: image, type: string, label: Image Path, required: true }
           - { name: alt, type: string, label: Alt Text }
+          - { name: link_url, type: string, label: Link URL }
       - { name: speed, type: string, label: Scroll Speed (e.g. 30s) }
       - { name: height, type: string, label: Image Height (e.g. 50px) }
   block_icon_links:

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -498,7 +498,7 @@ Continuously scrolling marquee of images (e.g. brand logos, partner badges).
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `items` | array | **required** | Image objects. Each: `{image, alt}`. `image` is a path; `alt` is optional alt text. Images are rendered with `eleventy:ignore` and `chobble:no-lqip` to skip processing. |
+| `items` | array | **required** | Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are rendered with `eleventy:ignore` and `chobble:no-lqip` to skip processing. |
 | `speed` | string | `"30s"` | CSS animation duration for one full scroll cycle (e.g. `"20s"`, `"45s"`). Slower = longer duration. |
 | `height` | string | `"50px"` | CSS height for the images (e.g. `"60px"`, `"80px"`). Width scales proportionally. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -498,7 +498,7 @@ Continuously scrolling marquee of images (e.g. brand logos, partner badges).
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `items` | array | **required** | Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are rendered with `eleventy:ignore` and `chobble:no-lqip` to skip processing. |
+| `items` | array | **required** | Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are processed via the `{% image %}` shortcode for responsive formats and proper URL normalization. |
 | `speed` | string | `"30s"` | CSS animation duration for one full scroll cycle (e.g. `"20s"`, `"45s"`). Slower = longer duration. |
 | `height` | string | `"50px"` | CSS height for the images (e.g. `"60px"`, `"80px"`). Width scales proportionally. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |

--- a/src/_includes/design-system/marquee-images.html
+++ b/src/_includes/design-system/marquee-images.html
@@ -34,9 +34,9 @@ Parameters (via block object):
         {%- assign image = item.image -%}
         {%- capture alt_text -%}{%- if item.alt -%}{{ item.alt }}{%- else -%}{%- include "get-alt-text.html" -%}{%- endif -%}{%- endcapture -%}
         {%- if item.link_url -%}
-        <a href="{{ item.link_url }}" class="marquee-images__link"><img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy"></a>
+        <a href="{{ item.link_url }}" class="marquee-images__link">{%- image item.image, alt_text -%}</a>
         {%- else -%}
-        <img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy">
+        {%- image item.image, alt_text -%}
         {%- endif -%}
       {%- endfor -%}
     </div>

--- a/src/_includes/design-system/marquee-images.html
+++ b/src/_includes/design-system/marquee-images.html
@@ -8,6 +8,7 @@ Parameters (via block object):
   - block.items: Array of image objects with properties:
     - image: Image path (required)
     - alt: Alt text (optional, falls back to alt-tags lookup then empty string)
+    - link_url: Optional URL to link the image to
   - block.speed: Animation duration for one cycle (default: "30s")
   - block.height: CSS height for images (default: "50px")
   - block.header_intro: Optional markdown section header above the marquee
@@ -26,17 +27,25 @@ Parameters (via block object):
 {%- if block.items.size > 0 -%}
   {%- assign speed = block.speed | default: "30s" -%}
   {%- assign height = block.height | default: "50px" -%}
-  <div class="marquee-images" style="--marquee-speed: {{ speed }}; --marquee-height: {{ height }}">
+  <div class="marquee-images{% if block.header_intro %} marquee-images--has-header{% endif %}" style="--marquee-speed: {{ speed }}; --marquee-height: {{ height }}">
     <div class="marquee-images__track">
       {%- for item in block.items -%}
         {%- assign image = item.image -%}
         {%- capture alt_text -%}{%- if item.alt -%}{{ item.alt }}{%- else -%}{%- include "get-alt-text.html" -%}{%- endif -%}{%- endcapture -%}
+        {%- if item.link_url -%}
+        <a href="{{ item.link_url }}" class="marquee-images__link"><img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy"></a>
+        {%- else -%}
         <img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy">
+        {%- endif -%}
       {%- endfor -%}
       {%- for item in block.items -%}
         {%- assign image = item.image -%}
         {%- capture alt_text -%}{%- if item.alt -%}{{ item.alt }}{%- else -%}{%- include "get-alt-text.html" -%}{%- endif -%}{%- endcapture -%}
+        {%- if item.link_url -%}
+        <a href="{{ item.link_url }}" class="marquee-images__link" tabindex="-1" aria-hidden="true"><img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy"></a>
+        {%- else -%}
         <img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy" aria-hidden="true">
+        {%- endif -%}
       {%- endfor -%}
     </div>
   </div>

--- a/src/_includes/design-system/marquee-images.html
+++ b/src/_includes/design-system/marquee-images.html
@@ -1,8 +1,9 @@
 {%- comment -%}
 Marquee images block - continuously scrolling row of images (e.g. brand logos).
 
-Uses pure CSS animation with a duplicated list for seamless infinite scroll.
-The second copy is aria-hidden to avoid duplicate screen-reader announcements.
+Uses pure CSS animation with dynamically cloned content for seamless infinite
+scroll. JavaScript measures the container width and clones items until the track
+is wide enough to scroll without gaps, then starts the animation.
 
 Parameters (via block object):
   - block.items: Array of image objects with properties:
@@ -36,15 +37,6 @@ Parameters (via block object):
         <a href="{{ item.link_url }}" class="marquee-images__link"><img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy"></a>
         {%- else -%}
         <img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy">
-        {%- endif -%}
-      {%- endfor -%}
-      {%- for item in block.items -%}
-        {%- assign image = item.image -%}
-        {%- capture alt_text -%}{%- if item.alt -%}{{ item.alt }}{%- else -%}{%- include "get-alt-text.html" -%}{%- endif -%}{%- endcapture -%}
-        {%- if item.link_url -%}
-        <a href="{{ item.link_url }}" class="marquee-images__link" tabindex="-1" aria-hidden="true"><img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy"></a>
-        {%- else -%}
-        <img src="{{ item.image }}" alt="{{ alt_text }}" eleventy:ignore chobble:no-lqip loading="lazy" aria-hidden="true">
         {%- endif -%}
       {%- endfor -%}
     </div>

--- a/src/_lib/public/design-system.js
+++ b/src/_lib/public/design-system.js
@@ -51,6 +51,33 @@ const initParallax = () => {
   requestAnimationFrame(tick);
 };
 
+const cloneAsHidden = (el, parent) => {
+  const clone = el.cloneNode(true);
+  clone.setAttribute("aria-hidden", "true");
+  if (clone.tagName === "A") clone.setAttribute("tabindex", "-1");
+  parent.appendChild(clone);
+};
+
+const fillTrack = (track, originals, minWidth) => {
+  while (track.scrollWidth < minWidth) {
+    for (const child of originals) cloneAsHidden(child, track);
+  }
+};
+
+const initMarquees = () => {
+  for (const container of document.querySelectorAll(
+    `${SCOPE} .marquee-images`,
+  )) {
+    const track = container.querySelector(".marquee-images__track");
+    if (!track || track.children.length === 0) continue;
+
+    fillTrack(track, [...track.children], container.offsetWidth);
+    for (const child of [...track.children]) cloneAsHidden(child, track);
+
+    container.classList.add("marquee-images--ready");
+  }
+};
+
 // Video facade - replace thumbnail with iframe from server-rendered <template> on click
 const initVideoFacades = () => {
   for (const button of document.querySelectorAll(`${SCOPE} .video-facade`)) {
@@ -111,6 +138,8 @@ const init = () => {
   });
 
   initVideoFacades();
+
+  initMarquees();
 };
 
 onReady(init);

--- a/src/_lib/utils/block-schema/marquee-images.js
+++ b/src/_lib/utils/block-schema/marquee-images.js
@@ -20,7 +20,7 @@ export const docs = {
     items: {
       ...ITEMS_ARRAY_PARAM,
       description:
-        "Image objects. Each: `{image, alt}`. `image` is a path; `alt` is optional alt text. Images are rendered with `eleventy:ignore` and `chobble:no-lqip` to skip processing.",
+        "Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are rendered with `eleventy:ignore` and `chobble:no-lqip` to skip processing.",
     },
     speed: {
       type: "string",
@@ -42,6 +42,7 @@ export const cmsFields = {
   items: objectList("Images", {
     image: str("Image Path", { required: true }),
     alt: str("Alt Text"),
+    link_url: str("Link URL"),
   }),
   speed: str("Scroll Speed (e.g. 30s)"),
   height: str("Image Height (e.g. 50px)"),

--- a/src/_lib/utils/block-schema/marquee-images.js
+++ b/src/_lib/utils/block-schema/marquee-images.js
@@ -20,7 +20,7 @@ export const docs = {
     items: {
       ...ITEMS_ARRAY_PARAM,
       description:
-        "Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are rendered with `eleventy:ignore` and `chobble:no-lqip` to skip processing.",
+        "Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are processed via the `{% image %}` shortcode for responsive formats and proper URL normalization.",
     },
     speed: {
       type: "string",

--- a/src/css/design-system/_marquee-images.scss
+++ b/src/css/design-system/_marquee-images.scss
@@ -2,11 +2,10 @@
 
 // Marquee Images
 // Continuously scrolling row of images (e.g. brand logos, partner badges).
-// Pure CSS animation — no JavaScript required.
+// CSS animation + JS cloning for seamless infinite scroll.
 //
-// The track contains two copies of the image list. Translating by -50%
-// moves the first copy exactly off-screen, at which point the animation
-// loops seamlessly back to 0%.
+// JS clones items until the track is wide enough to cover the viewport,
+// then duplicates the group so translateX(-50%) loops seamlessly.
 
 :root {
   --marquee-speed: 30s;
@@ -27,6 +26,9 @@
     display: flex;
     align-items: center;
     width: max-content;
+  }
+
+  .marquee-images--ready .marquee-images__track {
     animation: marquee-scroll var(--marquee-speed, 30s) linear infinite;
   }
 

--- a/src/css/design-system/_marquee-images.scss
+++ b/src/css/design-system/_marquee-images.scss
@@ -19,11 +19,21 @@
     min-width: 0;
   }
 
+  .marquee-images--has-header {
+    margin-top: $space-md;
+  }
+
   .marquee-images__track {
     display: flex;
     align-items: center;
     width: max-content;
     animation: marquee-scroll var(--marquee-speed, 30s) linear infinite;
+  }
+
+  .marquee-images__link {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
   }
 
   .marquee-images img,
@@ -34,6 +44,10 @@
     object-fit: contain;
     margin: 0 $space-xl;
     flex-shrink: 0;
+  }
+
+  .marquee-images__link img {
+    margin: 0 $space-xl;
   }
 }
 

--- a/src/css/design-system/_marquee-images.scss
+++ b/src/css/design-system/_marquee-images.scss
@@ -38,18 +38,20 @@
     flex-shrink: 0;
   }
 
-  .marquee-images img,
   .marquee-images .image-wrapper {
     height: var(--marquee-height, 50px);
-    width: auto;
-    border-radius: 0;
-    object-fit: contain;
+    width: auto !important;
+    max-width: none !important;
+    aspect-ratio: auto !important;
     margin: 0 $space-xl;
     flex-shrink: 0;
   }
 
-  .marquee-images__link img {
-    margin: 0 $space-xl;
+  .marquee-images .image-wrapper img {
+    height: 100%;
+    width: auto;
+    border-radius: 0;
+    object-fit: contain;
   }
 }
 

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -60,6 +60,7 @@ blocks:
     items:
       - image: /images/placeholders/blue.svg
         alt: Blue Brand
+        link_url: https://example.com/blue
       - image: /images/placeholders/green.svg
         alt: Green Brand
       - image: /images/placeholders/orange.svg


### PR DESCRIPTION
## Summary
Refactored the marquee-images component to use JavaScript-assisted cloning for more reliable infinite scroll behavior, and added support for linking images to URLs.

## Key Changes

- **Dynamic content cloning**: Replaced the static duplicate-list approach with JavaScript that intelligently clones items until the track is wide enough to cover the viewport, then duplicates the entire group for seamless looping
- **Link support**: Added optional `link_url` parameter to image items, allowing images to be wrapped in anchor tags with proper accessibility attributes
- **Improved accessibility**: Cloned items are marked with `aria-hidden="true"` and links have `tabindex="-1"` to prevent duplicate screen reader announcements and keyboard navigation
- **Animation state management**: Animation now only starts after JS has prepared the track (via `marquee-images--ready` class), preventing layout shifts
- **Image processing**: Switched from `eleventy:ignore` + `chobble:no-lqip` to using the `{% image %}` shortcode for responsive formats and proper URL normalization
- **Styling refinements**: 
  - Added `.marquee-images__link` wrapper styling with flex layout
  - Separated image-wrapper and img styling for better control
  - Added `marquee-images--has-header` modifier for spacing when header is present
  - Applied `!important` overrides to ensure image dimensions aren't constrained by wrapper defaults

## Implementation Details

The new `initMarquees()` function:
1. Measures each marquee container's width
2. Clones original items until `track.scrollWidth >= container.offsetWidth`
3. Clones the entire filled group once more to enable seamless `-50%` translateX looping
4. Marks the container as ready to trigger CSS animation

This approach is more robust than static duplication as it adapts to actual rendered content width and viewport size.

https://claude.ai/code/session_01WnDhwunr6fCn9GGwgKUtrH