### PR TITLE
Add blocks layout feature support to CMS customization

### DIFF
--- a/scripts/customise-cms/cli-io.js
+++ b/scripts/customise-cms/cli-io.js
@@ -27,6 +27,9 @@ const CLI_OPTIONS = {
   quiet: { type: "boolean", short: "q" },
   "list-collections": { type: "boolean" },
   "list-features": { type: "boolean" },
+  "use-blocks": { type: "boolean" },
+  "no-use-blocks": { type: "boolean" },
+  "custom-blocks-collections": { type: "string" },
 };
 
 /**

--- a/scripts/customise-cms/cli.js
+++ b/scripts/customise-cms/cli.js
@@ -38,6 +38,7 @@ const ALL_FEATURES = [
   "parent_categories",
   "videos",
   "below_products",
+  "use_blocks",
 ];
 
 /**
@@ -70,6 +71,11 @@ TEMPLATE STRUCTURE:
   --no-src-folder         Template does not have a 'src' folder
   --custom-home           Template has a custom home.html layout
   --no-custom-home        Template uses default homepage (default)
+
+BLOCKS LAYOUT:
+  --use-blocks            Use blocks layout on all collections
+  --no-use-blocks         Don't use blocks layout on all collections (default)
+  --custom-blocks-collections LIST  Comma-separated custom blocks collections (e.g., clients,services)
 
 OUTPUT CONTROL:
   --save-config           Save config to site.json (default)
@@ -163,6 +169,9 @@ export const hasCliFlags = (values) => {
     "no-src-folder",
     "custom-home",
     "no-custom-home",
+    "use-blocks",
+    "no-use-blocks",
+    "custom-blocks-collections",
     "save-config",
     "no-save-config",
     "dry-run",
@@ -308,6 +317,14 @@ export const buildConfigFromCli = (values) => {
     disabledFeatures,
   );
 
+  // Apply dedicated --use-blocks / --no-use-blocks flags (override --enable/--disable)
+  if (values["no-use-blocks"]) features.use_blocks = false;
+  else if (values["use-blocks"]) features.use_blocks = true;
+
+  const customBlocksCollections = parseCommaSeparated(
+    values["custom-blocks-collections"],
+  );
+
   return {
     collections,
     features,
@@ -323,6 +340,7 @@ export const buildConfigFromCli = (values) => {
       "no-custom-home",
       false,
     ),
+    customBlocksCollections,
   };
 };
 

--- a/scripts/customise-cms/config.js
+++ b/scripts/customise-cms/config.js
@@ -29,6 +29,7 @@ import { map, unique } from "#toolkit/fp/array.js";
  * @property {boolean} keywords - Enable search keywords on products and categories
  * @property {boolean} videos - Enable YouTube video embeds on pages
  * @property {boolean} below_products - Enable below-products description on categories
+ * @property {boolean} use_blocks - Enable blocks layout on all collections (design-system-base.html)
  */
 
 /**
@@ -37,6 +38,7 @@ import { map, unique } from "#toolkit/fp/array.js";
  * @property {CmsFeatures} features - Feature flags
  * @property {boolean} hasSrcFolder - Whether the template has a src/ folder
  * @property {boolean} customHomePage - Whether template has a custom home.html layout
+ * @property {string[]} [customBlocksCollections] - Custom blocks-only collections (e.g., ["clients", "services"])
  */
 
 /**
@@ -133,7 +135,9 @@ export const createDefaultConfig = () => ({
     parent_categories: true,
     videos: true,
     below_products: true,
+    use_blocks: false,
   },
   hasSrcFolder: true,
   customHomePage: false,
+  customBlocksCollections: [],
 });

--- a/scripts/customise-cms/generator.js
+++ b/scripts/customise-cms/generator.js
@@ -508,12 +508,19 @@ const addOptionalFields = (
   if (collectionName === "snippets") return coreFields;
 
   const collection = getCollection(collectionName);
+  const alreadyHasBlocks = collectionName === "pages";
   return compact([
     ...coreFields,
     config.features.permalinks && COMMON_FIELDS.permalink,
     config.features.redirects && COMMON_FIELDS.redirect_from,
     config.features.faqs && FAQS_FIELD,
     ...getCollectionSpecificFields(collection, config, fieldContext),
+    config.features.use_blocks &&
+      !alreadyHasBlocks &&
+      generateBlocksField(
+        Object.keys(BLOCK_CMS_FIELDS),
+        config.features.use_visual_editor,
+      ),
   ]);
 };
 
@@ -1070,6 +1077,66 @@ const applyComponentRefs = (contentArray) =>
   );
 
 /**
+ * Convert a slug to a human-readable label (e.g., "guide-pages" -> "Guide Pages")
+ * @param {string} slug - The slug to convert
+ * @returns {string} Human-readable label
+ */
+const slugToLabel = (slug) =>
+  slug
+    .split("-")
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+
+/**
+ * Get optional fields for a custom blocks collection based on enabled features
+ * @param {CmsConfig} config - CMS configuration
+ * @returns {(false | CmsField)[]} Optional fields (with false for disabled features)
+ */
+const getCustomBlocksOptionalFields = (config) => [
+  config.features.permalinks && COMMON_FIELDS.permalink,
+  config.features.redirects && COMMON_FIELDS.redirect_from,
+  config.features.faqs && FAQS_FIELD,
+  config.features.galleries && GALLERY_FIELD,
+  config.features.header_images && COMMON_FIELDS.header_image,
+  config.features.header_images && COMMON_FIELDS.header_text,
+];
+
+/**
+ * Generate configuration for a custom blocks collection.
+ * Custom blocks collections are page-like collections that use the blocks layout.
+ * @param {string} name - Collection name slug (e.g., "clients")
+ * @param {CmsConfig} config - CMS configuration
+ * @param {FieldContext} fieldContext - Precomputed fields
+ * @returns {CollectionConfig} Collection configuration
+ */
+const generateCustomBlocksCollectionConfig = (name, config, fieldContext) => {
+  const hasSrcFolder = config.hasSrcFolder ?? true;
+  const path = hasSrcFolder ? `src/${name}` : name;
+
+  return {
+    name,
+    label: slugToLabel(name),
+    path,
+    type: "collection",
+    filename: "{primary}.md",
+    fields: compact([
+      COMMON_FIELDS.title,
+      COMMON_FIELDS.subtitle,
+      COMMON_FIELDS.thumbnail,
+      COMMON_FIELDS.order,
+      fieldContext.body,
+      ...META_FIELDS,
+      createEleventyNavigationField(config.features.external_navigation_urls),
+      ...getCustomBlocksOptionalFields(config),
+      generateBlocksField(
+        Object.keys(BLOCK_CMS_FIELDS),
+        config.features.use_visual_editor,
+      ),
+    ]),
+  };
+};
+
+/**
  * Generate complete .pages.yml configuration
  * @param {CmsConfig} config - CMS configuration
  * @returns {string} YAML string for .pages.yml
@@ -1083,6 +1150,10 @@ export const generatePagesYaml = (config) => {
     (name) => generateCollectionConfig(name, config, fieldContext),
   )(config.collections);
 
+  const customBlocksConfigs = (config.customBlocksCollections || []).map(
+    (name) => generateCustomBlocksCollectionConfig(name, config, fieldContext),
+  );
+
   const hasSrcFolder = config.hasSrcFolder ?? true;
   const customHomePage = config.customHomePage ?? false;
   const dataPath = getDataPath(hasSrcFolder);
@@ -1091,6 +1162,7 @@ export const generatePagesYaml = (config) => {
   // Build content array, conditionally including homepage
   const contentArray = [
     ...collectionConfigs,
+    ...customBlocksConfigs,
     ...(customHomePage ? [] : [getHomepageConfig(dataPath)]),
     getSiteConfig(dataPath),
     getMetaConfig(dataPath),

--- a/scripts/customise-cms/index.js
+++ b/scripts/customise-cms/index.js
@@ -74,6 +74,11 @@ const logConfigSummary = (config, message, quiet) => {
   if (enabledFeatures.length > 0) {
     log(`  Features: ${enabledFeatures.join(", ")}`, quiet);
   }
+
+  const customBlocks = config.customBlocksCollections || [];
+  if (customBlocks.length > 0) {
+    log(`  Custom blocks collections: ${customBlocks.join(", ")}`, quiet);
+  }
 };
 
 /**

--- a/scripts/customise-cms/prompts.js
+++ b/scripts/customise-cms/prompts.js
@@ -62,6 +62,23 @@ const askYesNo = async (rl, question, defaultValue = false) => {
 };
 
 /**
+ * Ask a free-text question and return the trimmed answer
+ * @param {readline.Interface} rl - Readline interface
+ * @param {string} question - Question to ask
+ * @param {string} [defaultValue=""] - Default answer if user presses enter
+ * @returns {Promise<string>} User's answer
+ */
+const askFreeText = async (rl, question, defaultValue = "") => {
+  const defaultHint = defaultValue ? ` [${defaultValue}]` : "";
+  return new Promise((resolve) => {
+    rl.question(`${question}${defaultHint}: `, (answer) => {
+      const trimmed = answer.trim();
+      resolve(trimmed === "" ? defaultValue : trimmed);
+    });
+  });
+};
+
+/**
  * Parse selection input into array of selected names
  * @param {string} input - User's input (comma-separated numbers, "all", "none", or empty)
  * @param {SelectableOption[]} options - Available options to select from
@@ -371,6 +388,52 @@ const askVideosQuestion = async (rl, collections, defaultFeatures) => {
 };
 
 /**
+ * Ask whether to use blocks layout on all collections
+ * @param {readline.Interface} rl - Readline interface
+ * @param {Partial<CmsFeatures>} defaultFeatures - Default feature values
+ * @returns {Promise<{use_blocks: boolean}>} Use blocks selection
+ */
+const askUseBlocksQuestion = async (rl, defaultFeatures) => ({
+  use_blocks: await askYesNo(
+    rl,
+    "Are you using the blocks layout on all collections (design-system-base.html)?",
+    defaultFeatures.use_blocks ?? false,
+  ),
+});
+
+/**
+ * Parse a comma-separated string into an array of slugified names
+ * @param {string} input - Comma-separated names (e.g., "clients, services")
+ * @returns {string[]} Array of slugified names
+ */
+const parseCustomCollectionNames = (input) => {
+  if (!input) return [];
+  return input
+    .split(",")
+    .map((s) => s.trim().toLowerCase().replace(/\s+/g, "-"))
+    .filter((s) => s.length > 0);
+};
+
+/**
+ * Ask about custom blocks collections
+ * @param {readline.Interface} rl - Readline interface
+ * @param {string[]} defaultCustomCollections - Previously configured custom collections
+ * @returns {Promise<string[]>} Custom collection names
+ */
+const askCustomBlocksCollectionsQuestion = async (
+  rl,
+  defaultCustomCollections,
+) => {
+  const defaultValue = defaultCustomCollections.join(", ");
+  const answer = await askFreeText(
+    rl,
+    "Enter custom blocks collections (comma-separated, e.g., 'clients, services'), or leave empty for none",
+    defaultValue,
+  );
+  return parseCustomCollectionNames(answer);
+};
+
+/**
  * Ask feature questions
  * @param {readline.Interface} rl - Readline interface
  * @param {string[]} collections - Selected collection names
@@ -463,6 +526,7 @@ const askFeatureQuestions = async (rl, collections, defaultFeatures) => {
     collections,
     defaultFeatures,
   );
+  const blocksFeatures = await askUseBlocksQuestion(rl, defaultFeatures);
 
   return {
     ...baseFeatures,
@@ -475,6 +539,7 @@ const askFeatureQuestions = async (rl, collections, defaultFeatures) => {
     ...parentCategoriesFeatures,
     ...videosFeatures,
     ...belowProductsFeatures,
+    ...blocksFeatures,
   };
 };
 
@@ -519,6 +584,8 @@ export const askQuestions = async (existingConfig = null) => {
     const defaultFeatures = existingConfig?.features || {};
     const defaultHasSrc = existingConfig?.hasSrcFolder ?? true;
     const defaultCustomHome = existingConfig?.customHomePage ?? false;
+    const defaultCustomBlocksCollections =
+      existingConfig?.customBlocksCollections || [];
 
     console.log("\n--- Template Configuration ---\n");
     const hasSrcFolder = await askSrcFolderQuestion(rl, defaultHasSrc);
@@ -534,7 +601,20 @@ export const askQuestions = async (existingConfig = null) => {
       defaultFeatures,
     );
 
-    return { collections, features, hasSrcFolder, customHomePage };
+    const customBlocksCollections = features.use_blocks
+      ? await askCustomBlocksCollectionsQuestion(
+          rl,
+          defaultCustomBlocksCollections,
+        )
+      : [];
+
+    return {
+      collections,
+      features,
+      hasSrcFolder,
+      customHomePage,
+      customBlocksCollections,
+    };
   } finally {
     rl.close();
   }

--- a/test/unit/scripts/customise-cms.test.js
+++ b/test/unit/scripts/customise-cms.test.js
@@ -61,6 +61,7 @@ const DISABLED_FEATURES = {
   event_locations_and_dates: false,
   use_visual_editor: false,
   below_products: false,
+  use_blocks: false,
 };
 
 /**
@@ -77,6 +78,7 @@ const createTestConfig = (overrides = {}) => ({
   features: { ...DISABLED_FEATURES, ...(overrides.features ?? {}) },
   hasSrcFolder: overrides.hasSrcFolder ?? true,
   customHomePage: overrides.customHomePage ?? false,
+  customBlocksCollections: overrides.customBlocksCollections ?? [],
 });
 
 /**
@@ -1733,5 +1735,215 @@ describe("customise-cms CLI", () => {
 
   test("handleListOptions returns true for --list-features", () => {
     expect(handleListOptions({ "list-features": true })).toBe(true);
+  });
+
+  // ============================================
+  // use_blocks feature
+  // ============================================
+  test("buildConfigFromCli handles --use-blocks flag", () => {
+    const config = buildConfigFromCli({
+      collections: "pages",
+      "use-blocks": true,
+    });
+    expect(config.features.use_blocks).toBe(true);
+  });
+
+  test("buildConfigFromCli handles --no-use-blocks flag", () => {
+    const config = buildConfigFromCli({
+      all: true,
+      "no-use-blocks": true,
+    });
+    expect(config.features.use_blocks).toBe(false);
+  });
+
+  test("buildConfigFromCli handles --custom-blocks-collections flag", () => {
+    const config = buildConfigFromCli({
+      collections: "pages",
+      "use-blocks": true,
+      "custom-blocks-collections": "clients,services",
+    });
+    expect(config.customBlocksCollections).toEqual(["clients", "services"]);
+  });
+
+  test("buildConfigFromCli defaults customBlocksCollections to empty array", () => {
+    const config = buildConfigFromCli({
+      collections: "pages",
+    });
+    expect(config.customBlocksCollections).toEqual([]);
+  });
+
+  test("hasCliFlags detects --use-blocks flag", () => {
+    expect(hasCliFlags({ "use-blocks": true })).toBe(true);
+  });
+
+  test("hasCliFlags detects --custom-blocks-collections flag", () => {
+    expect(hasCliFlags({ "custom-blocks-collections": "clients" })).toBe(true);
+  });
+
+  test("ALL_FEATURES includes use_blocks", () => {
+    expect(ALL_FEATURES).toContain("use_blocks");
+  });
+});
+
+describe("customise-cms blocks layout", () => {
+  // ============================================
+  // use_blocks adds blocks to non-pages collections
+  // ============================================
+  test("generatePagesYaml adds blocks field to products when use_blocks is enabled", () => {
+    const config = createTestConfig({
+      collections: ["pages", "products", "categories"],
+      features: { use_blocks: true },
+    });
+    const yaml = generatePagesYaml(config);
+    const productsSection = getSection("products")(yaml);
+
+    expect(productsSection).toContain("name: blocks");
+    expect(productsSection).toContain("type: block");
+  });
+
+  test("generatePagesYaml does not add blocks to non-pages collections when use_blocks is disabled", () => {
+    const config = createTestConfig({
+      collections: ["pages", "products", "categories"],
+      features: { use_blocks: false },
+    });
+    const yaml = generatePagesYaml(config);
+    const productsSection = getSection("products")(yaml);
+
+    expect(productsSection).not.toContain("name: blocks");
+  });
+
+  test("generatePagesYaml does not duplicate blocks on pages when use_blocks is enabled", () => {
+    const config = createTestConfig({
+      collections: ["pages"],
+      features: { use_blocks: true },
+    });
+    const yaml = generatePagesYaml(config);
+    const pagesSection = getSection("pages")(yaml);
+
+    // Count occurrences of "name: blocks" in pages section
+    const matches = pagesSection.match(/name: blocks/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  test("generatePagesYaml adds blocks to news when use_blocks is enabled", () => {
+    const config = createTestConfig({
+      collections: ["pages", "news"],
+      features: { use_blocks: true },
+    });
+    const yaml = generatePagesYaml(config);
+    const newsSection = getSection("news")(yaml);
+
+    expect(newsSection).toContain("name: blocks");
+  });
+
+  test("generatePagesYaml does not add blocks to snippets even when use_blocks is enabled", () => {
+    const config = createTestConfig({
+      collections: ["pages", "snippets"],
+      features: { use_blocks: true },
+    });
+    const yaml = generatePagesYaml(config);
+    const snippetsSection = getSection("snippets")(yaml);
+
+    expect(snippetsSection).not.toContain("name: blocks");
+  });
+
+  // ============================================
+  // Custom blocks collections
+  // ============================================
+  test("generatePagesYaml includes custom blocks collections", () => {
+    const config = createTestConfig({
+      customBlocksCollections: ["clients", "services"],
+    });
+    const yaml = generatePagesYaml(config);
+
+    expect(yaml).toContain("name: clients");
+    expect(yaml).toContain("label: Clients");
+    expect(yaml).toContain("path: src/clients");
+
+    expect(yaml).toContain("name: services");
+    expect(yaml).toContain("label: Services");
+    expect(yaml).toContain("path: src/services");
+  });
+
+  test("custom blocks collections include blocks field", () => {
+    const config = createTestConfig({
+      customBlocksCollections: ["clients"],
+    });
+    const yaml = generatePagesYaml(config);
+    const clientsSection = getSection("clients")(yaml);
+
+    expect(clientsSection).toContain("name: blocks");
+    expect(clientsSection).toContain("type: block");
+  });
+
+  test("custom blocks collections include standard page-like fields", () => {
+    const config = createTestConfig({
+      customBlocksCollections: ["clients"],
+    });
+    const yaml = generatePagesYaml(config);
+    const clientsSection = getSection("clients")(yaml);
+
+    expect(clientsSection).toContain("name: title");
+    expect(clientsSection).toContain("name: subtitle");
+    expect(clientsSection).toContain("name: body");
+    expect(clientsSection).toContain("name: meta_title");
+    expect(clientsSection).toContain("name: meta_description");
+  });
+
+  test("custom blocks collections respect hasSrcFolder setting", () => {
+    const config = createTestConfig({
+      hasSrcFolder: false,
+      customBlocksCollections: ["clients"],
+    });
+    const yaml = generatePagesYaml(config);
+
+    expect(yaml).toContain("path: clients");
+    expect(yaml).not.toContain("path: src/clients");
+  });
+
+  test("custom blocks collections respect optional features", () => {
+    const config = createTestConfig({
+      features: { permalinks: true, galleries: true },
+      customBlocksCollections: ["clients"],
+    });
+    const yaml = generatePagesYaml(config);
+    const clientsSection = getSection("clients")(yaml);
+
+    expect(clientsSection).toContain("name: permalink");
+    expect(clientsSection).toContain("name: gallery");
+  });
+
+  test("custom blocks collections omit optional features when disabled", () => {
+    const config = createTestConfig({
+      features: { permalinks: false, galleries: false },
+      customBlocksCollections: ["clients"],
+    });
+    const yaml = generatePagesYaml(config);
+    const clientsSection = getSection("clients")(yaml);
+
+    expect(clientsSection).not.toContain("name: permalink");
+    expect(clientsSection).not.toContain("name: gallery");
+  });
+
+  test("custom blocks collections handle multi-word slugs correctly", () => {
+    const config = createTestConfig({
+      customBlocksCollections: ["case-studies"],
+    });
+    const yaml = generatePagesYaml(config);
+
+    expect(yaml).toContain("name: case-studies");
+    expect(yaml).toContain("label: Case Studies");
+  });
+
+  test("generatePagesYaml handles empty customBlocksCollections", () => {
+    const config = createTestConfig({
+      customBlocksCollections: [],
+    });
+    const yaml = generatePagesYaml(config);
+
+    // Should still produce valid output without custom collections
+    expect(yaml).toContain("media:");
+    expect(yaml).toContain("content:");
+    expect(yaml).toContain("name: pages");
   });
 });


### PR DESCRIPTION
## Summary
This PR adds support for the blocks layout feature to the CMS customization CLI tool. It enables users to configure collections to use a blocks-based layout (design-system-base.html) and define custom blocks collections with full field configuration.

## Key Changes

- **Feature Flag**: Added `use_blocks` feature flag to enable blocks layout across all collections
- **Custom Collections**: Introduced `customBlocksCollections` configuration to define page-like collections that use the blocks layout
- **CLI Support**: Added `--use-blocks`, `--no-use-blocks`, and `--custom-blocks-collections` command-line flags
- **Interactive Prompts**: Added `askUseBlocksQuestion()` and `askCustomBlocksCollectionsQuestion()` to guide users through configuration
- **YAML Generation**: 
  - Modified `addOptionalFields()` to inject blocks field into non-pages collections when feature is enabled
  - Added `generateCustomBlocksCollectionConfig()` to create full collection configurations for custom blocks collections
  - Custom collections include standard page fields (title, subtitle, body, meta fields) plus optional features (permalinks, galleries, etc.)
- **Utilities**: Added `slugToLabel()` helper to convert collection slugs to human-readable labels and `parseCustomCollectionNames()` for parsing comma-separated input
- **Configuration**: Updated config schema and test fixtures to include `customBlocksCollections` property
- **Documentation**: Updated CLI help text with blocks layout options

## Implementation Details

- Custom blocks collections respect the `hasSrcFolder` setting for path generation
- Blocks field is automatically added to custom collections and non-pages collections when feature is enabled
- Pages collection is excluded from automatic blocks field injection to avoid duplication
- Snippets collection is excluded from blocks layout support
- Custom collections inherit optional feature fields based on enabled features in the configuration
- Comprehensive test coverage added for all new functionality

https://claude.ai/code/session_01JTKuy2iMFgtYdaW8cPYnXJ