### PR TITLE
Prefix encrypted email hrefs with # to prevent navigation

### DIFF
--- a/src/_lib/public/ui/decrypt-text.js
+++ b/src/_lib/public/ui/decrypt-text.js
@@ -60,7 +60,7 @@ onReady(async () => {
   const key = await importKey(keyText);
   for (const link of links) {
     const [href, text] = await Promise.all([
-      decrypt(link.getAttribute("href"), key),
+      decrypt(link.getAttribute("href").replace(/^#/, ""), key),
       decrypt(link.textContent, key),
     ]);
     link.setAttribute("href", href);

--- a/src/_lib/transforms/encrypt-emails.js
+++ b/src/_lib/transforms/encrypt-emails.js
@@ -18,7 +18,10 @@ const keyBytes = decodeBase64(keyText);
 const encryptEmails = (document) => {
   for (const link of document.querySelectorAll('a[href^="mailto:"]')) {
     link.textContent = encrypt(link.textContent, keyBytes);
-    link.setAttribute("href", encrypt(link.getAttribute("href"), keyBytes));
+    link.setAttribute(
+      "href",
+      `#${encrypt(link.getAttribute("href"), keyBytes)}`,
+    );
     link.setAttribute("data-decrypt-link", "");
   }
 };

--- a/test/unit/eleventy/html-transform.test.js
+++ b/test/unit/eleventy/html-transform.test.js
@@ -60,6 +60,8 @@ describe("html-transform", () => {
 
       expect(result).not.toContain("mailto:hello@example.com");
       expect(result).toContain("data-decrypt-link");
+      const hrefMatch = result.match(/href="([^"]+)"[^>]*data-decrypt-link/);
+      expect(hrefMatch[1]).toMatch(/^#[0-9a-zA-Z_-]+$/);
     });
 
     test("linkifies phone numbers with default config", async () => {

--- a/test/unit/transforms/encrypt-emails.test.js
+++ b/test/unit/transforms/encrypt-emails.test.js
@@ -65,13 +65,13 @@ describe("encrypt-emails", () => {
       expect(result).toContain("</a>");
     });
 
-    test("encrypted href contains only URL-safe chars", async () => {
+    test("encrypted href starts with # and contains only URL-safe chars", async () => {
       const html = wrapHtml(
         '<a href="mailto:test@example.com">test@example.com</a>',
       );
       const result = await transformHtml(html);
       const hrefMatch = result.match(/href="([^"]+)"/);
-      expect(hrefMatch[1]).toMatch(/^[0-9a-zA-Z_-]+$/);
+      expect(hrefMatch[1]).toMatch(/^#[0-9a-zA-Z_-]+$/);
     });
   });
 });


### PR DESCRIPTION
## Summary
Modified the email encryption system to prefix encrypted href attributes with `#` (hash symbol), preventing browsers from attempting to navigate to encrypted email addresses while maintaining the ability to decrypt them client-side.

## Key Changes
- **encrypt-emails.js**: Updated href encryption to prepend `#` to encrypted mailto URLs, converting them from navigable links to fragment identifiers
- **decrypt-text.js**: Added logic to strip the `#` prefix before decrypting the href, restoring the original mailto URL for client-side decryption
- **Tests**: Updated test expectations to validate that encrypted hrefs start with `#` and contain only URL-safe characters

## Implementation Details
The `#` prefix serves as a security measure by:
1. Preventing the browser from treating encrypted hrefs as actual navigation targets
2. Keeping the encrypted data in the href attribute for client-side decryption
3. Maintaining URL-safe character requirements for the encrypted portion

The decryption process handles the prefix transparently by removing it before decrypting, ensuring the original mailto URL is restored when needed.

https://claude.ai/code/session_015yXCuW4QkdqcrvBAf8w93Z