### PR TITLE
Disable coverage by default, only enforce on full test suite

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,11 +10,12 @@ root = "./test"
 # Timeout for individual tests (30 seconds)
 timeout = 30000
 
-# Always enable coverage reporting
-coverage = true
+# Coverage is NOT enabled by default - only the full test suite (bun run test)
+# passes --coverage explicitly. This prevents ad-hoc test runs (bun test:unit,
+# bun test test/some-file) from failing with exit code 1 due to coverage
+# thresholds when all tests actually pass.
 
-# Coverage thresholds - tests fail if coverage drops below these levels
-# Allows manual management of .coverage_exceptions.json while preventing regressions
+# Coverage thresholds - enforced only when --coverage flag is passed
 # Full 100% coverage required for both lines and functions
 coverageThreshold = { lines = 1.0, functions = 1.0 }
 


### PR DESCRIPTION
## Summary
Changed the coverage configuration to be disabled by default, with coverage thresholds only enforced when the `--coverage` flag is explicitly passed. This prevents ad-hoc test runs from failing due to coverage threshold violations when all tests actually pass.

## Key Changes
- Disabled `coverage = true` by default in `bunfig.toml`
- Updated coverage configuration comments to clarify that:
  - Coverage is only enabled for the full test suite (`bun run test`)
  - Ad-hoc test runs (`bun test:unit`, `bun test test/some-file`) will not fail on coverage thresholds
  - Coverage thresholds are only enforced when the `--coverage` flag is explicitly passed
  - Full 100% coverage is still required for both lines and functions when coverage is enabled

## Implementation Details
The full test suite command (`bun run test`) will continue to pass the `--coverage` flag explicitly, ensuring coverage thresholds are enforced in CI/CD pipelines while allowing developers to run individual test files without coverage-related failures.

https://claude.ai/code/session_018hg5LgsvDexGrE5yJSmZi6