### PR TITLE
Remove explicit alt section_class in favor of automatic alternating

### DIFF
--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -23,7 +23,7 @@ Every block object supports these properties (handled by blocks.html, not the in
 | Property | Type | Effect |
 |---|---|---|
 | `type` | string | **Required.** Selects which template to render. |
-| `section_class` | string | CSS class(es) on the wrapping `<section>`. Built-in: `alt` (alternate bg), `dark` (dark bg + inverted colors), `gradient` (gradient bg), `compact` (reduced padding). |
+| `section_class` | string | CSS class(es) on the wrapping `<section>`. Built-in: `dark` (dark bg + inverted colors), `gradient` (gradient bg), `compact` (reduced padding). Alternating backgrounds are applied automatically via `:nth-child(even)`. |
 | `container_width` | string | `"full"`, `"wide"` (default), or `"narrow"`. Controls the inner container max-width. `"full"` omits the container wrapper entirely so content spans the full viewport width. |
 
 ### Section Behavior

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -227,7 +227,6 @@ blocks:
 
   # E-Commerce Features (with header, grid--4 layout, custom colors)
   - type: features
-    section_class: alt
 
     header_intro: |-
       ## Commerce Options
@@ -269,7 +268,6 @@ blocks:
 
   # SEO Features (with header)
   - type: features
-    section_class: alt
 
     header_intro: |-
       ## Built-in SEO

--- a/src/snippets/specs.md
+++ b/src/snippets/specs.md
@@ -2,7 +2,6 @@
 name: Specs
 blocks:
   - type: stats
-    section_class: alt
     items:
       - value: "14"
         label: Content Types

--- a/test/unit/data/eleventy-computed.test.js
+++ b/test/unit/data/eleventy-computed.test.js
@@ -549,11 +549,11 @@ describe("eleventyComputed", () => {
 
     test("Explicit section_class overrides default empty string", () => {
       const data = {
-        blocks: [{ type: "stats", items: [], section_class: "alt" }],
+        blocks: [{ type: "stats", items: [], section_class: "dark" }],
         page,
       };
       const result = eleventyComputed.blocks(data);
-      expect(result[0].section_class).toBe("alt");
+      expect(result[0].section_class).toBe("dark");
     });
 
     test("Processes multiple blocks with different types", () => {


### PR DESCRIPTION
## Summary
This PR removes the explicit `alt` section class from block configurations and updates the documentation to reflect that alternating backgrounds are now applied automatically via CSS `:nth-child(even)` selector.

## Key Changes
- **Documentation Update**: Modified `BLOCKS_LAYOUT.md` to remove `alt` from the list of built-in section classes and clarify that alternating backgrounds are applied automatically
- **Template Updates**: Removed `section_class: alt` from three block instances:
  - E-Commerce Features block in `chobble-template.md`
  - SEO Features block in `chobble-template.md`
  - Stats block in `specs.md`
- **Test Update**: Updated unit test to use `dark` instead of `alt` as the example explicit section class, maintaining test coverage for explicit overrides

## Implementation Details
The changes indicate a shift from manual alternating background styling (via explicit `alt` class) to automatic CSS-based alternation. This simplifies the block configuration by removing the need to manually specify alternating styles while maintaining the same visual result through CSS selectors.

https://claude.ai/code/session_01QFLAAydRNtzFUGGQEVUcPQ