### PR TITLE
Add split-callout block component

### DIFF
--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -272,6 +272,31 @@ Two-column layout with text content and custom HTML.
 
 ---
 
+### `split-callout`
+
+Two-column layout with text content and a styled callout box with icon, title, and subtitle.
+
+**Template:** `src/_includes/design-system/split-callout.html`
+**SCSS:** `src/css/design-system/_split-callout.scss`
+**HTML root:** `<div class="split-callout">`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `title` | string | — | Section heading. |
+| `title_level` | number | `2` | Heading level. |
+| `subtitle` | string | — | Subtitle with `.text-muted` styling. |
+| `content` | string | — | Main content. Rendered through `renderContent: "md"` filter (supports markdown). Wrapped in `.prose`. |
+| `reverse` | boolean | `false` | Reverses column order (content right, figure left) on desktop. |
+| `reveal_content` | string | `"left"` | `data-reveal` for the text side. Auto-set to `"right"` when `reverse` is true. |
+| `reveal_figure` | string | `"scale"` | `data-reveal` for the figure side. |
+| `button` | object | — | `{text, href, variant}`. Rendered below content. Default variant: `"secondary"`. |
+| `figure_icon` | string | — | Icon content: Iconify ID (`prefix:name`), emoji, or image path. |
+| `figure_title` | string | **required** | Bold heading text in the callout box. |
+| `figure_subtitle` | string | — | Supporting text below the title. |
+| `figure_variant` | string | `"primary"` | Color scheme: `"primary"`, `"secondary"`, `"gradient"`, or a custom CSS gradient string. |
+
+---
+
 ### `split-full`
 
 Full-width two-panel layout with distinct background colors per side.

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -35,6 +35,7 @@ const BLOCK_DEFAULTS = {
   "split-code": { title_level: 2, reveal_figure: "scale" },
   "split-icon-links": { title_level: 2, reveal_figure: "scale" },
   "split-html": { title_level: 2, reveal_figure: "scale" },
+  "split-callout": { title_level: 2, reveal_figure: "scale" },
   "section-header": { align: "center" },
   "image-cards": { reveal: true, heading_level: 3 },
   "code-block": { reveal: true },

--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -37,6 +37,9 @@ Renders a single block by type. Used by blocks.html.
   {%- when "split-html" -%}
     {%- include "design-system/split.html", block: block -%}
 
+  {%- when "split-callout" -%}
+    {%- include "design-system/split-callout.html", block: block -%}
+
   {%- when "split-full" -%}
     {%- include "design-system/split-full.html", block: block -%}
 

--- a/src/_includes/design-system/split-article.html
+++ b/src/_includes/design-system/split-article.html
@@ -1,0 +1,30 @@
+{%- comment -%}
+Shared article (text side) of split-* layouts. Used by split.html and
+split-callout.html.
+
+Parameters (via block object):
+  - block.title: Section heading
+  - block.title_level: Heading level, defaults to 2
+  - block.subtitle: Optional subtitle text (with text-muted styling)
+  - block.content: Main content (rendered as markdown)
+  - block.button: Optional button object { text, href, variant }
+
+Parameters (direct):
+  - reveal_content: data-reveal value for the article
+{%- endcomment -%}
+
+{%- assign title_level = block.title_level | default: 2 -%}
+
+<article class="stack" data-reveal="{{ reveal_content }}">
+  {%- if block.title -%}
+    <h{{ title_level }}>{{ block.title }}</h{{ title_level }}>
+  {%- endif -%}
+  {%- if block.subtitle -%}
+    <p class="text-muted">{{ block.subtitle }}</p>
+  {%- endif -%}
+  <div class="prose">{{ block.content | renderContent: "md" }}</div>
+  {%- if block.button -%}
+    {%- assign btn_variant = block.button.variant | default: "secondary" -%}
+    <a href="{{ block.button.href }}" class="btn btn--{{ btn_variant }}">{{ block.button.text }}</a>
+  {%- endif -%}
+</article>

--- a/src/_includes/design-system/split-callout.html
+++ b/src/_includes/design-system/split-callout.html
@@ -32,36 +32,20 @@ Usage:
   %}
 {%- endcomment -%}
 
-{%- assign title_level = block.title_level | default: 2 -%}
 {%- assign reveal_content = block.reveal_content | default: "left" -%}
 {%- assign reveal_figure = block.reveal_figure | default: "scale" -%}
 {%- assign variant = block.figure_variant | default: "primary" -%}
-
-<!--
-// jscpd:ignore-start
--->
-<div class="split-callout{% if block.reverse %} split-callout--reverse{% endif %}">
-  <article class="stack" data-reveal="{{ reveal_content }}">
-    {%- if block.title -%}
-      <h{{ title_level }}>{{ block.title }}</h{{ title_level }}>
-    {%- endif -%}
-    {%- if block.subtitle -%}
-      <p class="text-muted">{{ block.subtitle }}</p>
-    {%- endif -%}
-    <div class="prose">{{ block.content | renderContent: "md" }}</div>
-    {%- if block.button -%}
-      {%- assign btn_variant = block.button.variant | default: "secondary" -%}
-      <a href="{{ block.button.href }}" class="btn btn--{{ btn_variant }}">{{ block.button.text }}</a>
-    {%- endif -%}
-  </article>
-<!--
-// jscpd:ignore-end
--->
-  {%- if variant == "primary" or variant == "secondary" or variant == "gradient" -%}
-  <figure class="callout-box callout-box--{{ variant }}" data-reveal="{{ reveal_figure }}">
+{%- case variant -%}
+  {%- when "primary", "secondary", "gradient" -%}
+    {%- assign callout_class = "callout-box callout-box--" | append: variant -%}
   {%- else -%}
-  <figure class="callout-box" style="background: {{ variant }}" data-reveal="{{ reveal_figure }}">
-  {%- endif -%}
+    {%- assign callout_class = "callout-box" -%}
+    {%- assign callout_style = variant -%}
+{%- endcase -%}
+
+<div class="split-callout{% if block.reverse %} split-callout--reverse{% endif %}">
+  {%- include "design-system/split-article.html", block: block, reveal_content: reveal_content -%}
+  <figure class="{{ callout_class }}"{% if callout_style %} style="background: {{ callout_style }}"{% endif %} data-reveal="{{ reveal_figure }}">
     {%- if block.figure_icon -%}
       <div class="callout-box__icon">{%- include "design-system/icon.html", icon: block.figure_icon -%}</div>
     {%- endif -%}

--- a/src/_includes/design-system/split-callout.html
+++ b/src/_includes/design-system/split-callout.html
@@ -1,0 +1,69 @@
+{%- comment -%}
+Split layout with text content and a styled callout box.
+
+Parameters (via block object):
+  Shared:
+    - block.title: Section heading
+    - block.title_level: Heading level, defaults to 2
+    - block.subtitle: Optional subtitle text (with text-muted styling)
+    - block.content: Main content (rendered as markdown)
+    - block.reverse: If true, reverses the layout (content on right)
+    - block.reveal_content: Animation for content side (e.g., "left", "right")
+    - block.reveal_figure: Animation for figure side (default: "scale")
+    - block.button: Optional button object { text, href, variant }
+
+  Callout fields:
+    - block.figure_icon: Iconify ID, emoji, or image path
+    - block.figure_title: Bold heading text in the callout
+    - block.figure_subtitle: Supporting text
+    - block.figure_variant: Color scheme ("primary", "secondary", "gradient",
+      or a custom CSS gradient string)
+
+Usage:
+  {% include "design-system/split-callout.html",
+     block: {
+       title: "Our Coverage",
+       content: "We serve customers across the south of England.",
+       figure_icon: "&#128248;",
+       figure_title: "Covering the whole of the UK",
+       figure_subtitle: "Surrey, London, Kent, Sussex...",
+       figure_variant: "primary"
+     }
+  %}
+{%- endcomment -%}
+
+{%- assign title_level = block.title_level | default: 2 -%}
+{%- assign reveal_content = block.reveal_content | default: "left" -%}
+{%- assign reveal_figure = block.reveal_figure | default: "scale" -%}
+{%- assign variant = block.figure_variant | default: "primary" -%}
+
+<div class="split-callout{% if block.reverse %} split-callout--reverse{% endif %}">
+  <article class="stack" data-reveal="{{ reveal_content }}">
+    {%- if block.title -%}
+      <h{{ title_level }}>{{ block.title }}</h{{ title_level }}>
+    {%- endif -%}
+    {%- if block.subtitle -%}
+      <p class="text-muted">{{ block.subtitle }}</p>
+    {%- endif -%}
+    <div class="prose">{{ block.content | renderContent: "md" }}</div>
+    {%- if block.button -%}
+      {%- assign btn_variant = block.button.variant | default: "secondary" -%}
+      <a href="{{ block.button.href }}" class="btn btn--{{ btn_variant }}">{{ block.button.text }}</a>
+    {%- endif -%}
+  </article>
+  {%- if variant == "primary" or variant == "secondary" or variant == "gradient" -%}
+  <figure class="callout-box callout-box--{{ variant }}" data-reveal="{{ reveal_figure }}">
+  {%- else -%}
+  <figure class="callout-box" style="background: {{ variant }}" data-reveal="{{ reveal_figure }}">
+  {%- endif -%}
+    {%- if block.figure_icon -%}
+      <div class="callout-box__icon">{%- include "design-system/icon.html", icon: block.figure_icon -%}</div>
+    {%- endif -%}
+    {%- if block.figure_title -%}
+      <strong class="callout-box__title">{{ block.figure_title }}</strong>
+    {%- endif -%}
+    {%- if block.figure_subtitle -%}
+      <p class="callout-box__subtitle">{{ block.figure_subtitle }}</p>
+    {%- endif -%}
+  </figure>
+</div>

--- a/src/_includes/design-system/split-callout.html
+++ b/src/_includes/design-system/split-callout.html
@@ -37,6 +37,9 @@ Usage:
 {%- assign reveal_figure = block.reveal_figure | default: "scale" -%}
 {%- assign variant = block.figure_variant | default: "primary" -%}
 
+<!--
+// jscpd:ignore-start
+-->
 <div class="split-callout{% if block.reverse %} split-callout--reverse{% endif %}">
   <article class="stack" data-reveal="{{ reveal_content }}">
     {%- if block.title -%}
@@ -51,6 +54,9 @@ Usage:
       <a href="{{ block.button.href }}" class="btn btn--{{ btn_variant }}">{{ block.button.text }}</a>
     {%- endif -%}
   </article>
+<!--
+// jscpd:ignore-end
+-->
   {%- if variant == "primary" or variant == "secondary" or variant == "gradient" -%}
   <figure class="callout-box callout-box--{{ variant }}" data-reveal="{{ reveal_figure }}">
   {%- else -%}

--- a/src/_includes/design-system/split.html
+++ b/src/_includes/design-system/split.html
@@ -29,19 +29,7 @@ Parameters (via block object):
 {%- assign figure_type = block.type | replace: "split-", "" -%}
 
 <div class="split{% if block.reverse %} split--reverse{% endif %}">
-  <article class="stack" data-reveal="{{ reveal_content }}">
-    {%- if block.title -%}
-      <h{{ title_level }}>{{ block.title }}</h{{ title_level }}>
-    {%- endif -%}
-    {%- if block.subtitle -%}
-      <p class="text-muted">{{ block.subtitle }}</p>
-    {%- endif -%}
-    <div class="prose">{{ block.content | renderContent: "md" }}</div>
-    {%- if block.button -%}
-      {%- assign variant = block.button.variant | default: "secondary" -%}
-      <a href="{{ block.button.href }}" class="btn btn--{{ variant }}">{{ block.button.text }}</a>
-    {%- endif -%}
-  </article>
+  {%- include "design-system/split-article.html", block: block, reveal_content: reveal_content -%}
   <figure data-reveal="{{ reveal_figure }}">
     {%- case figure_type -%}
       {%- when "image" -%}

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -36,6 +36,7 @@ import * as reviews from "#utils/block-schema/reviews.js";
 import * as sectionHeader from "#utils/block-schema/section-header.js";
 import { CONTAINER_FIELDS } from "#utils/block-schema/shared.js";
 import * as snippet from "#utils/block-schema/snippet.js";
+import * as splitCallout from "#utils/block-schema/split-callout.js";
 import * as splitCode from "#utils/block-schema/split-code.js";
 import * as splitFull from "#utils/block-schema/split-full.js";
 import * as splitHtml from "#utils/block-schema/split-html.js";
@@ -71,6 +72,7 @@ const BLOCK_MODULES = [
   splitCode,
   splitIconLinks,
   splitHtml,
+  splitCallout,
   splitFull,
   cta,
   videoBackground,

--- a/src/_lib/utils/block-schema/split-callout.js
+++ b/src/_lib/utils/block-schema/split-callout.js
@@ -1,0 +1,57 @@
+/* jscpd:ignore-start */
+import {
+  SPLIT_BASE_CMS_FIELDS,
+  SPLIT_BASE_PARAMS,
+  SPLIT_BASE_SCHEMA,
+  str,
+} from "#utils/block-schema/split-shared.js";
+/* jscpd:ignore-end */
+
+export const type = "split-callout";
+
+export const schema = [
+  ...SPLIT_BASE_SCHEMA,
+  "figure_icon",
+  "figure_title",
+  "figure_subtitle",
+  "figure_variant",
+];
+
+export const docs = {
+  summary:
+    "Two-column layout with text content and a styled callout box with icon, title, and subtitle.",
+  template: "src/_includes/design-system/split-callout.html",
+  scss: "src/css/design-system/_split-callout.scss",
+  htmlRoot: '<div class="split-callout">',
+  params: {
+    ...SPLIT_BASE_PARAMS,
+    figure_icon: {
+      type: "string",
+      description:
+        "Icon content: Iconify ID (`prefix:name`), emoji, or image path.",
+    },
+    figure_title: {
+      type: "string",
+      required: true,
+      description: "Bold heading text in the callout box.",
+    },
+    figure_subtitle: {
+      type: "string",
+      description: "Supporting text below the title.",
+    },
+    figure_variant: {
+      type: "string",
+      default: '"primary"',
+      description:
+        'Color scheme: `"primary"`, `"secondary"`, `"gradient"`, or a custom CSS gradient string.',
+    },
+  },
+};
+
+export const cmsFields = {
+  ...SPLIT_BASE_CMS_FIELDS,
+  figure_icon: str("Icon (Iconify ID, emoji, or path)"),
+  figure_title: str("Callout Title", { required: true }),
+  figure_subtitle: str("Callout Subtitle"),
+  figure_variant: str("Callout Color Variant"),
+};

--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -56,6 +56,16 @@
   gap: $gap;
 }
 
+// Two-column responsive split: single column on mobile, two columns on md+.
+// Shared by .split, .split-callout, and .contact-form-block layouts.
+@mixin two-column-split {
+  @include grid(1, $space-2xl);
+
+  @include breakpoint.up("md") {
+    @include grid(2, $space-3xl);
+  }
+}
+
 @mixin grid-auto($min-width: 280px, $gap: $space-lg) {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax($min-width, 1fr));

--- a/src/css/design-system/_contact-form-block.scss
+++ b/src/css/design-system/_contact-form-block.scss
@@ -1,6 +1,5 @@
 @use "../variables" as *;
 @use "../mixins" as *;
-@use "../breakpoints" as breakpoint;
 
 // =============================================================================
 // CONTACT FORM BLOCK (text left, form right)
@@ -8,12 +7,8 @@
 
 .design-system {
   .contact-form-block {
-    @include grid(1, $space-2xl);
+    @include two-column-split;
     align-items: center;
-
-    @include breakpoint.up("md") {
-      @include grid(2, $space-3xl);
-    }
   }
 
   .contact-form-block > .prose {

--- a/src/css/design-system/_index.scss
+++ b/src/css/design-system/_index.scss
@@ -33,6 +33,7 @@
 @forward "specs";
 @forward "cta";
 @forward "split";
+@forward "split-callout";
 @forward "grid";
 @forward "slider";
 @forward "items";

--- a/src/css/design-system/_split-callout.scss
+++ b/src/css/design-system/_split-callout.scss
@@ -8,6 +8,7 @@
 // Two-column layout with text on one side and a styled callout box on the other.
 
 .design-system {
+  // jscpd:ignore-start
   .split-callout {
     @include grid(1, $space-2xl);
     align-items: center;
@@ -27,6 +28,7 @@
       }
     }
   }
+  // jscpd:ignore-end
 
   .callout-box {
     @include flex-col($space-md, center, center);

--- a/src/css/design-system/_split-callout.scss
+++ b/src/css/design-system/_split-callout.scss
@@ -1,34 +1,17 @@
 @use "../variables" as *;
 @use "../mixins" as *;
-@use "../breakpoints" as breakpoint;
 
 // =============================================================================
 // SPLIT CALLOUT
 // =============================================================================
-// Two-column layout with text on one side and a styled callout box on the other.
+// Two-column layout with text on one side and a styled callout box on the
+// other. Shared grid/reverse layout lives in _split.scss — this file only
+// defines the callout-box styling specific to this block.
 
 .design-system {
-  // jscpd:ignore-start
   .split-callout {
-    @include grid(1, $space-2xl);
     align-items: center;
-
-    @include breakpoint.up("md") {
-      @include grid(2, $space-3xl);
-    }
-
-    &--reverse {
-      @include breakpoint.up("md") {
-        > :first-child {
-          order: 2;
-        }
-        > :last-child {
-          order: 1;
-        }
-      }
-    }
   }
-  // jscpd:ignore-end
 
   .callout-box {
     @include flex-col($space-md, center, center);

--- a/src/css/design-system/_split-callout.scss
+++ b/src/css/design-system/_split-callout.scss
@@ -1,0 +1,68 @@
+@use "../variables" as *;
+@use "../mixins" as *;
+@use "../breakpoints" as breakpoint;
+
+// =============================================================================
+// SPLIT CALLOUT
+// =============================================================================
+// Two-column layout with text on one side and a styled callout box on the other.
+
+.design-system {
+  .split-callout {
+    @include grid(1, $space-2xl);
+    align-items: center;
+
+    @include breakpoint.up("md") {
+      @include grid(2, $space-3xl);
+    }
+
+    &--reverse {
+      @include breakpoint.up("md") {
+        > :first-child {
+          order: 2;
+        }
+        > :last-child {
+          order: 1;
+        }
+      }
+    }
+  }
+
+  .callout-box {
+    @include flex-col($space-md, center, center);
+    text-align: center;
+    padding: clamp($space-lg, 6vw, $space-3xl);
+    border-radius: $radius-2xl;
+    @include contrast-text-vars;
+
+    &--primary {
+      background: var(--color-link);
+    }
+
+    &--secondary {
+      background: var(--color-secondary);
+    }
+
+    &--gradient {
+      @include brand-gradient;
+    }
+
+    &__icon {
+      font-size: $font-size-4xl;
+
+      .icon {
+        width: 1em;
+        height: 1em;
+      }
+    }
+
+    &__title {
+      @include heading-md;
+    }
+
+    &__subtitle {
+      @include body-lg;
+      opacity: 0.9;
+    }
+  }
+}

--- a/src/css/design-system/_split.scss
+++ b/src/css/design-system/_split.scss
@@ -7,24 +7,25 @@
 // =============================================================================
 
 .design-system {
-  .split {
-    @include grid(1, $space-2xl);
-    align-items: start;
+  .split,
+  .split-callout {
+    @include two-column-split;
+  }
 
+  .split--reverse,
+  .split-callout--reverse {
     @include breakpoint.up("md") {
-      @include grid(2, $space-3xl);
-    }
-
-    &--reverse {
-      @include breakpoint.up("md") {
-        > :first-child {
-          order: 2;
-        }
-        > :last-child {
-          order: 1;
-        }
+      > :first-child {
+        order: 2;
+      }
+      > :last-child {
+        order: 1;
       }
     }
+  }
+
+  .split {
+    align-items: start;
 
     > figure {
       border-radius: $radius-xl;

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -206,7 +206,7 @@ blocks:
       ```
 
   # Themes Split (reversed)
-  - type: split-html
+  - type: split-callout
     title: 10 Themes.
     reverse: true
     reveal_content: right
@@ -218,12 +218,10 @@ blocks:
       text: Try the Live Theme Editor
       href: https://example.chobble.com/theme-editor/
       variant: secondary
-    figure_html: |
-      <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 3rem; text-align: center; color: white;">
-        <div style="font-size: 4rem; margin-bottom: 1rem;">🎨</div>
-        <strong style="font-size: 1.5rem;">Theme Switcher</strong>
-        <p style="opacity: 0.8; margin: 0.5rem 0 0;">Let visitors preview themes instantly (in the bottom right)</p>
-      </div>
+    figure_icon: "🎨"
+    figure_title: Theme Switcher
+    figure_subtitle: Let visitors preview themes instantly (in the bottom right)
+    figure_variant: gradient
 
   # E-Commerce Features (with header, grid--4 layout, custom colors)
   - type: features

--- a/test/unit/code-quality/html-in-js.test.js
+++ b/test/unit/code-quality/html-in-js.test.js
@@ -321,6 +321,7 @@ const htmlInJsAnalysis = withAllowlist({
     "src/_lib/utils/block-schema/markdown.js",
     "src/_lib/utils/block-schema/marquee-images.js",
     "src/_lib/utils/block-schema/section-header.js",
+    "src/_lib/utils/block-schema/split-callout.js",
     "src/_lib/utils/block-schema/split-shared.js",
     "src/_lib/utils/block-schema/split-full.js",
     "src/_lib/utils/block-schema/stats.js",

--- a/test/unit/code-quality/unused-classes.test.js
+++ b/test/unit/code-quality/unused-classes.test.js
@@ -111,6 +111,23 @@ const findClassReferencesInScss = (content, name) => {
     if (basePattern.test(content) && modifierPattern.test(content)) return true;
   }
 
+  // For BEM-style elements (e.g., "callout-box__icon"), check for SCSS nesting
+  // Pattern: &__element within a .base { } block (can be deeply nested)
+  if (name.includes("__")) {
+    const separatorIndex = name.indexOf("__");
+    const base = name.slice(0, separatorIndex);
+    const element = name.slice(separatorIndex + 2);
+    const baseEscaped = base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const elementEscaped = element.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Check if we have .base somewhere before &__element (allowing any nesting depth)
+    const basePattern = new RegExp(`${prefix}${baseEscaped}\\s*\\{`, "m");
+    const elementPattern = new RegExp(
+      `&__${elementEscaped}(?=[\\s,:{\\[>+~.)#]|$)`,
+      "m",
+    );
+    if (basePattern.test(content) && elementPattern.test(content)) return true;
+  }
+
   return false;
 };
 

--- a/test/unit/utils/block-schema.test.js
+++ b/test/unit/utils/block-schema.test.js
@@ -19,6 +19,7 @@ describe("BLOCK_SCHEMAS", () => {
       "split-code",
       "split-icon-links",
       "split-html",
+      "split-callout",
       "split-full",
       "cta",
       "video-background",
@@ -213,6 +214,39 @@ describe("validateBlocks", () => {
       },
     ];
     expect(() => validateBlocks(blocks)).not.toThrow();
+  });
+
+  test("allows all valid keys for split-callout", () => {
+    const blocks = [
+      {
+        type: "split-callout",
+        title: "Our Coverage",
+        title_level: 2,
+        subtitle: "Subtitle",
+        content: "<p>We serve the south of England.</p>",
+        figure_icon: "\u{1F4F8}",
+        figure_title: "Covering the whole of the UK",
+        figure_subtitle: "Surrey, London, Kent, Sussex...",
+        figure_variant: "primary",
+        reverse: true,
+        reveal_content: "left",
+        reveal_figure: "scale",
+        button: { text: "Learn More", href: "/coverage" },
+      },
+    ];
+    expect(() => validateBlocks(blocks)).not.toThrow();
+  });
+
+  test("rejects image-specific keys on split-callout", () => {
+    const blocks = [
+      {
+        type: "split-callout",
+        figure_title: "Title",
+        figure_src: "/img.jpg",
+        content: "<p>Content</p>",
+      },
+    ];
+    expect(() => validateBlocks(blocks)).toThrow('unknown keys: "figure_src"');
   });
 
   test("rejects figure_type key on split variants", () => {


### PR DESCRIPTION
## Summary
Introduces a new `split-callout` block component that provides a two-column layout combining text content on one side with a styled callout box on the other. The callout box features an icon, title, and subtitle with customizable color variants.

## Key Changes

- **New Component Files:**
  - `split-callout.html` - Main template with shared article content and styled callout figure
  - `split-callout.scss` - Styling for the callout box with color variants (primary, secondary, gradient, custom)
  - `split-callout.js` - Block schema definition and CMS field configuration

- **Refactored Shared Logic:**
  - Extracted common article markup into `split-article.html` to eliminate duplication between `split.html` and `split-callout.html`
  - Created `two-column-split()` mixin in `_mixins.scss` to consolidate responsive grid layout logic shared by `.split`, `.split-callout`, and `.contact-form-block`
  - Updated `_split.scss` to use the new mixin and apply shared layout to both `.split` and `.split-callout`

- **Integration:**
  - Registered block type in `render-block.html`
  - Added schema to `block-schema.js` with validation tests
  - Updated `eleventyComputed.js` with default reveal animations
  - Added SCSS import to `_index.scss`
  - Updated code quality tests to recognize BEM element selectors in nested SCSS and allowlist new schema file

- **Documentation:**
  - Added comprehensive block documentation to `BLOCKS_LAYOUT.md` with all parameters and defaults

## Implementation Details

The callout box supports flexible styling through the `figure_variant` parameter, accepting predefined variants ("primary", "secondary", "gradient") or custom CSS gradient strings. The component inherits all standard split layout features including reverse layout, custom reveal animations, and optional buttons. The refactored `split-article.html` ensures consistent text side rendering across split-based components.

https://claude.ai/code/session_012A8twSahhjvFzDHvaMvwRS