### PR TITLE
Refine slider navigation button selectors to target anchor elements

### DIFF
--- a/src/css/design-system/_slider.scss
+++ b/src/css/design-system/_slider.scss
@@ -70,8 +70,8 @@
     @include flex-row($space-md, center, center);
   }
 
-  .slider-prev,
-  .slider-next {
+  a.slider-prev,
+  a.slider-next {
     @include button-base;
     @include focus-ring;
     text-decoration: none;
@@ -100,8 +100,8 @@
   }
 
   // Dark section variant - hover inherits from base rule above
-  .dark .slider-prev,
-  .dark .slider-next {
+  .dark a.slider-prev,
+  .dark a.slider-next {
     background: var(--color-card-bg);
     border-color: $color-dark-card-bg;
     color: $color-dark-text;


### PR DESCRIPTION
## Summary
Updated CSS selectors for slider navigation buttons to specifically target anchor (`<a>`) elements, improving selector specificity and ensuring styles are applied only to the intended button elements.

## Key Changes
- Modified `.slider-prev` and `.slider-next` selectors to `a.slider-prev` and `a.slider-next` in the base slider styles
- Updated corresponding dark variant selectors from `.dark .slider-prev` and `.dark .slider-next` to `.dark a.slider-prev` and `.dark a.slider-next`

## Implementation Details
These changes increase selector specificity by explicitly requiring the element to be an anchor tag. This prevents the styles from being inadvertently applied to other elements that might have these classes, and ensures the button styling is only applied to the intended semantic HTML structure.

https://claude.ai/code/session_01FAAe2qfaAjKhntu23rc4x3