### PR TITLE
Consolidate split block type handling in render-block

### DIFF
--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -22,19 +22,7 @@ Renders a single block by type. Used by blocks.html.
   {%- when "hero" -%}
     {%- include "design-system/hero.html", block: block -%}
 
-  {%- when "split-image" -%}
-    {%- include "design-system/split.html", block: block -%}
-
-  {%- when "split-video" -%}
-    {%- include "design-system/split.html", block: block -%}
-
-  {%- when "split-code" -%}
-    {%- include "design-system/split.html", block: block -%}
-
-  {%- when "split-icon-links" -%}
-    {%- include "design-system/split.html", block: block -%}
-
-  {%- when "split-html" -%}
+  {%- when "split-image", "split-video", "split-code", "split-icon-links", "split-html" -%}
     {%- include "design-system/split.html", block: block -%}
 
   {%- when "split-callout" -%}

--- a/src/_includes/design-system/split.html
+++ b/src/_includes/design-system/split.html
@@ -23,30 +23,28 @@ Parameters (via block object):
     split-html:       figure_html
 {%- endcomment -%}
 
-{%- assign title_level = block.title_level | default: 2 -%}
 {%- assign reveal_content = block.reveal_content | default: "left" -%}
 {%- assign reveal_figure = block.reveal_figure | default: "scale" -%}
-{%- assign figure_type = block.type | replace: "split-", "" -%}
 
 <div class="split{% if block.reverse %} split--reverse{% endif %}">
   {%- include "design-system/split-article.html", block: block, reveal_content: reveal_content -%}
   <figure data-reveal="{{ reveal_figure }}">
-    {%- case figure_type -%}
-      {%- when "image" -%}
+    {%- case block.type -%}
+      {%- when "split-image" -%}
         {% image block.figure_src, block.figure_alt %}
         {%- if block.figure_caption -%}
           <figcaption>{{ block.figure_caption }}</figcaption>
         {%- endif -%}
-      {%- when "video" -%}
+      {%- when "split-video" -%}
         {%- include "design-system/video-iframe.html", video_id: block.figure_video_id, title: block.figure_alt -%}
         {%- if block.figure_caption -%}
           <figcaption>{{ block.figure_caption }}</figcaption>
         {%- endif -%}
-      {%- when "code" -%}
+      {%- when "split-code" -%}
         {%- include "design-system/code-block.html", filename: block.figure_filename, code: block.figure_code, language: block.figure_language -%}
-      {%- when "icon-links" -%}
+      {%- when "split-icon-links" -%}
         {%- include "design-system/icon-links.html", items: block.figure_items -%}
-      {%- when "html" -%}
+      {%- when "split-html" -%}
         {{ block.figure_html }}
     {%- endcase -%}
   </figure>

--- a/test/unit/utils/block-docs.test.js
+++ b/test/unit/utils/block-docs.test.js
@@ -15,7 +15,9 @@ const GENERATOR_SCRIPT = join(rootDir, "scripts/generate-blocks-reference.js");
 /** Extract block type names from the Liquid case statements in render-block.html */
 const getRenderedBlockTypes = () => {
   const content = readFileSync(RENDER_BLOCK_PATH, "utf-8");
-  const whenClauses = [...content.matchAll(/when\s+("[^"]+"(?:\s*,\s*"[^"]+")*)/g)];
+  const whenClauses = [
+    ...content.matchAll(/when\s+("[^"]+"(?:\s*,\s*"[^"]+")*)/g),
+  ];
   return whenClauses
     .flatMap((m) => [...m[1].matchAll(/"([^"]+)"/g)].map((q) => q[1]))
     .sort();

--- a/test/unit/utils/block-docs.test.js
+++ b/test/unit/utils/block-docs.test.js
@@ -15,8 +15,10 @@ const GENERATOR_SCRIPT = join(rootDir, "scripts/generate-blocks-reference.js");
 /** Extract block type names from the Liquid case statements in render-block.html */
 const getRenderedBlockTypes = () => {
   const content = readFileSync(RENDER_BLOCK_PATH, "utf-8");
-  const matches = [...content.matchAll(/when\s+"([^"]+)"/g)];
-  return matches.map((m) => m[1]).sort();
+  const whenClauses = [...content.matchAll(/when\s+("[^"]+"(?:\s*,\s*"[^"]+")*)/g)];
+  return whenClauses
+    .flatMap((m) => [...m[1].matchAll(/"([^"]+)"/g)].map((q) => q[1]))
+    .sort();
 };
 
 describe("BLOCK_DOCS completeness", () => {


### PR DESCRIPTION
## Summary
Refactored the split block type handling to reduce code duplication and improve maintainability by consolidating multiple similar case statements into a single multi-value case clause.

## Key Changes
- **render-block.html**: Consolidated five separate `when` clauses for split block types (`split-image`, `split-video`, `split-code`, `split-icon-links`, `split-html`) into a single multi-value case statement that all include the same template
- **split.html**: 
  - Removed the `title_level` variable assignment (unused)
  - Removed the `figure_type` variable and string replacement logic
  - Updated the case statement to match against the full `block.type` value instead of the derived `figure_type`
  - Changed all case values from shortened names (e.g., `"image"`) to full block type names (e.g., `"split-image"`)
- **block-docs.test.js**: Updated the regex pattern to correctly parse multi-value case statements with comma-separated values, ensuring the test properly extracts all block type names

## Implementation Details
This refactoring eliminates redundant code while maintaining identical functionality. The consolidation in `render-block.html` makes it immediately clear that all five split variants use the same template, and the updated `split.html` logic is more straightforward by working directly with the block type rather than deriving and transforming it.

https://claude.ai/code/session_01LjLHeqQiGNuxy85w5EmEPj