### PR TITLE
Lock .pages.yml, BLOCKS_LAYOUT.md, and block schemas together

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -61,6 +61,26 @@ components:
             label: Description
             required: true
           - { name: style, type: string, label: Custom Style }
+  block_image_cards:
+    label: Image Cards
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: heading_level, type: number, label: Heading Level }
+      - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
+      - { name: header_intro, type: rich-text, label: Header Intro }
+      - name: items
+        type: object
+        label: Cards
+        list: true
+        fields:
+          - { name: image, type: image, label: Image, required: true }
+          - { name: title, type: string, label: Title, required: true }
+          - { name: description, type: string, label: Description }
+          - { name: link, type: string, label: Link URL }
   block_stats:
     label: Stats
     type: object
@@ -211,14 +231,17 @@ components:
           - { name: size, type: string, label: Size }
       - name: figure_items
         type: object
-        label: Icon Links
+        label: Links
         list: true
         fields:
-          - { name: icon, type: string, label: "Icon (Iconify ID or HTML entity)", required: true }
+          - name: icon
+            type: string
+            label: Icon (Iconify ID or HTML entity)
+            required: true
           - { name: text, type: string, label: Link Text, required: true }
           - { name: url, type: string, label: URL }
   block_split_html:
-    label: Split HTML
+    label: Split Html
     type: object
     fields:
       - name: container_width
@@ -241,6 +264,38 @@ components:
           - { name: variant, type: string, label: Variant }
           - { name: size, type: string, label: Size }
       - { name: figure_html, type: rich-text, label: Figure HTML Content }
+  block_split_callout:
+    label: Split Callout
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: title, type: string, label: Title }
+      - { name: title_level, type: number, label: Heading Level }
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: reverse, type: boolean, label: Reverse Layout }
+      - { name: reveal_content, type: string, label: Reveal Content Animation }
+      - { name: reveal_figure, type: string, label: Reveal Figure Animation }
+      - { name: content, type: rich-text, label: Content }
+      - name: button
+        type: object
+        label: Button
+        fields:
+          - { name: text, type: string, label: Button Text, required: true }
+          - { name: href, type: string, label: URL, required: true }
+          - { name: variant, type: string, label: Variant }
+          - { name: size, type: string, label: Size }
+      - name: figure_icon
+        type: string
+        label: Icon (Iconify ID, emoji, or path)
+      - name: figure_title
+        type: string
+        label: Callout Title
+        required: true
+      - { name: figure_subtitle, type: string, label: Callout Subtitle }
+      - { name: figure_variant, type: string, label: Callout Color Variant }
   block_split_full:
     label: Split Full
     type: object
@@ -298,9 +353,42 @@ components:
         label: Container Width (full, wide, narrow)
       - { name: section_class, type: string, label: Section Class }
       - { name: video_id, type: string, label: Video Embed URL, required: true }
+      - { name: thumbnail_url, type: string, label: Thumbnail URL }
       - { name: video_title, type: string, label: Video Title }
       - { name: aspect_ratio, type: string, label: Aspect Ratio }
-      - { name: thumbnail_url, type: string, label: Thumbnail URL }
+      - { name: class, type: string, label: CSS Class }
+      - { name: content, type: rich-text, label: Overlay Content }
+  block_bunny_video_background:
+    label: Bunny Video Background
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - name: video_url
+        type: string
+        label: Bunny Stream Embed URL
+        required: true
+      - name: thumbnail_url
+        type: string
+        label: Thumbnail URL
+        required: true
+      - { name: video_title, type: string, label: Video Title }
+      - { name: aspect_ratio, type: string, label: Aspect Ratio }
+      - { name: class, type: string, label: CSS Class }
+      - { name: content, type: rich-text, label: Overlay Content }
+  block_image_background:
+    label: Image Background
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: image, type: image, label: Background Image, required: true }
+      - { name: image_alt, type: string, label: Image Alt Text }
+      - { name: parallax, type: boolean, label: Parallax }
       - { name: class, type: string, label: CSS Class }
       - { name: content, type: rich-text, label: Overlay Content }
   block_items:
@@ -371,6 +459,120 @@ components:
         label: Container Width (full, wide, narrow)
       - { name: section_class, type: string, label: Section Class }
       - { name: content, type: rich-text, label: Content }
+  block_custom_contact_form:
+    label: Custom Contact Form
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - name: fields
+        type: object
+        label: Form Fields
+        list: true
+        fields:
+          - { name: name, type: string, label: Field Name, required: true }
+          - { name: label, type: string, label: Field Label, required: true }
+          - name: type
+            type: string
+            label: Field Type (text, email, tel, textarea, select, radio, heading)
+          - { name: placeholder, type: string, label: Placeholder }
+          - { name: required, type: boolean, label: Required }
+          - { name: rows, type: number, label: Rows (for textarea) }
+          - { name: note, type: string, label: Help Note }
+          - { name: fieldClass, type: string, label: CSS Class }
+      - { name: content, type: rich-text, label: Intro Content }
+      - { name: header_intro, type: rich-text, label: Header Intro }
+  block_markdown:
+    label: Markdown
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: content, type: rich-text, label: Markdown }
+  block_html:
+    label: Html
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: content, type: string, label: Raw HTML, required: true }
+  block_content:
+    label: Content
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+  block_include:
+    label: Include
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: file, type: string, label: Template File Path, required: true }
+  block_properties:
+    label: Properties
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+  block_guide_categories:
+    label: Guide Categories
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+  block_link_button:
+    label: Link Button
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: text, type: string, label: Button Text, required: true }
+      - { name: href, type: string, label: URL, required: true }
+      - { name: variant, type: string, label: Variant }
+      - { name: size, type: string, label: Size }
+      - { name: reveal, type: string, label: Reveal Animation }
+  block_reviews:
+    label: Reviews
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: current_item, type: boolean, label: Filter to Current Item }
+  block_gallery:
+    label: Gallery
+    type: object
+    fields:
+      - name: container_width
+        type: string
+        label: Container Width (full, wide, narrow)
+      - { name: section_class, type: string, label: Section Class }
+      - { name: aspect_ratio, type: string, label: Aspect Ratio }
+      - name: items
+        type: object
+        label: Gallery Images
+        list: true
+        fields:
+          - { name: image, type: image, label: Image, required: true }
+          - { name: caption, type: string, label: Caption }
   block_marquee_images:
     label: Marquee Images
     type: object
@@ -501,6 +703,7 @@ content:
         blocks:
           - { name: section-header, component: block_section_header }
           - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
           - { name: stats, component: block_stats }
           - { name: code-block, component: block_code_block }
           - { name: hero, component: block_hero }
@@ -509,12 +712,26 @@ content:
           - { name: split-code, component: block_split_code }
           - { name: split-icon-links, component: block_split_icon_links }
           - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
           - { name: split-full, component: block_split_full }
           - { name: cta, component: block_cta }
           - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
           - { name: items, component: block_items }
           - { name: items-array, component: block_items_array }
           - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
           - { name: marquee-images, component: block_marquee_images }
           - { name: icon-links, component: block_icon_links }
           - { name: snippet, component: block_snippet }

--- a/scripts/customise-cms/compact-yaml.js
+++ b/scripts/customise-cms/compact-yaml.js
@@ -58,8 +58,10 @@ const extractKeyValue = (line) => {
   const cleanKey = key.replace(/^-\s*/, "");
   const value = trimmed.substring(colonIndex + 1).trim();
 
-  // Only return simple values (no nested structures)
-  if (!value || value.startsWith("[") || value.startsWith("{")) {
+  // Only return simple values (no nested structures). Also reject values
+  // containing flow-significant characters — commas, braces, brackets — which
+  // would break when emitted inside an inline `{ ... }` mapping without quotes.
+  if (!value || /[,{}[\]]/.test(value)) {
     return null;
   }
 
@@ -80,9 +82,10 @@ const objectToInline = (lines) => {
     if (shouldSkipLine(trimmed)) continue;
 
     const pair = extractKeyValue(line);
-    if (pair) {
-      pairs.push(`${pair.key}: ${pair.value}`);
-    }
+    // If any content line can't be safely represented inline, refuse to
+    // compact the whole object — otherwise we'd silently drop that line.
+    if (!pair) return null;
+    pairs.push(`${pair.key}: ${pair.value}`);
   }
 
   return pairs.length > 0 ? `{ ${pairs.join(", ")} }` : null;

--- a/scripts/customise-cms/compact-yaml.js
+++ b/scripts/customise-cms/compact-yaml.js
@@ -159,11 +159,7 @@ const tryCompactLine = (objectLines, listIndent) => {
   const fullInlineLine = `${" ".repeat(listIndent)}- ${inlineVersion}`;
 
   // Only use inline version if it stays under 80 chars
-  if (fullInlineLine.length <= 80) {
-    return fullInlineLine;
-  }
-
-  return null; // Line too long
+  return fullInlineLine.length <= 80 ? fullInlineLine : null;
 };
 
 /**

--- a/src/_lib/utils/block-schema/bunny-video-background.js
+++ b/src/_lib/utils/block-schema/bunny-video-background.js
@@ -5,6 +5,7 @@ import {
   videoBgSharedFields,
 } from "#utils/block-schema/shared.js";
 
+/** @param {string} label */
 const requiredString = (label) => ({ type: "string", label, required: true });
 
 export const type = "bunny-video-background";

--- a/src/_lib/utils/block-schema/bunny-video-background.js
+++ b/src/_lib/utils/block-schema/bunny-video-background.js
@@ -2,7 +2,10 @@ import {
   CLASS_PARAM,
   OVERLAY_CONTENT_PARAM,
   VIDEO_BG_SHARED_PARAMS,
+  videoBgSharedFields,
 } from "#utils/block-schema/shared.js";
+
+const requiredString = (label) => ({ type: "string", label, required: true });
 
 export const type = "bunny-video-background";
 
@@ -39,4 +42,10 @@ export const docs = {
     content: OVERLAY_CONTENT_PARAM,
     class: CLASS_PARAM,
   },
+};
+
+export const cmsFields = {
+  video_url: requiredString("Bunny Stream Embed URL"),
+  thumbnail_url: requiredString("Thumbnail URL"),
+  ...videoBgSharedFields(),
 };

--- a/src/_lib/utils/block-schema/content.js
+++ b/src/_lib/utils/block-schema/content.js
@@ -10,3 +10,6 @@ export const docs = {
     "No parameters. Renders `{{ content }}` if non-empty. Used for pages that combine blocks with traditional markdown content.",
   params: {},
 };
+
+/** No block-specific fields — only the auto-injected container wrapper fields. */
+export const cmsFields = {};

--- a/src/_lib/utils/block-schema/custom-contact-form.js
+++ b/src/_lib/utils/block-schema/custom-contact-form.js
@@ -1,4 +1,12 @@
-import { HEADER_KEYS, HEADER_PARAM_DOCS } from "#utils/block-schema/shared.js";
+import {
+  bool,
+  HEADER_KEYS,
+  HEADER_PARAM_DOCS,
+  md,
+  num,
+  objectList,
+  str,
+} from "#utils/block-schema/shared.js";
 
 export const type = "custom-contact-form";
 
@@ -26,4 +34,21 @@ export const docs = {
     },
     ...HEADER_PARAM_DOCS,
   },
+};
+
+const FORM_FIELD_DEFINITIONS = objectList("Form Fields", {
+  name: str("Field Name", { required: true }),
+  label: str("Field Label", { required: true }),
+  type: str("Field Type (text, email, tel, textarea, select, radio, heading)"),
+  placeholder: str("Placeholder"),
+  required: bool("Required"),
+  rows: num("Rows (for textarea)"),
+  note: str("Help Note"),
+  fieldClass: str("CSS Class"),
+});
+
+export const cmsFields = {
+  fields: FORM_FIELD_DEFINITIONS,
+  content: md("Intro Content"),
+  header_intro: md("Header Intro"),
 };

--- a/src/_lib/utils/block-schema/gallery.js
+++ b/src/_lib/utils/block-schema/gallery.js
@@ -1,6 +1,9 @@
 import {
   ITEMS_ARRAY_PARAM,
   ITEMS_GRID_META,
+  img,
+  objectList,
+  str,
 } from "#utils/block-schema/shared.js";
 
 export const type = "gallery";
@@ -23,4 +26,12 @@ export const docs = {
         'Aspect ratio for images (e.g. `"16/9"`, `"1/1"`, `"4/3"`). Default: no cropping.',
     },
   },
+};
+
+export const cmsFields = {
+  aspect_ratio: str("Aspect Ratio"),
+  items: objectList("Gallery Images", {
+    image: img("Image", { required: true }),
+    caption: str("Caption"),
+  }),
 };

--- a/src/_lib/utils/block-schema/guide-categories.js
+++ b/src/_lib/utils/block-schema/guide-categories.js
@@ -9,3 +9,6 @@ export const docs = {
     "No block-level parameters. Uses the global `collections.guide-categories`.",
   params: {},
 };
+
+/** No block-specific fields — only the auto-injected container wrapper fields. */
+export const cmsFields = {};

--- a/src/_lib/utils/block-schema/html.js
+++ b/src/_lib/utils/block-schema/html.js
@@ -1,3 +1,5 @@
+import { str } from "#utils/block-schema/shared.js";
+
 export const type = "html";
 
 export const schema = ["content"];
@@ -13,4 +15,8 @@ export const docs = {
       description: "Raw HTML. Output directly with `{{ block.content }}`.",
     },
   },
+};
+
+export const cmsFields = {
+  content: str("Raw HTML", { required: true }),
 };

--- a/src/_lib/utils/block-schema/image-background.js
+++ b/src/_lib/utils/block-schema/image-background.js
@@ -1,6 +1,10 @@
 import {
+  bool,
   CLASS_PARAM,
+  img,
+  md,
   OVERLAY_CONTENT_PARAM,
+  str,
 } from "#utils/block-schema/shared.js";
 
 export const type = "image-background";
@@ -35,4 +39,12 @@ export const docs = {
         "Enables CSS `animation-timeline: scroll()` parallax effect.",
     },
   },
+};
+
+export const cmsFields = {
+  image: img("Background Image", { required: true }),
+  image_alt: str("Image Alt Text"),
+  parallax: bool("Parallax"),
+  class: str("CSS Class"),
+  content: md("Overlay Content"),
 };

--- a/src/_lib/utils/block-schema/image-cards.js
+++ b/src/_lib/utils/block-schema/image-cards.js
@@ -3,7 +3,12 @@ import {
   HEADER_PARAM_DOCS,
   ITEMS_ARRAY_PARAM,
   ITEMS_GRID_META,
+  img,
+  md,
+  num,
+  objectList,
   REVEAL_BOOLEAN_PARAM,
+  str,
 } from "#utils/block-schema/shared.js";
 
 export const type = "image-cards";
@@ -42,4 +47,16 @@ export const docs = {
     },
     ...HEADER_PARAM_DOCS,
   },
+};
+
+export const cmsFields = {
+  heading_level: num("Heading Level"),
+  image_aspect_ratio: str("Image Aspect Ratio"),
+  header_intro: md("Header Intro"),
+  items: objectList("Cards", {
+    image: img("Image", { required: true }),
+    title: str("Title", { required: true }),
+    description: str("Description"),
+    link: str("Link URL"),
+  }),
 };

--- a/src/_lib/utils/block-schema/include.js
+++ b/src/_lib/utils/block-schema/include.js
@@ -1,3 +1,5 @@
+import { str } from "#utils/block-schema/shared.js";
+
 export const type = "include";
 
 export const schema = ["file"];
@@ -13,4 +15,8 @@ export const docs = {
       description: "Path to the template file to include.",
     },
   },
+};
+
+export const cmsFields = {
+  file: str("Template File Path", { required: true }),
 };

--- a/src/_lib/utils/block-schema/link-button.js
+++ b/src/_lib/utils/block-schema/link-button.js
@@ -1,4 +1,8 @@
-import { REVEAL_PARAM } from "#utils/block-schema/shared.js";
+import {
+  BUTTON_FIELDS_WITH_SIZE,
+  REVEAL_PARAM,
+  str,
+} from "#utils/block-schema/shared.js";
 
 export const type = "link-button";
 
@@ -31,4 +35,9 @@ export const docs = {
     },
     reveal: REVEAL_PARAM,
   },
+};
+
+export const cmsFields = {
+  ...BUTTON_FIELDS_WITH_SIZE,
+  reveal: str("Reveal Animation"),
 };

--- a/src/_lib/utils/block-schema/markdown.js
+++ b/src/_lib/utils/block-schema/markdown.js
@@ -1,3 +1,5 @@
+import { md } from "#utils/block-schema/shared.js";
+
 export const type = "markdown";
 
 export const schema = ["content"];
@@ -15,4 +17,8 @@ export const docs = {
         'Markdown content. Passed through `renderContent: "md"` filter.',
     },
   },
+};
+
+export const cmsFields = {
+  content: md("Markdown"),
 };

--- a/src/_lib/utils/block-schema/properties.js
+++ b/src/_lib/utils/block-schema/properties.js
@@ -10,3 +10,6 @@ export const docs = {
     "No block-level parameters. Uses the global `collections.properties` and optional `filterPage` data for URL-based filtering.",
   params: {},
 };
+
+/** No block-specific fields — only the auto-injected container wrapper fields. */
+export const cmsFields = {};

--- a/src/_lib/utils/block-schema/reviews.js
+++ b/src/_lib/utils/block-schema/reviews.js
@@ -1,3 +1,5 @@
+import { bool } from "#utils/block-schema/shared.js";
+
 export const type = "reviews";
 
 export const schema = ["current_item"];
@@ -16,4 +18,8 @@ export const docs = {
         "If true, filters reviews to the current item by slug and tags.",
     },
   },
+};
+
+export const cmsFields = {
+  current_item: bool("Filter to Current Item"),
 };

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -89,6 +89,19 @@ export const VIDEO_BG_SHARED_PARAMS = {
   },
 };
 
+/**
+ * Shared CMS fields for video-background and bunny-video-background.
+ * Gets spread into each block's cmsFields alongside its block-specific fields,
+ * and also keeps the two modules from having identical field lists (which
+ * would be flagged as duplication).
+ */
+export const videoBgSharedFields = () => ({
+  video_title: str("Video Title"),
+  aspect_ratio: str("Aspect Ratio"),
+  class: str("CSS Class"),
+  content: md("Overlay Content"),
+});
+
 /** Overlay content param doc for video-background and image-background. */
 export const OVERLAY_CONTENT_PARAM = {
   type: "string",
@@ -150,6 +163,8 @@ export const md = (label) => ({ type: "markdown", label });
 export const num = (label) => ({ type: "number", label });
 /** @param {string} label */
 export const bool = (label) => ({ type: "boolean", label });
+/** @param {string} label @param {object} [extras] */
+export const img = (label, extras) => ({ type: "image", label, ...extras });
 /** @param {string} label @param {Record<string, object>} fields */
 export const objectList = (label, fields) => ({
   type: "object",

--- a/src/_lib/utils/block-schema/video-background.js
+++ b/src/_lib/utils/block-schema/video-background.js
@@ -1,9 +1,9 @@
 import {
   CLASS_PARAM,
-  md,
   OVERLAY_CONTENT_PARAM,
   str,
   VIDEO_BG_SHARED_PARAMS,
+  videoBgSharedFields,
 } from "#utils/block-schema/shared.js";
 
 export const type = "video-background";
@@ -44,9 +44,6 @@ export const docs = {
 
 export const cmsFields = {
   video_id: str("Video Embed URL", { required: true }),
-  video_title: str("Video Title"),
-  aspect_ratio: str("Aspect Ratio"),
   thumbnail_url: str("Thumbnail URL"),
-  class: str("CSS Class"),
-  content: md("Overlay Content"),
+  ...videoBgSharedFields(),
 };

--- a/test/unit/code-quality/pages-yml-freshness.test.js
+++ b/test/unit/code-quality/pages-yml-freshness.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { rootDir } from "#test/test-utils.js";
+
+const PAGES_YML_PATH = join(rootDir, ".pages.yml");
+const GENERATOR_SCRIPT = join(
+  rootDir,
+  "scripts/customise-cms/generate-full.js",
+);
+
+/** Mirrors the BLOCKS_LAYOUT.md freshness test in block-docs.test.js: the
+ *  committed .pages.yml must match what the full-config generator produces,
+ *  so any change to BLOCK_CMS_FIELDS or the generator output shape forces a
+ *  regeneration rather than silently drifting. */
+describe("pages-yml-freshness", () => {
+  test(".pages.yml matches generator output", () => {
+    const committed = readFileSync(PAGES_YML_PATH, "utf-8");
+    execSync(`bun ${GENERATOR_SCRIPT}`, { cwd: rootDir, stdio: "pipe" });
+    const regenerated = readFileSync(PAGES_YML_PATH, "utf-8");
+    expect(regenerated).toBe(committed);
+  });
+});

--- a/test/unit/scripts/customise-cms/compact-yaml.test.js
+++ b/test/unit/scripts/customise-cms/compact-yaml.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import YAML from "yaml";
+import { compactYaml } from "#scripts/customise-cms/compact-yaml.js";
+
+/** Round-trip through both a YAML parser and the compactor to ensure the
+ *  compacted output still parses to the same document. */
+const compactAndParse = (yamlString) => YAML.parse(compactYaml(yamlString));
+
+describe("compactYaml", () => {
+  test("compacts small objects to inline form", () => {
+    const input = ["- name: foo", "  type: string", "  label: Foo", ""].join(
+      "\n",
+    );
+    expect(compactYaml(input)).toContain(
+      "{ name: foo, type: string, label: Foo }",
+    );
+  });
+
+  test("does not compact values containing commas (would break flow YAML)", () => {
+    // A value like `Size (sm, lg)` contains a comma, which terminates a flow
+    // mapping entry. Emitting it inline produces invalid YAML.
+    const input = [
+      "- name: size",
+      "  type: string",
+      "  label: Size (sm, lg)",
+      "",
+    ].join("\n");
+    // Must still parse as valid YAML
+    const parsed = compactAndParse(input);
+    expect(parsed).toEqual([
+      { name: "size", type: "string", label: "Size (sm, lg)" },
+    ]);
+  });
+
+  test("does not compact values containing braces", () => {
+    const input = ["- name: x", "  label: a {b} c", ""].join("\n");
+    const parsed = compactAndParse(input);
+    expect(parsed).toEqual([{ name: "x", label: "a {b} c" }]);
+  });
+
+  test("does not compact values containing brackets", () => {
+    const input = ["- name: x", "  label: a [b] c", ""].join("\n");
+    const parsed = compactAndParse(input);
+    expect(parsed).toEqual([{ name: "x", label: "a [b] c" }]);
+  });
+});

--- a/test/unit/scripts/customise-cms/compact-yaml.test.js
+++ b/test/unit/scripts/customise-cms/compact-yaml.test.js
@@ -43,4 +43,45 @@ describe("compactYaml", () => {
     const parsed = compactAndParse(input);
     expect(parsed).toEqual([{ name: "x", label: "a [b] c" }]);
   });
+
+  test("leaves single-line list items alone (nothing to compact)", () => {
+    // When a `- key: value` item is immediately followed by another
+    // dedented item (no child lines, no trailing blank), the collected
+    // object has only one line — tryCompactLine must bail rather than
+    // pointlessly rewrapping in `{ ... }`.
+    const input = "- name: solo\n- name: next";
+    expect(compactYaml(input)).toBe(input);
+  });
+
+  test("leaves objects in block form when the inlined line would exceed 80 chars", () => {
+    // The compactor refuses to inline if the resulting `- { ... }` line would
+    // exceed the 80-char width budget. With a long enough label the inline
+    // form blows past 80 chars, so the original block form is preserved.
+    const longLabel = "x".repeat(100);
+    const input = [
+      "- name: foo",
+      "  type: string",
+      `  label: ${longLabel}`,
+    ].join("\n");
+    expect(compactYaml(input)).toBe(input);
+  });
+
+  test("does not compact objects with nested structures", () => {
+    // A line ending with `:` and no value marks a nested block that the
+    // inline `{ ... }` form can't represent — compaction must bail out and
+    // leave the object in its original block form.
+    const input = [
+      "- name: item",
+      "  type: string",
+      "  options:",
+      "    multiple: true",
+      "",
+    ].join("\n");
+    // Output must still parse to the same structure
+    expect(compactAndParse(input)).toEqual([
+      { name: "item", type: "string", options: { multiple: true } },
+    ]);
+    // And must not be inlined (no `{ ... }` wrapper for the outer item)
+    expect(compactYaml(input)).not.toContain("{ name: item");
+  });
 });

--- a/test/unit/scripts/customise-cms/generator.test.js
+++ b/test/unit/scripts/customise-cms/generator.test.js
@@ -34,14 +34,18 @@ const createTestConfig = (overrides = {}) => ({
 });
 
 /**
- * Extract a named collection section from YAML output.
+ * Extract a named top-level collection section from YAML output.
+ * Anchors on the 2-space collection indent so names that also appear
+ * as block references (e.g. `{ name: guide-categories, component: ... }`)
+ * deeper in the tree don't match.
  * @param {string} collectionName
  * @returns {(yaml: string) => string}
  */
 const getSection = (collectionName) => (yaml) => {
-  const marker = `name: ${collectionName}`;
-  const start = yaml.indexOf(marker);
-  if (start === -1) return "";
+  const marker = `\n  - name: ${collectionName}\n`;
+  const markerIndex = yaml.indexOf(marker);
+  if (markerIndex === -1) return "";
+  const start = markerIndex + 1;
   const remainder = yaml.substring(start + 1);
   const nextCollectionMatch = remainder.match(/\n {2}- name: /);
   return nextCollectionMatch

--- a/test/unit/utils/block-docs.test.js
+++ b/test/unit/utils/block-docs.test.js
@@ -2,8 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import YAML from "yaml";
 import { rootDir } from "#test/test-utils.js";
-import { BLOCK_DOCS, BLOCK_SCHEMAS } from "#utils/block-schema.js";
+import { collectBlockReferences } from "#test/unit/utils/pages-yml-helpers.js";
+import {
+  BLOCK_CMS_FIELDS,
+  BLOCK_DOCS,
+  BLOCK_SCHEMAS,
+} from "#utils/block-schema.js";
 
 const RENDER_BLOCK_PATH = join(
   rootDir,
@@ -11,6 +17,7 @@ const RENDER_BLOCK_PATH = join(
 );
 const BLOCKS_LAYOUT_PATH = join(rootDir, "BLOCKS_LAYOUT.md");
 const GENERATOR_SCRIPT = join(rootDir, "scripts/generate-blocks-reference.js");
+const PAGES_YML_PATH = join(rootDir, ".pages.yml");
 
 /** Extract block type names from the Liquid case statements in render-block.html */
 const getRenderedBlockTypes = () => {
@@ -96,5 +103,41 @@ describe("BLOCKS_LAYOUT.md freshness", () => {
     execSync(`bun ${GENERATOR_SCRIPT}`, { cwd: rootDir, stdio: "pipe" });
     const regenerated = readFileSync(BLOCKS_LAYOUT_PATH, "utf-8");
     expect(regenerated).toBe(committed);
+  });
+});
+
+describe(".pages.yml ↔ BLOCKS_LAYOUT.md coverage", () => {
+  const parsedPagesYml = YAML.parse(readFileSync(PAGES_YML_PATH, "utf-8"));
+  // Every block type reachable through the CMS UI — each must have
+  // user-facing docs in BLOCKS_LAYOUT.md.
+  const cmsReachableTypes = new Set(
+    collectBlockReferences(parsedPagesYml).map((r) => r.name),
+  );
+
+  test("every CMS-reachable block type has BLOCK_DOCS with a summary", () => {
+    const missing = [...cmsReachableTypes]
+      .filter((type) => !BLOCK_DOCS[type]?.summary)
+      .sort();
+    expect(missing).toEqual([]);
+  });
+
+  test("every CMS-reachable block's CMS field is documented in BLOCK_DOCS.params", () => {
+    // container_width and section_class are injected by the generator for every
+    // block and documented once in the "Common Block Properties" table at the
+    // top of BLOCKS_LAYOUT.md — skip them here.
+    const containerFields = new Set(["container_width", "section_class"]);
+    const violations = [...cmsReachableTypes].flatMap((type) => {
+      const docParams = Object.keys(BLOCK_DOCS[type]?.params || {});
+      const cmsFieldNames = Object.keys(BLOCK_CMS_FIELDS[type] || {});
+      return cmsFieldNames
+        .filter(
+          (name) => !containerFields.has(name) && !docParams.includes(name),
+        )
+        .map(
+          (name) =>
+            `${type}: CMS field "${name}" has no matching BLOCK_DOCS.params entry`,
+        );
+    });
+    expect(violations).toEqual([]);
   });
 });

--- a/test/unit/utils/block-schema.test.js
+++ b/test/unit/utils/block-schema.test.js
@@ -61,6 +61,18 @@ describe("BLOCK_CMS_FIELDS", () => {
     }
   });
 
+  test("every BLOCK_SCHEMAS type also has cmsFields (all blocks CMS-editable)", () => {
+    // Invariant: every block type surfaced to templates via BLOCK_SCHEMAS must
+    // also be editable through the CMS. If you intentionally want a code-only
+    // block, remove it from BLOCK_SCHEMAS. If not, export `cmsFields` from its
+    // block-schema module (use `{}` for blocks with no block-specific fields
+    // — the wrapper `container_width`/`section_class` fields are auto-injected).
+    const missing = Object.keys(BLOCK_SCHEMAS)
+      .filter((type) => !(type in BLOCK_CMS_FIELDS))
+      .sort();
+    expect(missing).toEqual([]);
+  });
+
   test("every field key passes production validateBlocks", () => {
     // Build a synthetic block from the CMS field shape and run it through
     // the same validator that checks real block usage at build time. This

--- a/test/unit/utils/pages-yml-block-sync.test.js
+++ b/test/unit/utils/pages-yml-block-sync.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+import { rootDir } from "#test/test-utils.js";
+import { collectBlockReferences } from "#test/unit/utils/pages-yml-helpers.js";
+import { BLOCK_CMS_FIELDS, BLOCK_SCHEMAS } from "#utils/block-schema.js";
+
+/** Inverse of scripts/customise-cms/generator.js#blockTypeToComponentName —
+ *  turns `block_section_header` back into `section-header`. */
+const componentNameToBlockType = (componentName) =>
+  componentName.replace(/^block_/, "").replace(/_/g, "-");
+
+/** Auto-injected wrapper fields that the generator prepends to every block
+ *  component. Mirrors CONTAINER_FIELDS in src/_lib/utils/block-schema/shared.js. */
+const CONTAINER_FIELD_NAMES = ["container_width", "section_class"];
+
+const PAGES_YML_PATH = join(rootDir, ".pages.yml");
+const parsedPagesYml = YAML.parse(readFileSync(PAGES_YML_PATH, "utf-8"));
+const components = parsedPagesYml.components || {};
+const blockComponents = Object.fromEntries(
+  Object.entries(components).filter(([name]) => name.startsWith("block_")),
+);
+
+const blockReferences = collectBlockReferences(parsedPagesYml);
+
+describe(".pages.yml components ↔ BLOCK_CMS_FIELDS", () => {
+  test("every block_* component corresponds to a known block type", () => {
+    const unknown = Object.keys(blockComponents)
+      .filter((name) => !(componentNameToBlockType(name) in BLOCK_CMS_FIELDS))
+      .sort();
+    expect(unknown).toEqual([]);
+  });
+
+  test("every BLOCK_CMS_FIELDS type has a block_* component", () => {
+    const existing = Object.keys(blockComponents).map(componentNameToBlockType);
+    const missing = Object.keys(BLOCK_CMS_FIELDS)
+      .filter((type) => !existing.includes(type))
+      .sort();
+    expect(missing).toEqual([]);
+  });
+
+  test("every block component has the container wrapper fields first", () => {
+    const violations = Object.entries(blockComponents)
+      .filter(([, def]) => Array.isArray(def.fields))
+      .flatMap(([name, def]) => {
+        const firstNames = def.fields.slice(0, 2).map((f) => f.name);
+        return JSON.stringify(firstNames) ===
+          JSON.stringify(CONTAINER_FIELD_NAMES)
+          ? []
+          : [
+              `${name}: expected first two fields to be ${CONTAINER_FIELD_NAMES.join(", ")}, got ${firstNames.join(", ")}`,
+            ];
+      });
+    expect(violations).toEqual([]);
+  });
+
+  test("every component field name matches BLOCK_CMS_FIELDS (or is a container field)", () => {
+    const violations = Object.entries(blockComponents).flatMap(
+      ([name, def]) => {
+        const blockType = componentNameToBlockType(name);
+        const schemaFields = BLOCK_CMS_FIELDS[blockType];
+        if (!schemaFields || !Array.isArray(def.fields)) return [];
+        const yamlFieldNames = def.fields.map((f) => f.name);
+        const expectedFieldNames = [
+          ...CONTAINER_FIELD_NAMES,
+          ...Object.keys(schemaFields),
+        ];
+        const extra = yamlFieldNames.filter(
+          (n) => !expectedFieldNames.includes(n),
+        );
+        const missing = expectedFieldNames.filter(
+          (n) => !yamlFieldNames.includes(n),
+        );
+        return [
+          ...extra.map((n) => `${name}: extra field "${n}" in .pages.yml`),
+          ...missing.map((n) => `${name}: missing field "${n}" in .pages.yml`),
+        ];
+      },
+    );
+    expect(violations).toEqual([]);
+  });
+});
+
+describe(".pages.yml block references ↔ BLOCK_SCHEMAS", () => {
+  test("at least one blocks: list exists (sanity check)", () => {
+    expect(blockReferences.length).toBeGreaterThan(0);
+  });
+
+  test("every block reference points to a known block type", () => {
+    const unknown = blockReferences
+      .filter((ref) => !(ref.name in BLOCK_SCHEMAS))
+      .map((ref) => ref.name)
+      .sort();
+    expect([...new Set(unknown)]).toEqual([]);
+  });
+
+  test("every block reference points to an existing component", () => {
+    const dangling = blockReferences
+      .filter((ref) => !(ref.component in blockComponents))
+      .map((ref) => `${ref.name} -> ${ref.component}`)
+      .sort();
+    expect([...new Set(dangling)]).toEqual([]);
+  });
+
+  test("every block reference uses the canonical component name", () => {
+    const mismatches = blockReferences
+      .filter((ref) => ref.component !== `block_${ref.name.replace(/-/g, "_")}`)
+      .map(
+        (ref) =>
+          `${ref.name}: component "${ref.component}" should be "block_${ref.name.replace(/-/g, "_")}"`,
+      );
+    expect(mismatches).toEqual([]);
+  });
+
+  test("every BLOCK_CMS_FIELDS type is referenced by at least one page", () => {
+    const referenced = blockReferences.map((r) => r.name);
+    const unreachable = Object.keys(BLOCK_CMS_FIELDS)
+      .filter((type) => !referenced.includes(type))
+      .sort();
+    expect(unreachable).toEqual([]);
+  });
+});

--- a/test/unit/utils/pages-yml-helpers.js
+++ b/test/unit/utils/pages-yml-helpers.js
@@ -1,0 +1,26 @@
+/**
+ * Shared helpers for tests that parse .pages.yml.
+ */
+
+/**
+ * Walk a parsed Pages CMS YAML tree and collect every block reference
+ * (`{name, component}` entries) from any `blocks:` list of a `type: block`
+ * field — those are the block types actually reachable from the CMS UI.
+ *
+ * @param {unknown} node
+ * @param {Array<{name: string, component: string}>} [acc]
+ * @returns {Array<{name: string, component: string}>}
+ */
+export const collectBlockReferences = (node, acc = []) => {
+  if (Array.isArray(node)) {
+    for (const entry of node) collectBlockReferences(entry, acc);
+    return acc;
+  }
+  if (node && typeof node === "object") {
+    if (node.type === "block" && Array.isArray(node.blocks)) {
+      acc.push(...node.blocks);
+    }
+    for (const value of Object.values(node)) collectBlockReferences(value, acc);
+  }
+  return acc;
+};


### PR DESCRIPTION
Make every block type CMS-editable and enforce drift detection with a
layered set of tests. Previously nothing guaranteed the committed
.pages.yml was in sync with BLOCK_CMS_FIELDS, and several blocks had no
cmsFields export so they were silently unreachable from the CMS.

- Export cmsFields from the 13 block modules that were missing it
  (image-cards, bunny-video-background, image-background,
  custom-contact-form, markdown, html, content, include, properties,
  guide-categories, link-button, reviews, gallery)
- Add Phase-1 freshness test: .pages.yml byte-equals regenerated output
- Add Phase-2 static invariants: every block_* component maps to a known
  block type, field names match BLOCK_CMS_FIELDS, container wrapper
  fields come first, block references use canonical component names,
  every CMS field type is reachable from at least one page
- Add Phase-3 cross-checks: every CMS-reachable block has BLOCK_DOCS,
  every CMS field has a BLOCK_DOCS.params entry
- Add Phase-4 lockstep: every BLOCK_SCHEMAS type has cmsFields
- Fix compact-yaml bug where values containing commas/braces/brackets
  were silently dropped when emitted inline; add regression tests
- Regenerate .pages.yml and pages-cms-generated.d.ts