### PR TITLE
Remove redundant collection key from items-array block

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -424,10 +424,6 @@ components:
         type: string
         label: Container Width (full, wide, narrow)
       - { name: section_class, type: string, label: Section Class }
-      - name: collection
-        type: string
-        label: Collection Name
-        required: true
       - name: items
         label: Items
         type: reference

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -423,14 +423,13 @@ Displays an Eleventy collection as a card grid or horizontal slider.
 
 ### `items-array`
 
-Renders items from an explicit list of paths (e.g. from Pages CMS content references).
+Renders items from an explicit list of paths (e.g. from Pages CMS content references). The collection is inferred dynamically from each item's path.
 
 **Template:** `src/_includes/design-system/items-array-block.html`
 **SCSS:** `src/css/design-system/_items.scss`
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `collection` | string | **required** | Collection to resolve paths against. |
 | `items` | array | **required** | Array of file paths (e.g. from Pages CMS references). |
 | `intro` | string | — | Markdown content rendered above items in `.prose`. |
 | `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |

--- a/src/_includes/design-system/items-array-block.html
+++ b/src/_includes/design-system/items-array-block.html
@@ -1,8 +1,11 @@
 {%- comment -%}
 Items array block: renders items from an explicit list of paths using items.html.
 
+The collection is inferred dynamically from each item's path — paths like
+"src/locations/manchester.md" resolve against collections.all regardless of
+which collection the item belongs to.
+
 Parameters (from block):
-  collection  - Name of an Eleventy collection to resolve paths against
   items       - Array of file paths (e.g. from PagesCMS references)
   intro       - Optional markdown content rendered above the items
   horizontal  - If true, renders as a horizontal slider

--- a/src/_lib/utils/block-schema/items-array.js
+++ b/src/_lib/utils/block-schema/items-array.js
@@ -1,29 +1,30 @@
 import {
-  buildItemsDocs,
   ITEMS_CMS_SHARED_FIELDS,
   ITEMS_COMMON_KEYS,
+  ITEMS_COMMON_PARAMS,
+  ITEMS_GRID_META,
 } from "#utils/block-schema/shared.js";
 
 export const type = "items-array";
 
-export const schema = ["collection", "items", ...ITEMS_COMMON_KEYS];
+export const schema = ["items", ...ITEMS_COMMON_KEYS];
 
-export const docs = buildItemsDocs({
+export const docs = {
   summary:
-    "Renders items from an explicit list of paths (e.g. from Pages CMS content references).",
+    "Renders items from an explicit list of paths (e.g. from Pages CMS content references). The collection is inferred dynamically from each item's path.",
   template: "src/_includes/design-system/items-array-block.html",
-  collectionDescription: "Collection to resolve paths against.",
-  extraParams: {
+  scss: ITEMS_GRID_META.scss,
+  params: {
     items: {
       type: "array",
       required: true,
       description: "Array of file paths (e.g. from Pages CMS references).",
     },
+    ...ITEMS_COMMON_PARAMS,
   },
-});
+};
 
 export const cmsFields = {
-  collection: ITEMS_CMS_SHARED_FIELDS.collection,
   items: {
     type: "reference",
     label: "Items",

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -101,7 +101,6 @@ blocks:
 
   # Items Array - explicit product selection
   - type: items-array
-    collection: products
     masonry: true
     items:
       - src/products/mini-gizmo.md

--- a/test/unit/scripts/customise-cms/blocks.test.js
+++ b/test/unit/scripts/customise-cms/blocks.test.js
@@ -97,8 +97,8 @@ describe("generateBlocksField generic field conversion", () => {
   });
 
   test("propagates required:true from the schema", () => {
-    // items-array.collection is required:true.
-    const field = generateBlocksField(["items-array"], false);
+    // items.collection is required:true.
+    const field = generateBlocksField(["items"], false);
     const collection = field.blocks[0].fields.find(
       (f) => f.name === "collection",
     );


### PR DESCRIPTION
## Summary

The `collection` key on the `items-array` block was purely semantic — the template already resolves paths against `collections.all` via `getItemsByPath`, so paths like `src/locations/manchester.md` or `src/products/widget.md` worked regardless of what `collection` was set to. Dropping the key makes the block truly collection-agnostic, so you can mix items from any collection in a single `items-array` block.

### Before
```yaml
- type: items-array
  collection: products   # ← required but ignored
  items:
    - src/products/mini-gizmo.md
    - src/products/ultrawidget-pro.md
```

### After
```yaml
- type: items-array
  items:
    - src/products/mini-gizmo.md
    - src/locations/manchester.md   # ← cross-collection now explicit
```

## Changes
- `src/_lib/utils/block-schema/items-array.js` — drop `collection` from `schema`, `docs.params`, and `cmsFields` (switch to constructing docs directly instead of via `buildItemsDocs`, which always injects a `collection` param)
- `src/_includes/design-system/items-array-block.html` — update parameter docstring
- `src/pages/chobble-template.md` — remove `collection: products` from the example
- `.pages.yml` / `BLOCKS_LAYOUT.md` — regenerated via `bun run generate-pages-yml` and `bun scripts/generate-blocks-reference.js`
- `test/unit/scripts/customise-cms/blocks.test.js` — the `required:true` propagation test now uses `items.collection` (still required) instead of `items-array.collection`

## Test plan
- [x] `bun run test:unit` — 2349 pass, 0 fail
- [x] `bun run build` — completes cleanly
- [x] Verified `_site/index.html` renders all three products from the `items-array` example (mini-gizmo, ultrawidget-pro, heritage-thingy-deluxe)
- [x] `bun run lint` — no issues

https://claude.ai/code/session_01MRjCDBuCPG38synaWbNraB