### PR TITLE
Refactor items-array to accept plain path strings

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -424,15 +424,7 @@ components:
         type: string
         label: Container Width (full, wide, narrow)
       - { name: section_class, type: string, label: Section Class }
-      - name: items
-        label: Items
-        type: reference
-        list: true
-        options:
-          collection: pages
-          search: primary
-          value: "{path}"
-          label: "{primary}"
+      - { name: items, type: string, label: Items, required: true, list: true }
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -423,14 +423,14 @@ Displays an Eleventy collection as a card grid or horizontal slider.
 
 ### `items-array`
 
-Renders items from an explicit list of paths (e.g. from Pages CMS content references). The collection is inferred dynamically from each item's path.
+Renders items from an explicit list of paths. The collection is inferred dynamically from each item's path.
 
 **Template:** `src/_includes/design-system/items-array-block.html`
 **SCSS:** `src/css/design-system/_items.scss`
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `items` | array | **required** | Array of file paths (e.g. from Pages CMS references). |
+| `items` | array | **required** | Array of file paths as strings. |
 | `intro` | string | — | Markdown content rendered above items in `.prose`. |
 | `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
 | `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |

--- a/src/_includes/design-system/items-array-block.html
+++ b/src/_includes/design-system/items-array-block.html
@@ -6,7 +6,7 @@ The collection is inferred dynamically from each item's path — paths like
 which collection the item belongs to.
 
 Parameters (from block):
-  items       - Array of file paths (e.g. from PagesCMS references)
+  items       - Array of file paths as strings
   intro       - Optional markdown content rendered above the items
   horizontal  - If true, renders as a horizontal slider
   masonry     - If true, renders as a masonry grid (uses uWrap)

--- a/src/_lib/utils/block-schema/items-array.js
+++ b/src/_lib/utils/block-schema/items-array.js
@@ -3,6 +3,7 @@ import {
   ITEMS_COMMON_KEYS,
   ITEMS_COMMON_PARAMS,
   ITEMS_GRID_META,
+  str,
 } from "#utils/block-schema/shared.js";
 
 export const type = "items-array";
@@ -11,27 +12,21 @@ export const schema = ["items", ...ITEMS_COMMON_KEYS];
 
 export const docs = {
   summary:
-    "Renders items from an explicit list of paths (e.g. from Pages CMS content references). The collection is inferred dynamically from each item's path.",
+    "Renders items from an explicit list of paths. The collection is inferred dynamically from each item's path.",
   template: "src/_includes/design-system/items-array-block.html",
   scss: ITEMS_GRID_META.scss,
   params: {
     items: {
       type: "array",
       required: true,
-      description: "Array of file paths (e.g. from Pages CMS references).",
+      description: "Array of file paths as strings.",
     },
     ...ITEMS_COMMON_PARAMS,
   },
 };
 
 export const cmsFields = {
-  items: {
-    type: "reference",
-    label: "Items",
-    collection: "pages",
-    search: "title",
-    multiple: true,
-  },
+  items: str("Items", { list: true, required: true }),
   intro: ITEMS_CMS_SHARED_FIELDS.intro,
   horizontal: ITEMS_CMS_SHARED_FIELDS.horizontal,
   masonry: ITEMS_CMS_SHARED_FIELDS.masonry,

--- a/test/unit/scripts/customise-cms/blocks.test.js
+++ b/test/unit/scripts/customise-cms/blocks.test.js
@@ -71,14 +71,15 @@ describe("generateBlocksField markdown field conversion", () => {
   });
 });
 
-describe("generateBlocksField reference field conversion", () => {
-  test("passes the target collection through to the CMS reference", () => {
-    // items-array.items declares collection:"pages" and multiple:true.
+describe("generateBlocksField list field conversion", () => {
+  test("emits a list string field for items-array.items paths", () => {
+    // items-array.items declares type:"string" with list:true to accept an
+    // array of file paths.
     const field = generateBlocksField(["items-array"], false);
     const items = field.blocks[0].fields.find((f) => f.name === "items");
 
-    expect(items.type).toBe("reference");
-    expect(items.options.collection).toBe("pages");
+    expect(items.type).toBe("string");
+    expect(items.list).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Changed the `items-array` block's CMS field for `items` from a Pages CMS `reference` (tied to the `pages` collection) to a simple string list. The block now just takes an array of file paths, matching what `getItemsByPath` actually consumes.
- Updated the block's docs/template comments to drop the "e.g. from Pages CMS references" wording.
- Regenerated `.pages.yml` and `BLOCKS_LAYOUT.md`.
- Updated `blocks.test.js` — the old test used `items-array` as the example for "reference field conversion"; replaced with a test that verifies `items` now emits a `type: string, list: true` CMS field.

## Test plan
- [x] `bun test test/unit/utils/block-schema.test.js` passes
- [x] `bun test test/unit/scripts/customise-cms/blocks.test.js` passes
- [x] `bun test test/unit/code-quality/pages-yml-freshness.test.js` passes (confirms regenerated `.pages.yml` is in sync)
- [x] `bun test test/unit/utils/pages-yml-block-sync.test.js test/unit/utils/block-docs.test.js` passes
- [x] `bun run lint` passes

https://claude.ai/code/session_01K16unbACBdSJ7jVYyYakC1