### PR TITLE
Remove header_intro and filter from items-array block

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -428,16 +428,6 @@ components:
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }
-      - { name: header_intro, type: rich-text, label: Header Intro }
-      - name: filter
-        type: object
-        label: Filter
-        fields:
-          - name: property
-            type: string
-            label: Property (e.g. url, data.title)
-          - { name: includes, type: string, label: Contains }
-          - { name: equals, type: string, label: Equals }
   block_contact_form:
     label: Contact Form
     type: object

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -434,10 +434,6 @@ Renders items from an explicit list of paths. The collection is inferred dynamic
 | `intro` | string | — | Markdown content rendered above items in `.prose`. |
 | `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
 | `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
-| `filter` | object | — | Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
 
 ---
 

--- a/src/_lib/utils/block-schema/items-array.js
+++ b/src/_lib/utils/block-schema/items-array.js
@@ -1,6 +1,5 @@
 import {
   ITEMS_CMS_SHARED_FIELDS,
-  ITEMS_COMMON_KEYS,
   ITEMS_COMMON_PARAMS,
   ITEMS_GRID_META,
   str,
@@ -8,7 +7,7 @@ import {
 
 export const type = "items-array";
 
-export const schema = ["items", ...ITEMS_COMMON_KEYS];
+export const schema = ["items", "intro", "horizontal", "masonry"];
 
 export const docs = {
   summary:
@@ -21,7 +20,9 @@ export const docs = {
       required: true,
       description: "Array of file paths as strings.",
     },
-    ...ITEMS_COMMON_PARAMS,
+    intro: ITEMS_COMMON_PARAMS.intro,
+    horizontal: ITEMS_COMMON_PARAMS.horizontal,
+    masonry: ITEMS_COMMON_PARAMS.masonry,
   },
 };
 
@@ -30,6 +31,4 @@ export const cmsFields = {
   intro: ITEMS_CMS_SHARED_FIELDS.intro,
   horizontal: ITEMS_CMS_SHARED_FIELDS.horizontal,
   masonry: ITEMS_CMS_SHARED_FIELDS.masonry,
-  header_intro: ITEMS_CMS_SHARED_FIELDS.header_intro,
-  filter: ITEMS_CMS_SHARED_FIELDS.filter,
 };


### PR DESCRIPTION
## Summary
- Remove `header_intro` (and the related `header_align` / `header_class` schema keys) from the `items-array` block — its existing `intro` field already provides markdown content above the items, so the separate section-header was redundant.
- Remove the `filter` field from `items-array` — callers of this block already hand-pick items explicitly by path, so filtering doesn't make sense here.
- Regenerate `BLOCKS_LAYOUT.md` and `.pages.yml` to reflect the reduced schema.

The sibling `items` block (collection-based) is unchanged and still supports `header_intro`, `filter`, etc.

## Test plan
- [x] `bun test test/unit` — 2349 pass
- [x] `bun run build` — builds clean (the demo `src/pages/chobble-template.md` uses `items-array` without either removed field)
- [x] `BLOCKS_LAYOUT.md` regenerated via `bun scripts/generate-blocks-reference.js`
- [x] `.pages.yml` regenerated via `bun scripts/customise-cms/generate-full.js` (pages-yml-freshness test stays green)

https://claude.ai/code/session_01JejYht5BEVn3oaJuXMKVin