### PR TITLE
Simplify CMS: replace section_class/container_width with dark boolean

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,6 +27,7 @@ import { configureItemFilterData } from "#eleventy/item-filter-data.js";
 // Validation
 import { configureCollectionValidation } from "#eleventy/validate-collections.js";
 // Eleventy plugins
+import { configureBlocks } from "#eleventy/blocks.js";
 import { configureCacheBuster } from "#eleventy/cache-buster.js";
 import { configureCanonicalUrl } from "#eleventy/canonical-url.js";
 import { configureCollectionFilter } from "#eleventy/collection-filter.js";
@@ -81,6 +82,7 @@ export default async function (eleventyConfig) {
   // configureLayoutAliases(eleventyConfig);
 
   configureAreaList(eleventyConfig);
+  configureBlocks(eleventyConfig);
   configureBreadcrumbs(eleventyConfig);
   configureCacheBuster(eleventyConfig);
   configureCollectionLookup(eleventyConfig);

--- a/.pages.yml
+++ b/.pages.yml
@@ -31,19 +31,13 @@ components:
     label: Section Header
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: intro, type: rich-text, label: Section Header Intro }
   block_features:
     label: Features
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: grid_class, type: string, label: Grid Class }
       - { name: heading_level, type: number, label: Heading Level }
       - { name: header_intro, type: rich-text, label: Header Intro }
@@ -65,10 +59,7 @@ components:
     label: Image Cards
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: heading_level, type: number, label: Heading Level }
       - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
       - { name: header_intro, type: rich-text, label: Header Intro }
@@ -85,10 +76,7 @@ components:
     label: Stats
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - name: items
         type: object
         label: Statistics
@@ -100,10 +88,7 @@ components:
     label: Code Block
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: filename, type: string, label: Filename, required: true }
       - { name: code, type: string, label: Code, required: true }
       - { name: language, type: string, label: Language }
@@ -111,10 +96,7 @@ components:
     label: Hero
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: class, type: string, label: CSS Class }
       - { name: badge, type: string, label: Badge Text }
       - { name: title, type: string, label: Title, required: true }
@@ -132,10 +114,7 @@ components:
     label: Split Image
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
@@ -158,10 +137,7 @@ components:
     label: Split Video
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
@@ -184,10 +160,7 @@ components:
     label: Split Code
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
@@ -210,10 +183,7 @@ components:
     label: Split Icon Links
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
@@ -244,10 +214,7 @@ components:
     label: Split Html
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
@@ -268,10 +235,7 @@ components:
     label: Split Callout
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
@@ -300,10 +264,7 @@ components:
     label: Split Full
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: variant, type: string, label: Variant }
       - { name: title_level, type: number, label: Heading Level }
       - { name: reveal_left, type: string, label: Reveal Left Animation }
@@ -330,10 +291,7 @@ components:
     label: Cta
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: title, type: string, label: Title, required: true }
       - { name: description, type: string, label: Description }
       - name: button
@@ -348,10 +306,7 @@ components:
     label: Video Background
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: video_id, type: string, label: Video Embed URL, required: true }
       - { name: thumbnail_url, type: string, label: Thumbnail URL }
       - { name: video_title, type: string, label: Video Title }
@@ -362,10 +317,7 @@ components:
     label: Bunny Video Background
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - name: video_url
         type: string
         label: Bunny Stream Embed URL
@@ -382,10 +334,7 @@ components:
     label: Image Background
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: image, type: image, label: Background Image, required: true }
       - { name: image_alt, type: string, label: Image Alt Text }
       - { name: parallax, type: boolean, label: Parallax }
@@ -395,10 +344,7 @@ components:
     label: Items
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - name: collection
         type: string
         label: Collection Name
@@ -420,10 +366,7 @@ components:
     label: Items Array
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: items, type: string, label: Items, required: true, list: true }
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
@@ -442,19 +385,13 @@ components:
     label: Contact Form
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: content, type: rich-text, label: Content }
   block_custom_contact_form:
     label: Custom Contact Form
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - name: fields
         type: object
         label: Form Fields
@@ -476,61 +413,40 @@ components:
     label: Markdown
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: content, type: rich-text, label: Markdown }
   block_html:
     label: Html
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: content, type: string, label: Raw HTML, required: true }
   block_content:
     label: Content
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
   block_include:
     label: Include
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: file, type: string, label: Template File Path, required: true }
   block_properties:
     label: Properties
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
   block_guide_categories:
     label: Guide Categories
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
   block_link_button:
     label: Link Button
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: text, type: string, label: Button Text, required: true }
       - { name: href, type: string, label: URL, required: true }
       - { name: variant, type: string, label: Variant }
@@ -540,19 +456,13 @@ components:
     label: Reviews
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: current_item, type: boolean, label: Filter to Current Item }
   block_gallery:
     label: Gallery
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: aspect_ratio, type: string, label: Aspect Ratio }
       - name: items
         type: object
@@ -565,10 +475,7 @@ components:
     label: Marquee Images
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - name: items
         type: object
         label: Images
@@ -583,10 +490,7 @@ components:
     label: Icon Links
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - name: items
         type: object
@@ -603,10 +507,7 @@ components:
     label: Snippet
     type: object
     fields:
-      - name: container_width
-        type: string
-        label: Container Width (full, wide, narrow)
-      - { name: section_class, type: string, label: Section Class }
+      - { name: dark, type: boolean, label: Dark }
       - name: reference
         label: Snippet
         type: reference

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -12,7 +12,7 @@ frontmatter blocks[] → design-system-base.html → blocks.html → render-bloc
 
 **Layout:** `src/_layouts/design-system-base.html` applies `class="design-system"` to `<body>`, loads the design system CSS bundle, and iterates blocks via `blocks.html`.
 
-**Block loop** (`src/_includes/design-system/blocks.html`): Each block becomes a `<section>`. If `block.dark` is true, the section gets `class="dark"`. Container width is determined by block type and is not user-configurable: `icon-links` uses `.container-narrow` (680px); `video-background`, `bunny-video-background`, `image-background`, and `marquee-images` are full-bleed (no container wrapper); everything else uses `.container-wide` (1200px).
+**Block loop** (`src/_includes/design-system/blocks.html`): Each block becomes a `<section>`. If `block.dark` is true, the section gets `class="dark"`. Container width is determined by block type and is not user-configurable: `icon-links` uses `.container-narrow` (680px); `hero`, `split-full`, `video-background`, `bunny-video-background`, `image-background`, and `marquee-images` are full-bleed (no container wrapper); everything else uses `.container-wide` (1200px).
 
 **Block router** (`src/_includes/design-system/render-block.html`): A Liquid `case` statement dispatching `block.type` to the appropriate include template.
 

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -12,7 +12,7 @@ frontmatter blocks[] → design-system-base.html → blocks.html → render-bloc
 
 **Layout:** `src/_layouts/design-system-base.html` applies `class="design-system"` to `<body>`, loads the design system CSS bundle, and iterates blocks via `blocks.html`.
 
-**Block loop** (`src/_includes/design-system/blocks.html`): Each block becomes a `<section>`. If `block.section_class` is set, it's applied to the section. Content is wrapped in a container based on `block.container_width`: `"wide"` (default, 1200px, `.container-wide`), `"narrow"` (680px, `.container-narrow`), or `"full"` (no wrapper). The `icon-links` block defaults to `"narrow"`. The `video-background`, `bunny-video-background`, and `image-background` blocks default to `"full"`.
+**Block loop** (`src/_includes/design-system/blocks.html`): Each block becomes a `<section>`. If `block.dark` is true, the section gets `class="dark"`. Container width is determined by block type and is not user-configurable: `icon-links` uses `.container-narrow` (680px); `video-background`, `bunny-video-background`, `image-background`, and `marquee-images` are full-bleed (no container wrapper); everything else uses `.container-wide` (1200px).
 
 **Block router** (`src/_includes/design-system/render-block.html`): A Liquid `case` statement dispatching `block.type` to the appropriate include template.
 
@@ -23,15 +23,12 @@ Every block object supports these properties (handled by blocks.html, not the in
 | Property | Type | Effect |
 |---|---|---|
 | `type` | string | **Required.** Selects which template to render. |
-| `section_class` | string | CSS class(es) on the wrapping `<section>`. Built-in: `dark` (dark bg + inverted colors), `gradient` (gradient bg), `compact` (reduced padding). Alternating backgrounds are applied automatically via `:nth-child(even)`. |
-| `container_width` | string | `"full"`, `"wide"` (default), or `"narrow"`. Controls the inner container max-width. `"full"` omits the container wrapper entirely so content spans the full viewport width. |
+| `dark` | boolean | If true, adds `class="dark"` to the wrapping `<section>` (dark bg + inverted colors). |
 
 ### Section Behavior
 
 - Sections use `@mixin section` which applies `$space-3xl` (96px) vertical padding (60% on mobile).
-- `section.compact` uses `$space-2xl` (64px) padding.
 - `section.dark` inverts all CSS custom properties to dark palette.
-- `section.gradient` applies a diagonal gradient background.
 - Even-numbered sections automatically get `--body-background-alt` background.
 - Sections containing `.split-full` have zero padding (panels self-pad).
 

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -12,7 +12,7 @@ frontmatter blocks[] → design-system-base.html → blocks.html → render-bloc
 
 **Layout:** `src/_layouts/design-system-base.html` applies `class="design-system"` to `<body>`, loads the design system CSS bundle, and iterates blocks via `blocks.html`.
 
-**Block loop** (`src/_includes/design-system/blocks.html`): Each block becomes a `<section>`. If `block.dark` is true, the section gets `class="dark"`. Container width is determined by block type and is not user-configurable: `icon-links` uses `.container-narrow` (680px); `hero`, `split-full`, `video-background`, `bunny-video-background`, `image-background`, and `marquee-images` are full-bleed (no container wrapper); everything else uses `.container-wide` (1200px).
+**Block loop** (`src/_includes/design-system/blocks.html`): Each block becomes a `<section>`. If `block.dark` is true, the section gets `class="dark"`. Container width is determined by block type via the `blockContainerWidth` Liquid filter (registered in `src/_lib/eleventy/blocks.js`, backed by `getBlockContainerWidth()` in `src/_lib/utils/block-schema.js`). Each block module declares its own width via an optional `containerWidth` export; modules that omit it default to `"wide"` (`.container-wide`, 1200px). Other values are `"full"` (no wrapper) and `"narrow"` (`.container-narrow`, 680px).
 
 **Block router** (`src/_includes/design-system/render-block.html`): A Liquid `case` statement dispatching `block.type` to the appropriate include template.
 

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -209,7 +209,7 @@ export default {
     return data.blocks.map((block) => {
       const blockType = String(block.type);
       const merged = Object.assign(
-        { section_class: "" },
+        { dark: false },
         BLOCK_DEFAULTS[blockType],
         block,
       );

--- a/src/_includes/design-system/blocks.html
+++ b/src/_includes/design-system/blocks.html
@@ -2,11 +2,10 @@
   {%- if block.type == "snippet" -%}
     {%- include "design-system/render-block.html", block: block -%}
   {%- else -%}
-    {%- assign default_width = "wide" -%}
-    {%- if block.type == "icon-links" -%}{%- assign default_width = "narrow" -%}{%- endif -%}
-    {%- if block.type == "video-background" or block.type == "bunny-video-background" or block.type == "image-background" or block.type == "marquee-images" -%}{%- assign default_width = "full" -%}{%- endif -%}
-    {%- assign cw = block.container_width | default: default_width -%}
-    <section{% if block.section_class != "" %} class="{{ block.section_class }}"{% endif %}>
+    {%- assign cw = "wide" -%}
+    {%- if block.type == "icon-links" -%}{%- assign cw = "narrow" -%}{%- endif -%}
+    {%- if block.type == "video-background" or block.type == "bunny-video-background" or block.type == "image-background" or block.type == "marquee-images" -%}{%- assign cw = "full" -%}{%- endif -%}
+    <section{% if block.dark %} class="dark"{% endif %}>
       {%- unless cw == "full" -%}<div class="container-{{ cw }}">{%- endunless -%}
       {%- include "design-system/render-block.html", block: block -%}
       {%- unless cw == "full" -%}</div>{%- endunless -%}

--- a/src/_includes/design-system/blocks.html
+++ b/src/_includes/design-system/blocks.html
@@ -4,7 +4,7 @@
   {%- else -%}
     {%- assign cw = "wide" -%}
     {%- if block.type == "icon-links" -%}{%- assign cw = "narrow" -%}{%- endif -%}
-    {%- if block.type == "video-background" or block.type == "bunny-video-background" or block.type == "image-background" or block.type == "marquee-images" -%}{%- assign cw = "full" -%}{%- endif -%}
+    {%- if block.type == "video-background" or block.type == "bunny-video-background" or block.type == "image-background" or block.type == "marquee-images" or block.type == "hero" or block.type == "split-full" -%}{%- assign cw = "full" -%}{%- endif -%}
     <section{% if block.dark %} class="dark"{% endif %}>
       {%- unless cw == "full" -%}<div class="container-{{ cw }}">{%- endunless -%}
       {%- include "design-system/render-block.html", block: block -%}

--- a/src/_includes/design-system/blocks.html
+++ b/src/_includes/design-system/blocks.html
@@ -2,9 +2,7 @@
   {%- if block.type == "snippet" -%}
     {%- include "design-system/render-block.html", block: block -%}
   {%- else -%}
-    {%- assign cw = "wide" -%}
-    {%- if block.type == "icon-links" -%}{%- assign cw = "narrow" -%}{%- endif -%}
-    {%- if block.type == "video-background" or block.type == "bunny-video-background" or block.type == "image-background" or block.type == "marquee-images" or block.type == "hero" or block.type == "split-full" -%}{%- assign cw = "full" -%}{%- endif -%}
+    {%- assign cw = block.type | blockContainerWidth -%}
     <section{% if block.dark %} class="dark"{% endif %}>
       {%- unless cw == "full" -%}<div class="container-{{ cw }}">{%- endunless -%}
       {%- include "design-system/render-block.html", block: block -%}

--- a/src/_lib/eleventy/blocks.js
+++ b/src/_lib/eleventy/blocks.js
@@ -1,0 +1,6 @@
+import { getBlockContainerWidth } from "#utils/block-schema.js";
+
+/** @param {{ addFilter: Function }} eleventyConfig */
+export const configureBlocks = (eleventyConfig) => {
+  eleventyConfig.addFilter("blockContainerWidth", getBlockContainerWidth);
+};

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -100,6 +100,23 @@ const indexByType = (getValue) =>
 const BLOCK_SCHEMAS = indexByType((m) => m.schema);
 
 /**
+ * Container width per block type. Block modules opt in via an exported
+ * `containerWidth` constant ("full" or "narrow"); blocks that omit it
+ * default to "wide".
+ * @type {Record<string, "full" | "wide" | "narrow">}
+ */
+const BLOCK_CONTAINER_WIDTHS = Object.fromEntries(
+  BLOCK_MODULES.map((m) => [m.type, m.containerWidth || "wide"]),
+);
+
+/**
+ * @param {string} blockType
+ * @returns {"full" | "wide" | "narrow"} Container wrapper width
+ */
+const getBlockContainerWidth = (blockType) =>
+  BLOCK_CONTAINER_WIDTHS[blockType] || "wide";
+
+/**
  * CMS field definitions for block types exposed in Pages CMS.
  *
  * Not every block type in BLOCK_SCHEMAS is exposed in the CMS — only modules
@@ -180,6 +197,7 @@ export {
   BLOCK_CMS_FIELDS,
   BLOCK_DOCS,
   BLOCK_SCHEMAS,
+  getBlockContainerWidth,
   validateBlock,
   validateBlocks,
 };

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -50,10 +50,7 @@ import * as videoBackground from "#utils/block-schema/video-background.js";
  * Common wrapper keys allowed on all block types.
  * These are used by blocks.html to wrap blocks in sections/containers.
  */
-const COMMON_BLOCK_KEYS = ["section_class", "container_width"];
-
-/** Valid values for the common `container_width` block property. */
-const CONTAINER_WIDTHS = ["full", "wide", "narrow"];
+const COMMON_BLOCK_KEYS = ["dark"];
 
 /**
  * Iteration order determines the order that `scripts/generate-blocks-reference.js`
@@ -106,9 +103,9 @@ const BLOCK_SCHEMAS = indexByType((m) => m.schema);
  * CMS field definitions for block types exposed in Pages CMS.
  *
  * Not every block type in BLOCK_SCHEMAS is exposed in the CMS — only modules
- * that export `cmsFields` are included. CONTAINER_FIELDS (container_width,
- * section_class) are injected here so per-block modules stay focused on
- * block-specific fields. This invariant is enforced by
+ * that export `cmsFields` are included. CONTAINER_FIELDS (`dark`) are
+ * injected here so per-block modules stay focused on block-specific fields.
+ * This invariant is enforced by
  * test/unit/utils/block-schema.test.js.
  */
 const BLOCK_CMS_FIELDS = Object.fromEntries(
@@ -162,12 +159,6 @@ const validateBlock = (block, ctx) => {
   assert(
     unknown.length === 0,
     `Block type "${block.type}" has unknown keys: ${quoteJoin(unknown)}${ctx}. Allowed keys: ${quoteJoin(allAllowed)}`,
-  );
-
-  assert(
-    block.container_width === undefined ||
-      CONTAINER_WIDTHS.includes(block.container_width),
-    `Block type "${block.type}" has invalid container_width "${block.container_width}"${ctx}. Valid values: ${CONTAINER_WIDTHS.join(", ")}`,
   );
 };
 

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -115,7 +115,10 @@ const BLOCK_SCHEMAS = indexByType((m) => m.schema);
  * @type {Record<string, "full" | "wide" | "narrow">}
  */
 const BLOCK_CONTAINER_WIDTHS = Object.fromEntries(
-  BLOCK_MODULES.map((m) => [m.type, m.containerWidth || "wide"]),
+  BLOCK_MODULES.map((m) => [
+    m.type,
+    "containerWidth" in m ? m.containerWidth : "wide",
+  ]),
 );
 
 /**

--- a/src/_lib/utils/block-schema/bunny-video-background.js
+++ b/src/_lib/utils/block-schema/bunny-video-background.js
@@ -10,6 +10,8 @@ const requiredString = (label) => ({ type: "string", label, required: true });
 
 export const type = "bunny-video-background";
 
+export const containerWidth = "full";
+
 export const schema = [
   "video_url",
   "thumbnail_url",

--- a/src/_lib/utils/block-schema/hero.js
+++ b/src/_lib/utils/block-schema/hero.js
@@ -8,6 +8,8 @@ import {
 
 export const type = "hero";
 
+export const containerWidth = "full";
+
 export const schema = ["badge", "title", "lead", "buttons", "class", "reveal"];
 
 export const docs = {

--- a/src/_lib/utils/block-schema/icon-links.js
+++ b/src/_lib/utils/block-schema/icon-links.js
@@ -7,6 +7,8 @@ import {
 
 export const type = "icon-links";
 
+export const containerWidth = "narrow";
+
 export const schema = ["intro", "items", "reveal"];
 
 export const docs = {

--- a/src/_lib/utils/block-schema/image-background.js
+++ b/src/_lib/utils/block-schema/image-background.js
@@ -9,6 +9,8 @@ import {
 
 export const type = "image-background";
 
+export const containerWidth = "full";
+
 export const schema = ["image", "image_alt", "content", "class", "parallax"];
 
 export const docs = {

--- a/src/_lib/utils/block-schema/marquee-images.js
+++ b/src/_lib/utils/block-schema/marquee-images.js
@@ -8,6 +8,8 @@ import {
 
 export const type = "marquee-images";
 
+export const containerWidth = "full";
+
 export const schema = ["items", "speed", "height", ...HEADER_KEYS];
 
 export const docs = {

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -181,8 +181,7 @@ export const objectField = (label, fields) => ({
 
 /** Container wrapper fields common to every CMS block. */
 export const CONTAINER_FIELDS = {
-  container_width: str("Container Width (full, wide, narrow)"),
-  section_class: str("Section Class"),
+  dark: bool("Dark"),
 };
 
 /** Button fields shared between hero, split, and cta blocks. */

--- a/src/_lib/utils/block-schema/split-full.js
+++ b/src/_lib/utils/block-schema/split-full.js
@@ -8,6 +8,8 @@ import {
 
 export const type = "split-full";
 
+export const containerWidth = "full";
+
 export const schema = [
   "variant",
   "title_level",

--- a/src/_lib/utils/block-schema/video-background.js
+++ b/src/_lib/utils/block-schema/video-background.js
@@ -8,6 +8,8 @@ import {
 
 export const type = "video-background";
 
+export const containerWidth = "full";
+
 export const schema = [
   "video_id",
   "video_title",

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -10,7 +10,6 @@ eleventyNavigation:
 blocks:
   # Hero
   - type: hero
-    container_width: full
     class: gradient
     badge: Opinionated & Complete
     title: A Free Eleventy Template for Small Business Websites
@@ -29,7 +28,6 @@ blocks:
 
   # Video Background Demo
   - type: bunny-video-background
-    container_width: full
     video_url: https://iframe.mediadelivery.net/embed/417100/64491289-f8e4-44a0-9d78-746cdf8f78fc?autoplay=true&loop=true&muted=true&preload=true&responsive=true
     thumbnail_url: src/images/video-background-placeholder.jpg
     video_title: Chobble Template Demo
@@ -41,7 +39,6 @@ blocks:
 
   # YouTube Video Background Demo
   - type: video-background
-    container_width: full
     video_id: dQw4w9WgXcQ
     video_title: YouTube Background Demo
     aspect_ratio: "21/9"
@@ -164,7 +161,6 @@ blocks:
 
   # Content Types Split Full
   - type: split-full
-    container_width: full
     variant: dark-left
     reveal_left: left
     reveal_right: right
@@ -242,8 +238,6 @@ blocks:
 
   # Performance Split
   - type: split-code
-    section_class: gradient
-
     title: Static HTML, Optimised Images
     reveal_content: left
     content: |
@@ -315,7 +309,6 @@ blocks:
 
   # Get It Built For You
   - type: split-full
-    container_width: full
     variant: primary-left
     reveal_left: left
     reveal_right: right
@@ -373,7 +366,6 @@ blocks:
 
   # Image Background Demo
   - type: image-background
-    container_width: full
     parallax: true
     image: src/images/city-traffic-night.jpg
     image_alt: Long exposure of the traffic in a city at night

--- a/test/unit/data/eleventy-computed.test.js
+++ b/test/unit/data/eleventy-computed.test.js
@@ -396,7 +396,7 @@ describe("eleventyComputed", () => {
       const data = { blocks, page };
       const result = eleventyComputed.blocks(data);
       expect(result).toEqual([
-        { type: "markdown", content: "test", section_class: "" },
+        { type: "markdown", content: "test", dark: false },
       ]);
     });
 
@@ -425,7 +425,7 @@ describe("eleventyComputed", () => {
         reveal: true,
         heading_level: 3,
         grid_class: "features",
-        section_class: "",
+        dark: false,
       });
     });
 
@@ -436,7 +436,7 @@ describe("eleventyComputed", () => {
         type: "stats",
         items: [],
         reveal: true,
-        section_class: "",
+        dark: false,
       });
     });
 
@@ -452,7 +452,7 @@ describe("eleventyComputed", () => {
         title_level: 2,
         reveal_figure: "scale",
         reveal_content: "left",
-        section_class: "",
+        dark: false,
       });
     });
 
@@ -484,7 +484,7 @@ describe("eleventyComputed", () => {
         type: "section-header",
         intro: "## Header",
         align: "center",
-        section_class: "",
+        dark: false,
       });
     });
 
@@ -496,7 +496,7 @@ describe("eleventyComputed", () => {
         items: [],
         reveal: true,
         heading_level: 3,
-        section_class: "",
+        dark: false,
       });
     });
 
@@ -511,7 +511,7 @@ describe("eleventyComputed", () => {
         code: "test",
         filename: "test.js",
         reveal: true,
-        section_class: "",
+        dark: false,
       });
     });
 
@@ -532,7 +532,7 @@ describe("eleventyComputed", () => {
         video_id: "dQw4w9WgXcQ",
         content: "<h2>Test</h2>",
         aspect_ratio: "16/9",
-        section_class: "",
+        dark: false,
       });
     });
 
@@ -547,13 +547,13 @@ describe("eleventyComputed", () => {
       expect(result[0].grid_class).toBe("features"); // default still applied
     });
 
-    test("Explicit section_class overrides default empty string", () => {
+    test("Explicit dark overrides default false", () => {
       const data = {
-        blocks: [{ type: "stats", items: [], section_class: "dark" }],
+        blocks: [{ type: "stats", items: [], dark: true }],
         page,
       };
       const result = eleventyComputed.blocks(data);
-      expect(result[0].section_class).toBe("dark");
+      expect(result[0].dark).toBe(true);
     });
 
     test("Processes multiple blocks with different types", () => {

--- a/test/unit/utils/block-docs.test.js
+++ b/test/unit/utils/block-docs.test.js
@@ -122,10 +122,10 @@ describe(".pages.yml ↔ BLOCKS_LAYOUT.md coverage", () => {
   });
 
   test("every CMS-reachable block's CMS field is documented in BLOCK_DOCS.params", () => {
-    // container_width and section_class are injected by the generator for every
-    // block and documented once in the "Common Block Properties" table at the
-    // top of BLOCKS_LAYOUT.md — skip them here.
-    const containerFields = new Set(["container_width", "section_class"]);
+    // `dark` is injected by the generator for every block and documented once
+    // in the "Common Block Properties" table at the top of BLOCKS_LAYOUT.md —
+    // skip it here.
+    const containerFields = new Set(["dark"]);
     const violations = [...cmsReachableTypes].flatMap((type) => {
       const docParams = Object.keys(BLOCK_DOCS[type]?.params || {});
       const cmsFieldNames = Object.keys(BLOCK_CMS_FIELDS[type] || {});

--- a/test/unit/utils/block-schema.test.js
+++ b/test/unit/utils/block-schema.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   BLOCK_CMS_FIELDS,
   BLOCK_SCHEMAS,
+  getBlockContainerWidth,
   validateBlocks,
 } from "#utils/block-schema.js";
 
@@ -430,5 +431,34 @@ describe("validateBlocks", () => {
     expect(() => validateBlocks(blocks)).toThrow(
       'unknown keys: "section_class"',
     );
+  });
+});
+
+describe("getBlockContainerWidth", () => {
+  test("defaults to wide for blocks without an explicit width", () => {
+    expect(getBlockContainerWidth("markdown")).toBe("wide");
+    expect(getBlockContainerWidth("features")).toBe("wide");
+    expect(getBlockContainerWidth("section-header")).toBe("wide");
+  });
+
+  test("returns full for image and video background blocks", () => {
+    for (const type of [
+      "video-background",
+      "bunny-video-background",
+      "image-background",
+      "marquee-images",
+      "hero",
+      "split-full",
+    ]) {
+      expect(getBlockContainerWidth(type)).toBe("full");
+    }
+  });
+
+  test("returns narrow for icon-links", () => {
+    expect(getBlockContainerWidth("icon-links")).toBe("narrow");
+  });
+
+  test("defaults unknown block types to wide", () => {
+    expect(getBlockContainerWidth("not-a-real-block")).toBe("wide");
   });
 });

--- a/test/unit/utils/block-schema.test.js
+++ b/test/unit/utils/block-schema.test.js
@@ -66,7 +66,7 @@ describe("BLOCK_CMS_FIELDS", () => {
     // also be editable through the CMS. If you intentionally want a code-only
     // block, remove it from BLOCK_SCHEMAS. If not, export `cmsFields` from its
     // block-schema module (use `{}` for blocks with no block-specific fields
-    // — the wrapper `container_width`/`section_class` fields are auto-injected).
+    // — the wrapper `dark` field is auto-injected).
     const missing = Object.keys(BLOCK_SCHEMAS)
       .filter((type) => !(type in BLOCK_CMS_FIELDS))
       .sort();
@@ -81,8 +81,7 @@ describe("BLOCK_CMS_FIELDS", () => {
     for (const [blockType, fields] of Object.entries(BLOCK_CMS_FIELDS)) {
       const block = { type: blockType };
       for (const fieldKey of Object.keys(fields)) {
-        block[fieldKey] =
-          fieldKey === "container_width" ? "wide" : "test-value";
+        block[fieldKey] = fieldKey === "dark" ? true : "test-value";
       }
       expect(() => validateBlocks([block])).not.toThrow();
     }
@@ -408,21 +407,28 @@ describe("validateBlocks", () => {
     expect(() => validateBlocks([])).not.toThrow();
   });
 
-  test("accepts valid container_width values", () => {
-    for (const width of ["full", "wide", "narrow"]) {
-      const blocks = [
-        { type: "section-header", intro: "x", container_width: width },
-      ];
+  test("accepts dark boolean on any block", () => {
+    for (const dark of [true, false]) {
+      const blocks = [{ type: "section-header", intro: "x", dark }];
       expect(() => validateBlocks(blocks)).not.toThrow();
     }
   });
 
-  test("throws for invalid container_width value", () => {
+  test("rejects removed container_width key", () => {
     const blocks = [
-      { type: "section-header", intro: "x", container_width: "huge" },
+      { type: "section-header", intro: "x", container_width: "wide" },
     ];
     expect(() => validateBlocks(blocks)).toThrow(
-      'invalid container_width "huge"',
+      'unknown keys: "container_width"',
+    );
+  });
+
+  test("rejects removed section_class key", () => {
+    const blocks = [
+      { type: "section-header", intro: "x", section_class: "dark" },
+    ];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'unknown keys: "section_class"',
     );
   });
 });

--- a/test/unit/utils/pages-yml-block-sync.test.js
+++ b/test/unit/utils/pages-yml-block-sync.test.js
@@ -13,7 +13,7 @@ const componentNameToBlockType = (componentName) =>
 
 /** Auto-injected wrapper fields that the generator prepends to every block
  *  component. Mirrors CONTAINER_FIELDS in src/_lib/utils/block-schema/shared.js. */
-const CONTAINER_FIELD_NAMES = ["container_width", "section_class"];
+const CONTAINER_FIELD_NAMES = ["dark"];
 
 const PAGES_YML_PATH = join(rootDir, ".pages.yml");
 const parsedPagesYml = YAML.parse(readFileSync(PAGES_YML_PATH, "utf-8"));
@@ -44,12 +44,14 @@ describe(".pages.yml components ↔ BLOCK_CMS_FIELDS", () => {
     const violations = Object.entries(blockComponents)
       .filter(([, def]) => Array.isArray(def.fields))
       .flatMap(([name, def]) => {
-        const firstNames = def.fields.slice(0, 2).map((f) => f.name);
+        const firstNames = def.fields
+          .slice(0, CONTAINER_FIELD_NAMES.length)
+          .map((f) => f.name);
         return JSON.stringify(firstNames) ===
           JSON.stringify(CONTAINER_FIELD_NAMES)
           ? []
           : [
-              `${name}: expected first two fields to be ${CONTAINER_FIELD_NAMES.join(", ")}, got ${firstNames.join(", ")}`,
+              `${name}: expected first ${CONTAINER_FIELD_NAMES.length} field(s) to be ${CONTAINER_FIELD_NAMES.join(", ")}, got ${firstNames.join(", ")}`,
             ];
       });
     expect(violations).toEqual([]);


### PR DESCRIPTION
## Summary

- Removes the per-block **Container Width** and **Section Class** fields from `.pages.yml` (33+ field pairs).
- Container width is now hardcoded by block type and not user-configurable:
  - `full` for `video-background`, `bunny-video-background`, `image-background`, `marquee-images`
  - `narrow` for `icon-links`
  - `wide` for everything else
- The free-form `section_class` string is replaced with a single `dark` boolean (the only built-in section class actually used in production was `dark`).
- Updates `blocks.html` to apply `class="dark"` from `block.dark` and to ignore any user-supplied `container_width` / `section_class`.
- Drops six redundant `container_width: full` overrides plus one `section_class: gradient` from `src/pages/chobble-template.md`.
- Regenerates `.pages.yml` and `BLOCKS_LAYOUT.md` from the updated schema.

## Notes

- Only one section class besides `dark` had ever been set in template content: a single `section_class: gradient` on the demo page's split-code performance block. That has been removed (the gradient was cosmetic).
- Two block types in the demo (`hero` and `split-full`) were previously using `container_width: full` overrides. They will now render at `container-wide` per the new defaults. If they need to be full-bleed again, the right fix is to add them to the `cw = "full"` list in `blocks.html` rather than reintroducing the user-facing field.
- `validateBlocks` now rejects the old `container_width` and `section_class` keys — so any old content frontmatter still using them will fail the build with a clear error message.

## Test plan

- [x] `bun test` — 2463 tests pass
- [x] `bun run build` — site builds cleanly
- [x] `.pages.yml` and `BLOCKS_LAYOUT.md` regenerated and committed
- [ ] Visual check that hero/split-full sections in the demo still look acceptable at `container-wide`