### PR TITLE
Render CTA block description as markdown

### DIFF
--- a/src/_includes/design-system/cta.html
+++ b/src/_includes/design-system/cta.html
@@ -3,7 +3,7 @@ Call-to-action block with gradient background.
 
 Parameters (via block object):
   - block.title: CTA heading (required)
-  - block.description: Supporting text
+  - block.description: Supporting text (rendered as markdown)
   - block.button: Button object with:
     - text: Button label
     - href: Link URL
@@ -24,7 +24,7 @@ Usage:
 <aside class="cta"{% if block.reveal %} data-reveal="{{ block.reveal }}"{% endif %}>
   <h2>{{ block.title }}</h2>
   {%- if block.description -%}
-    <p>{{ block.description }}</p>
+    <div class="prose">{{ block.description | renderContent: "md" }}</div>
   {%- endif -%}
   {%- if block.button -%}
     {%- assign variant = block.button.variant | default: "secondary" -%}


### PR DESCRIPTION
## Summary

- Replace hardcoded `<p>` tag in the CTA block with `renderContent: "md"` filter and a `.prose` wrapper
- Consistent with how all other blocks in the system handle text content (features, split-article, render-items-block, etc.)

## CSS impact

No CSS changes needed. The existing `.cta p { body-lg; opacity: 0.9; max-width: $width-narrow }` rule continues to style `<p>` elements generated by the markdown renderer — the `.prose` wrapper is transparent to those descendant selectors.

## Test plan

- [ ] Verify a CTA block with plain text description still renders correctly
- [ ] Verify a CTA block with markdown description (bold, links, line breaks) renders correctly
- [ ] Check visual appearance — prose wrapper should not affect layout since `.cta` already centers all flex children

https://claude.ai/code/session_01UaZHYgr8dgmLhiWJrTsWso