### PR TITLE
Add link-columns block for plain-text link lists

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -45,6 +45,7 @@ import { configureLinkList } from "#eleventy/link-list.js";
 import { configureOpeningTimes } from "#eleventy/opening-times.js";
 import { configurePdf } from "#eleventy/pdf.js";
 import { configureRecurringEvents } from "#eleventy/recurring-events.js";
+import { configureRemovePattern } from "#eleventy/remove-pattern.js";
 import { configureScreenshots } from "#eleventy/screenshots.js";
 import { configureStyleBundle } from "#eleventy/style-bundle.js";
 import { configureVideo } from "#eleventy/video.js";
@@ -114,6 +115,7 @@ export default async function (eleventyConfig) {
   configureNews(eleventyConfig);
   configureOpeningTimes(eleventyConfig);
   configureRecurringEvents(eleventyConfig);
+  configureRemovePattern(eleventyConfig);
   configureScreenshots(eleventyConfig);
   configureFilters(eleventyConfig);
   configureProducts(eleventyConfig);

--- a/.pages.yml
+++ b/.pages.yml
@@ -371,6 +371,27 @@ components:
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }
+  block_link_columns:
+    label: Link Columns
+    type: object
+    fields:
+      - { name: dark, type: boolean, label: Dark }
+      - name: collection
+        type: string
+        label: Collection Name
+        required: true
+      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: filter
+        type: object
+        label: Filter
+        fields:
+          - name: property
+            type: string
+            label: Property (e.g. url, data.title)
+          - { name: includes, type: string, label: Contains }
+          - { name: equals, type: string, label: Equals }
+      - { name: remove_text, type: string, label: Remove Text (Regex) }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_contact_form:
     label: Contact Form
     type: object
@@ -600,6 +621,7 @@ content:
           - { name: image-background, component: block_image_background }
           - { name: items, component: block_items }
           - { name: items-array, component: block_items_array }
+          - { name: link-columns, component: block_link_columns }
           - { name: contact-form, component: block_contact_form }
           - { name: custom-contact-form, component: block_custom_contact_form }
           - { name: markdown, component: block_markdown }

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -434,6 +434,25 @@ Renders items from an explicit list of paths. The collection is inferred dynamic
 
 ---
 
+### `link-columns`
+
+Renders a collection as a plain-text unordered list of links arranged in responsive CSS columns. Optionally strips matching text via a regex so repetitive prefixes/suffixes can be removed.
+
+**Template:** `src/_includes/design-system/link-columns.html`
+**SCSS:** `src/css/design-system/_link-columns.scss`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `collection` | string | **required** | Name of an Eleventy collection (e.g. `"locations"`, `"services"`). |
+| `intro` | string | — | Markdown content rendered above items in `.prose`. |
+| `filter` | object | — | Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value. |
+| `remove_text` | string | — | Regex pattern (JavaScript syntax, global flag implied). Each match is removed from every link's display text and the result is trimmed. Useful for stripping repetitive prefixes like `"Service in "` so links render tidier. |
+| `header_intro` | string | — | Section header content rendered as markdown above the block. |
+| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
+| `header_class` | string | — | Extra CSS classes on the section header. |
+
+---
+
 ### `contact-form`
 
 Two-column layout with prose content and a contact form.

--- a/src/_includes/design-system/block-intro.html
+++ b/src/_includes/design-system/block-intro.html
@@ -1,0 +1,18 @@
+{%- comment -%}
+Renders the optional section header and markdown intro for a block.
+Shared by any block that accepts header_intro / header_align / header_class
+and an `intro` markdown field.
+
+Expects:
+  block - the block frontmatter object
+{%- endcomment -%}
+{%- if block.header_intro -%}
+  {%- include "design-system/section-header.html",
+     intro: block.header_intro,
+     align: block.header_align,
+     header_class: block.header_class
+  -%}
+{%- endif -%}
+{%- if block.intro -%}
+  <div class="prose">{{ block.intro | renderContent: "md" }}</div>
+{%- endif -%}

--- a/src/_includes/design-system/link-columns.html
+++ b/src/_includes/design-system/link-columns.html
@@ -1,0 +1,33 @@
+{%- comment -%}
+Link-columns block: renders a collection as a plain-text <ul> of links
+arranged in CSS columns. Unlike items-block, there is no card, image or
+metadata — just a tidy list of links.
+
+Parameters (from block):
+  collection  - Name of an Eleventy collection (e.g. "locations")
+  intro       - Optional markdown content rendered above the list
+  filter      - Optional filter object ({property, includes, equals})
+  remove_text - Optional regex pattern; each match is stripped from every
+                link's display text and the result is trimmed. Useful for
+                killing repetitive prefixes like "Service in ".
+  header_intro / header_align / header_class - Optional section header.
+{%- endcomment -%}
+
+{%- include "design-system/block-intro.html" -%}
+
+{%- assign linkItems = collections[block.collection] -%}
+{%- if block.filter -%}
+  {%- assign linkItems = linkItems | filterItems: block.filter -%}
+{%- endif -%}
+
+{%- if linkItems.size > 0 -%}
+<ul class="link-columns" role="list">
+  {%- for item in linkItems -%}
+    {%- assign label = item.data.name | default: item.data.title -%}
+    {%- if block.remove_text -%}
+      {%- assign label = label | removePattern: block.remove_text -%}
+    {%- endif -%}
+    <li><a href="{{- item.url -}}{{ config.internal_link_suffix }}">{{ label }}</a></li>
+  {%- endfor -%}
+</ul>
+{%- endif -%}

--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -70,6 +70,9 @@ Renders a single block by type. Used by blocks.html.
   {%- when "items-array" -%}
     {%- include "design-system/items-array-block.html", block: block -%}
 
+  {%- when "link-columns" -%}
+    {%- include "design-system/link-columns.html", block: block -%}
+
   {%- when "guide-categories" -%}
     {%- include "design-system/guide-categories-block.html" -%}
 

--- a/src/_includes/design-system/render-items-block.html
+++ b/src/_includes/design-system/render-items-block.html
@@ -2,16 +2,7 @@
 Shared rendering logic for items blocks.
 Expects blockItems and block variables to be set by the caller.
 {%- endcomment -%}
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-     intro: block.header_intro,
-     align: block.header_align,
-     header_class: block.header_class
-  -%}
-{%- endif -%}
-{%- if block.intro -%}
-  <div class="prose">{{ block.intro | renderContent: "md" }}</div>
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 
 {%- if block.filter -%}
   {%- assign blockItems = blockItems | filterItems: block.filter -%}

--- a/src/_lib/eleventy/remove-pattern.js
+++ b/src/_lib/eleventy/remove-pattern.js
@@ -15,7 +15,7 @@ const removePattern = (str, pattern) => {
   return str.replace(new RegExp(pattern, "g"), "").trim();
 };
 
-/** @param {import("@11ty/eleventy").UserConfig} eleventyConfig */
+/** @param {*} eleventyConfig */
 const configureRemovePattern = (eleventyConfig) => {
   eleventyConfig.addFilter("removePattern", removePattern);
 };

--- a/src/_lib/eleventy/remove-pattern.js
+++ b/src/_lib/eleventy/remove-pattern.js
@@ -1,0 +1,23 @@
+/**
+ * Remove matches of a regex pattern from a string and trim the result.
+ *
+ * Used by the link-columns block so authors can strip repetitive text
+ * (e.g. `"Service in "` from titles like "Service in Town A") without
+ * editing the source item titles.
+ *
+ * @param {string} str - Source string.
+ * @param {string} pattern - JavaScript regex source (global flag is applied).
+ * @returns {string} String with all matches removed and whitespace trimmed.
+ *   Returns the input unchanged if `pattern` is falsy.
+ */
+const removePattern = (str, pattern) => {
+  if (!pattern) return str;
+  return str.replace(new RegExp(pattern, "g"), "").trim();
+};
+
+/** @param {import("@11ty/eleventy").UserConfig} eleventyConfig */
+const configureRemovePattern = (eleventyConfig) => {
+  eleventyConfig.addFilter("removePattern", removePattern);
+};
+
+export { configureRemovePattern, removePattern };

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -29,6 +29,7 @@ import * as include from "#utils/block-schema/include.js";
 import * as items from "#utils/block-schema/items.js";
 import * as itemsArray from "#utils/block-schema/items-array.js";
 import * as linkButton from "#utils/block-schema/link-button.js";
+import * as linkColumns from "#utils/block-schema/link-columns.js";
 import * as markdown from "#utils/block-schema/markdown.js";
 import * as marqueeImages from "#utils/block-schema/marquee-images.js";
 import * as properties from "#utils/block-schema/properties.js";
@@ -77,6 +78,7 @@ const BLOCK_MODULES = [
   imageBackground,
   items,
   itemsArray,
+  linkColumns,
   contactForm,
   customContactForm,
   markdown,

--- a/src/_lib/utils/block-schema/link-columns.js
+++ b/src/_lib/utils/block-schema/link-columns.js
@@ -1,0 +1,48 @@
+import {
+  COLLECTION_PARAM,
+  FILTER_FIELD,
+  HEADER_KEYS,
+  HEADER_PARAM_DOCS,
+  ITEMS_CMS_SHARED_FIELDS,
+  ITEMS_COMMON_PARAMS,
+  md,
+  str,
+} from "#utils/block-schema/shared.js";
+
+export const type = "link-columns";
+
+export const schema = [
+  "collection",
+  "intro",
+  "filter",
+  "remove_text",
+  ...HEADER_KEYS,
+];
+
+export const docs = {
+  summary:
+    "Renders a collection as a plain-text unordered list of links arranged in responsive CSS columns. Optionally strips matching text via a regex so repetitive prefixes/suffixes can be removed.",
+  template: "src/_includes/design-system/link-columns.html",
+  scss: "src/css/design-system/_link-columns.scss",
+  params: {
+    collection: COLLECTION_PARAM(
+      'Name of an Eleventy collection (e.g. `"locations"`, `"services"`).',
+    ),
+    intro: ITEMS_COMMON_PARAMS.intro,
+    filter: ITEMS_COMMON_PARAMS.filter,
+    remove_text: {
+      type: "string",
+      description:
+        'Regex pattern (JavaScript syntax, global flag implied). Each match is removed from every link\'s display text and the result is trimmed. Useful for stripping repetitive prefixes like `"Service in "` so links render tidier.',
+    },
+    ...HEADER_PARAM_DOCS,
+  },
+};
+
+export const cmsFields = {
+  collection: ITEMS_CMS_SHARED_FIELDS.collection,
+  intro: md("Intro Content (Markdown)"),
+  filter: FILTER_FIELD,
+  remove_text: str("Remove Text (Regex)"),
+  header_intro: md("Header Intro"),
+};

--- a/src/css/design-system/_index.scss
+++ b/src/css/design-system/_index.scss
@@ -50,6 +50,7 @@
 @forward "cart-icon";
 @forward "freetobook";
 @forward "link-button";
+@forward "link-columns";
 @forward "icon-links";
 @forward "marquee-images";
 

--- a/src/css/design-system/_link-columns.scss
+++ b/src/css/design-system/_link-columns.scss
@@ -1,0 +1,46 @@
+@use "../variables" as *;
+@use "../breakpoints" as breakpoint;
+
+// =============================================================================
+// LINK COLUMNS (for link-columns block)
+// =============================================================================
+// Plain-text unordered list of links flowed into CSS multi-columns so a long
+// list of related pages renders compactly and reads naturally.
+// =============================================================================
+
+.design-system {
+  ul.link-columns {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    column-gap: $space-lg;
+    columns: 1;
+
+    @include breakpoint.up("sm") {
+      columns: 2;
+    }
+
+    @include breakpoint.up("md") {
+      columns: 3;
+    }
+
+    @include breakpoint.up("lg") {
+      columns: 4;
+    }
+
+    > li {
+      break-inside: avoid;
+      padding: $space-xs 0;
+    }
+
+    a {
+      color: var(--color-link);
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/test/unit/eleventy/remove-pattern.test.js
+++ b/test/unit/eleventy/remove-pattern.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  configureRemovePattern,
+  removePattern,
+} from "#eleventy/remove-pattern.js";
+import { createMockEleventyConfig } from "#test/test-utils.js";
+
+describe("remove-pattern", () => {
+  test("registers removePattern filter with Eleventy", () => {
+    const mockConfig = createMockEleventyConfig();
+    configureRemovePattern(mockConfig);
+
+    expect(typeof mockConfig.filters.removePattern).toBe("function");
+  });
+
+  test("returns input unchanged when pattern is empty", () => {
+    expect(removePattern("Service in Town A", "")).toBe("Service in Town A");
+  });
+
+  test("returns input unchanged when pattern is undefined", () => {
+    expect(removePattern("hello", undefined)).toBe("hello");
+  });
+
+  test("strips a literal prefix from every match", () => {
+    expect(removePattern("Service in Town A", "Service in ")).toBe("Town A");
+  });
+
+  test("removes every match (global)", () => {
+    expect(removePattern("aa-bb-aa-cc-aa", "aa")).toBe("-bb--cc-");
+  });
+
+  test("supports regex metacharacters", () => {
+    expect(removePattern("foo123bar456baz", "\\d+")).toBe("foobarbaz");
+  });
+
+  test("trims whitespace left over after removal", () => {
+    expect(removePattern("  Service in Town A  ", "Service in ")).toBe(
+      "Town A",
+    );
+  });
+
+  test("throws on invalid regex so authors see the error immediately", () => {
+    expect(() => removePattern("anything", "(")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- New `link-columns` block renders an Eleventy collection as a plain `<ul>` of links flowed into responsive CSS columns, instead of the full card layout used by the `items` block.
- Supports the same intro / header / filter options as `items`, plus a new `remove_text` regex for stripping repetitive prefixes from link labels (e.g. `"Service in "` from `"Service in Town A"`) so lists read tidier and feel less spammy.
- Extracted the shared header+intro snippet into `design-system/block-intro.html` so the new block and `render-items-block` stay DRY (and the CPD check stays happy).

## Changes

**New files**
- `src/_lib/utils/block-schema/link-columns.js` — schema, docs, CMS fields (`collection`, `intro`, `filter`, `remove_text`, header keys)
- `src/_includes/design-system/link-columns.html` — Liquid template; applies filter, iterates collection, uses `item.data.name` falling back to `item.data.title`, and pipes through the `removePattern` filter when `remove_text` is set
- `src/_includes/design-system/block-intro.html` — shared header+intro include, reused by `render-items-block.html`
- `src/_lib/eleventy/remove-pattern.js` + tests — `removePattern` Liquid filter
- `src/css/design-system/_link-columns.scss` — responsive CSS columns (1 → 2 → 3 → 4 across sm/md/lg) with `break-inside: avoid` so labels don't split

**Wiring**
- Registered the block module in `src/_lib/utils/block-schema.js`
- Added `when "link-columns"` case in `render-block.html`
- Forwarded SCSS in `design-system/_index.scss`
- Registered the filter in `.eleventy.js`
- Regenerated `BLOCKS_LAYOUT.md` and `.pages.yml` from the generators

## Example

```yaml
blocks:
  - type: link-columns
    collection: locations
    header_intro: "## Where we work"
    remove_text: "Service in "
```

With items titled "Service in Town A", "Service in Town B", … this renders clean columns of `Town A`, `Town B`, …

## Test plan

- [x] `bun test` — 2597 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run build` — site builds successfully
- [x] New unit tests cover `removePattern` (empty pattern, literal + regex patterns, global replacement, trim, invalid-regex throws)
- [x] Existing `block-schema.test.js` data-driven invariants auto-cover the new block type (schema ↔ CMS ↔ docs parity)
- [ ] Manually verify the block renders a real collection in a running dev server

https://claude.ai/code/session_01TPTpLeMDGB3sfvmyvc6KV8