### PR TITLE
Make items field optional in items-array block

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -367,7 +367,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: items, type: string, label: Items, required: true, list: true }
+      - { name: items, type: string, label: Items, list: true }
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -427,7 +427,7 @@ Renders items from an explicit list of paths. The collection is inferred dynamic
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `items` | array | **required** | Array of path strings. Each entry may be a file path (e.g. `src/products/widget.md`) or a directory path (e.g. `locations/fulchester` or `locations/fulchester/`), in which case every item in that directory is included in place. |
+| `items` | array | — | Array of path strings. Each entry may be a file path (e.g. `src/products/widget.md`) or a directory path (e.g. `locations/fulchester` or `locations/fulchester/`), in which case every item in that directory is included in place. |
 | `intro` | string | — | Markdown content rendered above items in `.prose`. |
 | `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
 | `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |

--- a/src/_lib/utils/block-schema/items-array.js
+++ b/src/_lib/utils/block-schema/items-array.js
@@ -17,7 +17,6 @@ export const docs = {
   params: {
     items: {
       type: "array",
-      required: true,
       description:
         "Array of path strings. Each entry may be a file path (e.g. `src/products/widget.md`) or a directory path (e.g. `locations/fulchester` or `locations/fulchester/`), in which case every item in that directory is included in place.",
     },
@@ -28,7 +27,7 @@ export const docs = {
 };
 
 export const cmsFields = {
-  items: str("Items", { list: true, required: true }),
+  items: str("Items", { list: true }),
   intro: ITEMS_CMS_SHARED_FIELDS.intro,
   horizontal: ITEMS_CMS_SHARED_FIELDS.horizontal,
   masonry: ITEMS_CMS_SHARED_FIELDS.masonry,


### PR DESCRIPTION
Removes `required: true` from the `items` field in the `items-array` block schema — both in the `docs.params` definition and the `cmsFields` declaration.

https://claude.ai/code/session_01D77xUAKxW1h1PCpnt4Vrag