### PR TITLE
Use click-to-play facade for split-video blocks

### DIFF
--- a/src/_includes/design-system/split.html
+++ b/src/_includes/design-system/split.html
@@ -36,7 +36,13 @@ Parameters (via block object):
           <figcaption>{{ block.figure_caption }}</figcaption>
         {%- endif -%}
       {%- when "split-video" -%}
-        {%- include "design-system/video-iframe.html", video_id: block.figure_video_id, title: block.figure_alt -%}
+        {%- assign _is_youtube = block.figure_video_id | is_youtube_id -%}
+        {%- if _is_youtube -%}
+          {%- assign _thumbnail = block.figure_video_id | youtube_thumbnail -%}
+        {%- else -%}
+          {%- assign _thumbnail = null -%}
+        {%- endif -%}
+        {%- include "design-system/video-facade.html", video_id: block.figure_video_id, title: block.figure_alt, thumbnail_url: _thumbnail -%}
         {%- if block.figure_caption -%}
           <figcaption>{{ block.figure_caption }}</figcaption>
         {%- endif -%}

--- a/src/_includes/design-system/video-cards.html
+++ b/src/_includes/design-system/video-cards.html
@@ -34,22 +34,7 @@ Usage:
 <ul class="items video-cards{% if expand %} expanded{% endif %}" role="list">
   {%- for video in videos -%}
   <li{% if reveal %} data-reveal{% endif %}>
-    <button
-      type="button"
-      class="video-facade{% unless video.thumbnail_url %} video-facade--no-thumbnail{% endunless %}"
-      aria-label="Play {{ video.title }}"
-    >
-      {%- if video.thumbnail_url -%}
-      {%- image video.thumbnail_url, video.title, "", "", "", "16/9", "", false, true -%}
-      {%- endif -%}
-      <span class="video-play-button" aria-hidden="true">
-        <svg viewBox="0 0 68 48" width="68" height="48">
-          <path class="video-play-bg" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z"/>
-          <path class="video-play-icon" d="M 45,24 27,14 27,34"/>
-        </svg>
-      </span>
-      <template>{%- include "design-system/video-iframe.html", video_id: video.id, title: video.title -%}</template>
-    </button>
+    {%- include "design-system/video-facade.html", video_id: video.id, title: video.title, thumbnail_url: video.thumbnail_url -%}
     <h{{ heading_level }}>{{ video.title }}</h{{ heading_level }}>
   </li>
   {%- endfor -%}

--- a/src/_includes/design-system/video-facade.html
+++ b/src/_includes/design-system/video-facade.html
@@ -1,0 +1,32 @@
+{%- comment -%}
+Click-to-play video facade. Renders a thumbnail + play button that lazy-loads
+the iframe on click (no autoplay on page load).
+
+Used by video-cards (grid of videos) and split-video blocks so video UI is
+consistent across the site. The iframe lives inside a <template> and is
+swapped in by initVideoFacades() in design-system.js when the button is
+clicked; the embed URL still has autoplay=1 so the video starts as soon as
+it appears.
+
+Parameters:
+  - video_id: YouTube video ID or custom iframe URL (required)
+  - title: Accessible title/alt for the video (required)
+  - thumbnail_url: Thumbnail image URL. Falsy renders the no-thumbnail variant.
+{%- endcomment -%}
+
+<button
+  type="button"
+  class="video-facade{% unless thumbnail_url %} video-facade--no-thumbnail{% endunless %}"
+  aria-label="Play {{ title }}"
+>
+  {%- if thumbnail_url -%}
+  {%- image thumbnail_url, title, "", "", "", "16/9", "", false, true -%}
+  {%- endif -%}
+  <span class="video-play-button" aria-hidden="true">
+    <svg viewBox="0 0 68 48" width="68" height="48">
+      <path class="video-play-bg" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z"/>
+      <path class="video-play-icon" d="M 45,24 27,14 27,34"/>
+    </svg>
+  </span>
+  <template>{%- include "design-system/video-iframe.html", video_id: video_id, title: title -%}</template>
+</button>

--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -447,6 +447,72 @@
   }
 }
 
+// Shared video-facade + video-wrapper styles.
+// Used anywhere a click-to-play video is rendered (cards, split-video, etc.)
+// so the look is consistent across the site. Scoping is left to the caller.
+@mixin video-media($radius: 0) {
+  .video-wrapper {
+    @include iframe-embed;
+  }
+
+  .video-facade {
+    position: relative;
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    overflow: hidden;
+
+    .image-wrapper {
+      @include image-wrapper($border-radius: $radius);
+      aspect-ratio: 16 / 9;
+
+      img {
+        @include cover-img;
+      }
+    }
+
+    .video-play-button {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      transition:
+        transform $transition-fast,
+        opacity $transition-fast;
+
+      svg {
+        display: block;
+      }
+
+      .video-play-bg {
+        fill: var(--color-video-play-bg);
+        fill-opacity: 0.8;
+      }
+
+      .video-play-icon {
+        fill: var(--color-contrast-text);
+      }
+    }
+
+    &:hover .video-play-button {
+      transform: translate(-50%, -50%) scale(1.1);
+
+      .video-play-bg {
+        fill: var(--color-video-play-hover);
+        fill-opacity: 1;
+      }
+    }
+
+    &.video-facade--no-thumbnail {
+      background: var(--body-background-alt);
+      aspect-ratio: 16 / 9;
+    }
+  }
+}
+
 // Truncate text
 @mixin truncate($lines: 1) {
   @if $lines == 1 {

--- a/src/css/design-system/_items.scss
+++ b/src/css/design-system/_items.scss
@@ -119,66 +119,7 @@
         }
       }
 
-      .video-wrapper {
-        @include iframe-embed;
-      }
-
-      .video-facade {
-        position: relative;
-        display: block;
-        width: 100%;
-        padding: 0;
-        border: 0;
-        background: none;
-        cursor: pointer;
-        overflow: hidden;
-
-        .image-wrapper {
-          @include image-wrapper($border-radius: 0);
-          aspect-ratio: 16 / 9;
-
-          img {
-            @include cover-img;
-          }
-        }
-
-        .video-play-button {
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-          transition:
-            transform $transition-fast,
-            opacity $transition-fast;
-
-          svg {
-            display: block;
-          }
-
-          .video-play-bg {
-            fill: var(--color-video-play-bg);
-            fill-opacity: 0.8;
-          }
-
-          .video-play-icon {
-            fill: var(--color-contrast-text);
-          }
-        }
-
-        &:hover .video-play-button {
-          transform: translate(-50%, -50%) scale(1.1);
-
-          .video-play-bg {
-            fill: var(--color-video-play-hover);
-            fill-opacity: 1;
-          }
-        }
-
-        &.video-facade--no-thumbnail {
-          background: var(--body-background-alt);
-          aspect-ratio: 16 / 9;
-        }
-      }
+      @include video-media;
 
       // =======================================================================
       // TEXT CONTENT

--- a/src/css/design-system/_split.scss
+++ b/src/css/design-system/_split.scss
@@ -36,6 +36,8 @@
         width: 100%;
         height: auto;
       }
+
+      @include video-media;
     }
   }
 


### PR DESCRIPTION
## Summary

- The split-video block rendered the iframe directly, so it had no aspect ratio, no facade, and YouTube's `autoplay=1` fired on page load.
- Switched split-video to the same click-to-play facade used by video-cards: thumbnail + play button render server-side, iframe is swapped in on click (still via `initVideoFacades` in `design-system.js`).
- Extracted the facade/wrapper styles into a `video-media` mixin shared by `.items > li` and `.split > figure`, and pulled the facade markup into a new `video-facade.html` partial so video-cards and split-video stay in sync.

## Test plan

- [ ] Add a `split-video` block with a YouTube `figure_video_id`; verify thumbnail + play button show and no video loads until clicked.
- [ ] Click the play button; verify the iframe swaps in and the video plays.
- [ ] Try a custom (non-YouTube) URL; verify the no-thumbnail facade variant renders with correct 16:9 aspect ratio.
- [ ] Confirm existing video-cards still render unchanged.
- [ ] `bun test` passes.
