### PR TITLE
Add iframe-embed and buy-options block types

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -72,6 +72,30 @@ components:
           - { name: title, type: string, label: Title, required: true }
           - { name: description, type: string, label: Description }
           - { name: link, type: string, label: Link URL }
+  block_buy_options:
+    label: Buy Options
+    type: object
+    fields:
+      - { name: dark, type: boolean, label: Dark }
+      - { name: heading_level, type: number, label: Heading Level }
+      - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
+      - { name: header_intro, type: rich-text, label: Header Intro }
+      - name: items
+        type: object
+        label: Products
+        list: true
+        fields:
+          - { name: image, type: image, label: Image, required: true }
+          - { name: title, type: string, label: Title, required: true }
+          - { name: subtitle, type: string, label: Subtitle }
+          - name: price
+            type: string
+            label: Price (display, e.g. £15)
+          - name: currency
+            type: string
+            label: Currency (ISO code, e.g. GBP)
+          - { name: link, type: string, label: Buy Link, required: true }
+          - { name: button_text, type: string, label: Button Text }
   block_stats:
     label: Stats
     type: object
@@ -432,6 +456,23 @@ components:
     fields:
       - { name: dark, type: boolean, label: Dark }
       - { name: content, type: string, label: Raw HTML, required: true }
+  block_iframe_embed:
+    label: Iframe Embed
+    type: object
+    fields:
+      - { name: dark, type: boolean, label: Dark }
+      - { name: src, type: string, label: Iframe URL, required: true }
+      - { name: title, type: string, label: Accessible Title, required: true }
+      - { name: width, type: number, label: Width (px) }
+      - { name: height, type: number, label: Height (px) }
+      - { name: aspect_ratio, type: string, label: Aspect Ratio (e.g. 16/9) }
+      - name: max_width
+        type: string
+        label: Max Width (CSS, e.g. 560px)
+      - { name: sandbox, type: string, label: Sandbox }
+      - { name: allow, type: string, label: Allow (permissions policy) }
+      - { name: scrolling, type: string, label: Scrolling }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_content:
     label: Content
     type: object
@@ -604,6 +645,7 @@ content:
           - { name: section-header, component: block_section_header }
           - { name: features, component: block_features }
           - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
           - { name: stats, component: block_stats }
           - { name: code-block, component: block_code_block }
           - { name: hero, component: block_hero }
@@ -626,6 +668,7 @@ content:
           - { name: custom-contact-form, component: block_custom_contact_form }
           - { name: markdown, component: block_markdown }
           - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
           - { name: content, component: block_content }
           - { name: include, component: block_include }
           - { name: properties, component: block_properties }

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -102,6 +102,28 @@ Grid of cards featuring images with titles and optional descriptions.
 
 ---
 
+### `buy-options`
+
+Grid of buyable products — image, title, optional subtitle, price, and a buy button. Emits schema.org Product microdata.
+
+**Template:** `src/_includes/design-system/buy-options.html`
+**SCSS:** `src/css/design-system/_items.scss`
+**HTML root:** `<ul class="items" role="list">`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `items` | array | **required** | Product objects. Each: `{image, title, subtitle, price, currency, link, button_text}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP. |
+| `heading_level` | number | `3` | Heading level for titles. |
+| `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
+| `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
+| `header_intro` | string | — | Section header content rendered as markdown above the block. |
+| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
+| `header_class` | string | — | Extra CSS classes on the section header. |
+
+Each item renders as a `<li>` with `itemscope itemtype="https://schema.org/Product"`. The price is emitted as a nested `Offer` with `priceCurrency` (defaults to `GBP`). Use this block when the buy action is external (Stripe, itch.io, Gumroad); for sitewide shop listings, use the `items` block with a `products` collection.
+
+---
+
 ### `stats`
 
 Key metrics displayed as large numbers with labels.
@@ -514,6 +536,33 @@ Outputs raw HTML without processing.
 | `content` | string | **required** | Raw HTML. Output directly with `{{ block.content }}`. |
 
 Inline in `render-block.html` (no separate template file). No wrapping element. Useful for custom embeds, iframes, or one-off HTML.
+
+---
+
+### `iframe-embed`
+
+Third-party iframe embed (itch.io widgets, Buttondown, Bandcamp, Stripe buttons, etc).
+
+**Template:** `src/_includes/design-system/iframe-embed.html`
+**SCSS:** `src/css/design-system/_iframe-embed.scss`
+**HTML root:** `<div class="iframe-embed">`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `src` | string | **required** | Full URL of the iframe to embed. |
+| `title` | string | **required** | Accessible title for the iframe. |
+| `width` | number | — | Fixed pixel width. Omit to fill the container. |
+| `height` | number | — | Fixed pixel height. Required for non-responsive embeds unless `aspect_ratio` is set. |
+| `aspect_ratio` | string | — | CSS `aspect-ratio` for responsive height, e.g. `"16/9"`. Alternative to `height`. |
+| `max_width` | string | — | CSS max-width on the wrapper, e.g. `"560px"`. |
+| `sandbox` | string | — | Space-separated sandbox tokens, e.g. `"allow-scripts allow-same-origin allow-forms"`. |
+| `allow` | string | — | `allow` attribute for iframe permissions policy. |
+| `scrolling` | string | — | Legacy `scrolling` attribute, e.g. `"no"`. |
+| `header_intro` | string | — | Section header content rendered as markdown above the block. |
+| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
+| `header_class` | string | — | Extra CSS classes on the section header. |
+
+Provide either `height` for a fixed-height embed or `aspect_ratio` (e.g. `16/9`) for a responsive one. Use `max_width` to cap the embed width within the container.
 
 ---
 

--- a/src/_includes/design-system/buy-options.html
+++ b/src/_includes/design-system/buy-options.html
@@ -1,0 +1,64 @@
+{%- comment -%}
+Buy-options grid — cards for purchasable products with schema.org Product
+microdata. Renders on top of the shared .items grid styles.
+
+Parameters (via block object):
+  - block.items: Array of product objects with properties:
+    - image: Image path (required)
+    - title: Product name (required)
+    - subtitle: Short secondary line, e.g. "Print edition" (optional)
+    - price: Display price string, e.g. "£15" (optional)
+    - currency: ISO currency code for schema.org, defaults to "GBP" (optional)
+    - link: Buy URL (required)
+    - button_text: Button label, defaults to "Buy now" (optional)
+  - block.reveal: If true, adds data-reveal animation (default: true)
+  - block.heading_level: Heading level for titles, defaults to 3 (h3)
+  - block.image_aspect_ratio: Aspect ratio for images (e.g. "1/1", "4/3")
+  - block.header_intro, header_align, header_class: Optional section header
+{%- endcomment -%}
+
+{%- if block.header_intro -%}
+  {%- include "design-system/section-header.html",
+     intro: block.header_intro,
+     align: block.header_align,
+     header_class: block.header_class
+  -%}
+{%- endif -%}
+
+{%- assign heading_level = block.heading_level | default: 3 -%}
+{%- assign reveal = block.reveal | default: true -%}
+
+<ul class="items buy-options" role="list">
+  {%- for item in block.items -%}
+    {%- assign price_value = item.price
+       | replace: "£", ""
+       | replace: "$", ""
+       | replace: "€", ""
+       | replace: ",", ""
+       | strip -%}
+    {%- assign currency = item.currency | default: "GBP" -%}
+    {%- assign button_text = item.button_text | default: "Buy now" -%}
+    <li itemscope itemtype="https://schema.org/Product"{% if reveal %} data-reveal{% endif %}>
+      {%- if item.image -%}
+        <a class="image-link" href="{{ item.link }}">
+          {%- image item.image, item.title, "", "", "", block.image_aspect_ratio -%}
+          <meta itemprop="image" content="{{ item.image }}">
+        </a>
+      {%- endif -%}
+      <h{{ heading_level }} itemprop="name">
+        <a href="{{ item.link }}">{{ item.title }}</a>
+      </h{{ heading_level }}>
+      {%- if item.subtitle -%}
+        <p class="subtitle">{{ item.subtitle }}</p>
+      {%- endif -%}
+      {%- if item.price -%}
+        <p class="price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+          <span itemprop="priceCurrency" content="{{ currency }}"></span>
+          <meta itemprop="price" content="{{ price_value }}">
+          <span>{{ item.price }}</span>
+        </p>
+      {%- endif -%}
+      <a class="button" href="{{ item.link }}" itemprop="url">{{ button_text }}</a>
+    </li>
+  {%- endfor -%}
+</ul>

--- a/src/_includes/design-system/iframe-embed.html
+++ b/src/_includes/design-system/iframe-embed.html
@@ -1,0 +1,50 @@
+{%- comment -%}
+Third-party iframe embed block.
+
+Renders an <iframe> inside a .iframe-embed wrapper with optional fixed
+dimensions, responsive aspect ratio, and max-width. Use this block for
+itch.io widgets, Buttondown signup forms, Bandcamp/Spotify players, Stripe
+buy buttons, etc — any time you'd otherwise hand-write an <iframe> in an
+`html` block.
+
+Parameters (via block object):
+  - block.src: Iframe URL (required)
+  - block.title: Accessible title for the iframe (required)
+  - block.width: Fixed pixel width (optional)
+  - block.height: Fixed pixel height (optional)
+  - block.aspect_ratio: CSS aspect-ratio for responsive embeds, e.g. "16/9"
+  - block.max_width: CSS max-width, e.g. "560px"
+  - block.sandbox: Sandbox tokens
+  - block.allow: Permissions policy
+  - block.scrolling: Legacy scrolling attribute
+  - block.header_intro, header_align, header_class: Optional section header
+{%- endcomment -%}
+
+{%- if block.header_intro -%}
+  {%- include "design-system/section-header.html",
+     intro: block.header_intro,
+     align: block.header_align,
+     header_class: block.header_class
+  -%}
+{%- endif -%}
+
+{%- capture _wrap_style -%}
+  {%- if block.aspect_ratio %}aspect-ratio: {{ block.aspect_ratio }};{%- endif -%}
+  {%- if block.max_width %}max-width: {{ block.max_width }};{%- endif -%}
+  {%- if block.width %}width: {{ block.width }}px;{%- endif -%}
+{%- endcapture -%}
+
+<div class="iframe-embed{% if block.aspect_ratio %} iframe-embed--responsive{% endif %}"{% if _wrap_style != "" %} style="{{ _wrap_style | strip }}"{% endif %}>
+  <iframe
+    src="{{ block.src }}"
+    title="{{ block.title }}"
+    {% if block.width %}width="{{ block.width }}"{% endif %}
+    {% if block.height %}height="{{ block.height }}"{% endif %}
+    {% if block.sandbox %}sandbox="{{ block.sandbox }}"{% endif %}
+    {% if block.allow %}allow="{{ block.allow }}"{% endif %}
+    {% if block.scrolling %}scrolling="{{ block.scrolling }}"{% endif %}
+    loading="lazy"
+    frameborder="0"
+    referrerpolicy="origin"
+  ></iframe>
+</div>

--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -13,6 +13,9 @@ Renders a single block by type. Used by blocks.html.
   {%- when "image-cards" -%}
     {%- include "design-system/image-cards.html", block: block -%}
 
+  {%- when "buy-options" -%}
+    {%- include "design-system/buy-options.html", block: block -%}
+
   {%- when "stats" -%}
     {%- include "design-system/stats.html", block: block -%}
 
@@ -39,6 +42,9 @@ Renders a single block by type. Used by blocks.html.
 
   {%- when "html" -%}
     {{ block.content }}
+
+  {%- when "iframe-embed" -%}
+    {%- include "design-system/iframe-embed.html", block: block -%}
 
   {%- when "video-background" -%}
     {%- include "design-system/video-background.html", block: block -%}

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -12,6 +12,7 @@
  */
 
 import * as bunnyVideoBackground from "#utils/block-schema/bunny-video-background.js";
+import * as buyOptions from "#utils/block-schema/buy-options.js";
 import * as codeBlock from "#utils/block-schema/code-block.js";
 import * as contactForm from "#utils/block-schema/contact-form.js";
 import * as content from "#utils/block-schema/content.js";
@@ -23,6 +24,7 @@ import * as guideCategories from "#utils/block-schema/guide-categories.js";
 import * as hero from "#utils/block-schema/hero.js";
 import * as html from "#utils/block-schema/html.js";
 import * as iconLinks from "#utils/block-schema/icon-links.js";
+import * as iframeEmbed from "#utils/block-schema/iframe-embed.js";
 import * as imageBackground from "#utils/block-schema/image-background.js";
 import * as imageCards from "#utils/block-schema/image-cards.js";
 import * as include from "#utils/block-schema/include.js";
@@ -62,6 +64,7 @@ const BLOCK_MODULES = [
   sectionHeader,
   features,
   imageCards,
+  buyOptions,
   stats,
   codeBlock,
   hero,
@@ -83,6 +86,7 @@ const BLOCK_MODULES = [
   customContactForm,
   markdown,
   html,
+  iframeEmbed,
   content,
   include,
   properties,

--- a/src/_lib/utils/block-schema/buy-options.js
+++ b/src/_lib/utils/block-schema/buy-options.js
@@ -1,0 +1,49 @@
+/* jscpd:ignore-start */
+import {
+  IMAGE_CARD_GRID_KEYS,
+  IMAGE_CARD_GRID_PARAMS,
+  ITEMS_ARRAY_PARAM,
+  ITEMS_GRID_META,
+  imageCardCmsFields,
+  img,
+  objectList,
+  str,
+} from "#utils/block-schema/shared.js";
+/* jscpd:ignore-end */
+
+export const type = "buy-options";
+
+export const schema = IMAGE_CARD_GRID_KEYS;
+
+export const docs = {
+  summary:
+    "Grid of buyable products — image, title, optional subtitle, price, and a buy button. Emits schema.org Product microdata.",
+  template: "src/_includes/design-system/buy-options.html",
+  ...ITEMS_GRID_META,
+  notes:
+    'Each item renders as a `<li>` with `itemscope itemtype="https://schema.org/Product"`. The price is emitted as a nested `Offer` with `priceCurrency` (defaults to `GBP`). Use this block when the buy action is external (Stripe, itch.io, Gumroad); for sitewide shop listings, use the `items` block with a `products` collection.',
+  /* jscpd:ignore-start */
+  params: {
+    items: {
+      ...ITEMS_ARRAY_PARAM,
+      description:
+        "Product objects. Each: `{image, title, subtitle, price, currency, link, button_text}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP.",
+    },
+    ...IMAGE_CARD_GRID_PARAMS,
+  },
+  /* jscpd:ignore-end */
+};
+
+/* jscpd:ignore-start */
+export const cmsFields = imageCardCmsFields(
+  objectList("Products", {
+    image: img("Image", { required: true }),
+    title: str("Title", { required: true }),
+    subtitle: str("Subtitle"),
+    price: str("Price (display, e.g. £15)"),
+    currency: str("Currency (ISO code, e.g. GBP)"),
+    link: str("Buy Link", { required: true }),
+    button_text: str("Button Text"),
+  }),
+);
+/* jscpd:ignore-end */

--- a/src/_lib/utils/block-schema/iframe-embed.js
+++ b/src/_lib/utils/block-schema/iframe-embed.js
@@ -1,0 +1,89 @@
+import {
+  HEADER_KEYS,
+  HEADER_PARAM_DOCS,
+  md,
+  num,
+  str,
+} from "#utils/block-schema/shared.js";
+
+export const type = "iframe-embed";
+
+export const schema = [
+  "src",
+  "title",
+  "width",
+  "height",
+  "aspect_ratio",
+  "max_width",
+  "sandbox",
+  "allow",
+  "scrolling",
+  ...HEADER_KEYS,
+];
+
+export const docs = {
+  summary:
+    "Third-party iframe embed (itch.io widgets, Buttondown, Bandcamp, Stripe buttons, etc).",
+  template: "src/_includes/design-system/iframe-embed.html",
+  scss: "src/css/design-system/_iframe-embed.scss",
+  htmlRoot: '<div class="iframe-embed">',
+  notes:
+    "Provide either `height` for a fixed-height embed or `aspect_ratio` (e.g. `16/9`) for a responsive one. Use `max_width` to cap the embed width within the container.",
+  params: {
+    src: {
+      type: "string",
+      required: true,
+      description: "Full URL of the iframe to embed.",
+    },
+    title: {
+      type: "string",
+      required: true,
+      description: "Accessible title for the iframe.",
+    },
+    width: {
+      type: "number",
+      description: "Fixed pixel width. Omit to fill the container.",
+    },
+    height: {
+      type: "number",
+      description:
+        "Fixed pixel height. Required for non-responsive embeds unless `aspect_ratio` is set.",
+    },
+    aspect_ratio: {
+      type: "string",
+      description:
+        'CSS `aspect-ratio` for responsive height, e.g. `"16/9"`. Alternative to `height`.',
+    },
+    max_width: {
+      type: "string",
+      description: 'CSS max-width on the wrapper, e.g. `"560px"`.',
+    },
+    sandbox: {
+      type: "string",
+      description:
+        'Space-separated sandbox tokens, e.g. `"allow-scripts allow-same-origin allow-forms"`.',
+    },
+    allow: {
+      type: "string",
+      description: "`allow` attribute for iframe permissions policy.",
+    },
+    scrolling: {
+      type: "string",
+      description: 'Legacy `scrolling` attribute, e.g. `"no"`.',
+    },
+    ...HEADER_PARAM_DOCS,
+  },
+};
+
+export const cmsFields = {
+  src: str("Iframe URL", { required: true }),
+  title: str("Accessible Title", { required: true }),
+  width: num("Width (px)"),
+  height: num("Height (px)"),
+  aspect_ratio: str("Aspect Ratio (e.g. 16/9)"),
+  max_width: str("Max Width (CSS, e.g. 560px)"),
+  sandbox: str("Sandbox"),
+  allow: str("Allow (permissions policy)"),
+  scrolling: str("Scrolling"),
+  header_intro: md("Header Intro"),
+};

--- a/src/_lib/utils/block-schema/image-cards.js
+++ b/src/_lib/utils/block-schema/image-cards.js
@@ -1,25 +1,19 @@
+/* jscpd:ignore-start */
 import {
-  HEADER_KEYS,
-  HEADER_PARAM_DOCS,
+  IMAGE_CARD_GRID_KEYS,
+  IMAGE_CARD_GRID_PARAMS,
   ITEMS_ARRAY_PARAM,
   ITEMS_GRID_META,
+  imageCardCmsFields,
   img,
-  md,
-  num,
   objectList,
-  REVEAL_BOOLEAN_PARAM,
   str,
 } from "#utils/block-schema/shared.js";
+/* jscpd:ignore-end */
 
 export const type = "image-cards";
 
-export const schema = [
-  "items",
-  "reveal",
-  "heading_level",
-  "image_aspect_ratio",
-  ...HEADER_KEYS,
-];
+export const schema = IMAGE_CARD_GRID_KEYS;
 
 export const docs = {
   summary:
@@ -32,31 +26,15 @@ export const docs = {
       description:
         "Card objects. Each: `{image, title, description, link}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP.",
     },
-    heading_level: {
-      type: "number",
-      default: "3",
-      description: "Heading level for titles.",
-    },
-    image_aspect_ratio: {
-      type: "string",
-      description: 'Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`.',
-    },
-    reveal: {
-      ...REVEAL_BOOLEAN_PARAM,
-      description: "Adds `data-reveal` to each item.",
-    },
-    ...HEADER_PARAM_DOCS,
+    ...IMAGE_CARD_GRID_PARAMS,
   },
 };
 
-export const cmsFields = {
-  heading_level: num("Heading Level"),
-  image_aspect_ratio: str("Image Aspect Ratio"),
-  header_intro: md("Header Intro"),
-  items: objectList("Cards", {
+export const cmsFields = imageCardCmsFields(
+  objectList("Cards", {
     image: img("Image", { required: true }),
     title: str("Title", { required: true }),
     description: str("Description"),
     link: str("Link URL"),
   }),
-};
+);

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -186,6 +186,7 @@ export const IMAGE_CARD_GRID_PARAMS = {
  * Provide an objectList item field (e.g. `objectList("Cards", {...})`) and
  * this helper injects the common heading/aspect/header-intro fields around
  * it so each block module doesn't restate them.
+ * @param {object} itemsField - objectList field for the items array
  */
 export const imageCardCmsFields = (itemsField) => ({
   heading_level: num("Heading Level"),

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -151,6 +151,50 @@ export const ITEMS_ARRAY_PARAM = {
 };
 
 /**
+ * Shared schema keys for image-card-style grid blocks (image-cards, buy-options).
+ * These blocks render an items array as a responsive card grid with optional
+ * per-item image aspect ratio and section header.
+ */
+export const IMAGE_CARD_GRID_KEYS = [
+  "items",
+  "reveal",
+  "heading_level",
+  "image_aspect_ratio",
+  ...HEADER_KEYS,
+];
+
+/** Shared docs params for image-card-style grid blocks. */
+export const IMAGE_CARD_GRID_PARAMS = {
+  heading_level: {
+    type: "number",
+    default: "3",
+    description: "Heading level for titles.",
+  },
+  image_aspect_ratio: {
+    type: "string",
+    description: 'Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`.',
+  },
+  reveal: {
+    ...REVEAL_BOOLEAN_PARAM,
+    description: "Adds `data-reveal` to each item.",
+  },
+  ...HEADER_PARAM_DOCS,
+};
+
+/**
+ * Build the full cmsFields object for image-card-style grid blocks.
+ * Provide an objectList item field (e.g. `objectList("Cards", {...})`) and
+ * this helper injects the common heading/aspect/header-intro fields around
+ * it so each block module doesn't restate them.
+ */
+export const imageCardCmsFields = (itemsField) => ({
+  heading_level: num("Heading Level"),
+  image_aspect_ratio: str("Image Aspect Ratio"),
+  header_intro: md("Header Intro"),
+  items: itemsField,
+});
+
+/**
  * CMS field factory functions.
  * These create the field-shape objects consumed by scripts/customise-cms/generator.js.
  */

--- a/src/css/design-system/_buy-options.scss
+++ b/src/css/design-system/_buy-options.scss
@@ -1,0 +1,23 @@
+@use "../variables" as *;
+
+// =============================================================================
+// BUY OPTIONS
+// =============================================================================
+// Product cards for inline buy-now lists. Builds on `.items` grid styles
+// from _items.scss; this file only adds product-specific tweaks.
+
+.design-system {
+  ul.items.buy-options {
+    > li {
+      .subtitle {
+        font-style: italic;
+      }
+
+      .price {
+        display: flex;
+        align-items: baseline;
+        gap: $space-xs;
+      }
+    }
+  }
+}

--- a/src/css/design-system/_iframe-embed.scss
+++ b/src/css/design-system/_iframe-embed.scss
@@ -1,0 +1,27 @@
+@use "../variables" as *;
+
+// =============================================================================
+// IFRAME EMBED
+// =============================================================================
+// Wrapper for third-party iframe embeds (itch.io, Buttondown, Stripe, etc).
+// Supports fixed-height, responsive aspect-ratio, and max-width sizing.
+
+.design-system {
+  .iframe-embed {
+    display: block;
+    width: 100%;
+    margin-inline: auto;
+    border-radius: $radius-md;
+    overflow: hidden;
+
+    > iframe {
+      display: block;
+      width: 100%;
+      border: 0;
+    }
+
+    &--responsive > iframe {
+      height: 100%;
+    }
+  }
+}

--- a/src/css/design-system/_index.scss
+++ b/src/css/design-system/_index.scss
@@ -49,6 +49,8 @@
 @forward "theme-switcher";
 @forward "cart-icon";
 @forward "freetobook";
+@forward "iframe-embed";
+@forward "buy-options";
 @forward "link-button";
 @forward "link-columns";
 @forward "icon-links";

--- a/test/unit/code-quality/html-in-js.test.js
+++ b/test/unit/code-quality/html-in-js.test.js
@@ -309,6 +309,7 @@ const htmlInJsAnalysis = withAllowlist({
     // htmlRoot documentation strings in block schema modules describe template markup
     "src/_lib/utils/block-schema/shared.js",
     "src/_lib/utils/block-schema/bunny-video-background.js",
+    "src/_lib/utils/block-schema/buy-options.js",
     "src/_lib/utils/block-schema/code-block.js",
     "src/_lib/utils/block-schema/contact-form.js",
     "src/_lib/utils/block-schema/cta.js",
@@ -316,6 +317,7 @@ const htmlInJsAnalysis = withAllowlist({
     "src/_lib/utils/block-schema/features.js",
     "src/_lib/utils/block-schema/hero.js",
     "src/_lib/utils/block-schema/icon-links.js",
+    "src/_lib/utils/block-schema/iframe-embed.js",
     "src/_lib/utils/block-schema/image-background.js",
     "src/_lib/utils/block-schema/link-button.js",
     "src/_lib/utils/block-schema/markdown.js",


### PR DESCRIPTION
## Summary

Adds two new block types:

- **`iframe-embed`** — first-class wrapper for third-party iframes (itch.io widgets, Buttondown signups, Bandcamp/Spotify players, Stripe buttons). Supports fixed or responsive sizing via `height` / `aspect_ratio`, plus optional `max_width`, `sandbox`, and `allow`. Replaces hand-written `<div class="iframe-container"><iframe>` blocks.
- **`buy-options`** — grid of purchasable products (image, title, subtitle, price, buy button) emitting schema.org Product microdata with a nested `Offer` (currency defaults to `GBP`). Use when the buy action is external (Stripe, itch.io, Gumroad); for sitewide shop listings the existing `items` block with a `products` collection is still the right tool.

### Refactor for shared scaffolding

Extracted `IMAGE_CARD_GRID_KEYS`, `IMAGE_CARD_GRID_PARAMS`, and `imageCardCmsFields()` in `shared.js` so `image-cards` and `buy-options` reuse the same header / heading / aspect-ratio / reveal fields.

### Files

- New schemas: `src/_lib/utils/block-schema/{iframe-embed,buy-options}.js`
- New templates: `src/_includes/design-system/{iframe-embed,buy-options}.html`
- New SCSS: `src/css/design-system/_{iframe-embed,buy-options}.scss`
- Registrations: `block-schema.js`, `render-block.html`, `_index.scss`
- Auto-regenerated: `.pages.yml`, `BLOCKS_LAYOUT.md`

## Example usage

```yaml
- type: iframe-embed
  src: https://itch.io/embed/2094843?link_color=3e0b5d
  title: Drama Llamas on Itch.io
  width: 552
  height: 167
  max_width: 560px

- type: buy-options
  header_intro: "## Buy Direct"
  items:
    - image: src/images/products/drama_llamas.jpeg
      title: Drama Llamas
      subtitle: Main rulebook
      price: £15
      currency: GBP
      link: https://buy.stripe.com/...
      button_text: Buy now
```

## Test plan

- [x] `bun run test:unit` — 2495 pass, 0 fail
- [x] `bun run build` — clean build, 36 block types generated
- [x] `bun run scripts/generate-blocks-reference.js` — regenerated docs
- [ ] Visual check of rendered `iframe-embed` in a dev server
- [ ] Visual check of `buy-options` grid layout + schema.org validation via Google Rich Results Test
