### PR TITLE
Add callout block type

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -326,6 +326,19 @@ components:
           - { name: href, type: string, label: URL, required: true }
           - { name: variant, type: string, label: Variant }
           - { name: size, type: string, label: Size }
+  block_callout:
+    label: Callout
+    type: object
+    fields:
+      - { name: dark, type: boolean, label: Dark }
+      - name: variant
+        type: string
+        label: Variant (info | warning | success | danger)
+      - name: icon
+        type: string
+        label: Icon (Iconify ID, emoji, or path)
+      - { name: title, type: string, label: Title }
+      - { name: content, type: rich-text, label: Content, required: true }
   block_video_background:
     label: Video Background
     type: object
@@ -657,6 +670,7 @@ content:
           - { name: split-callout, component: block_split_callout }
           - { name: split-full, component: block_split_full }
           - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
           - { name: video-background, component: block_video_background }
           - name: bunny-video-background
             component: block_bunny_video_background

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -358,6 +358,23 @@ Call-to-action banner with gradient background.
 
 ---
 
+### `callout`
+
+One-column callout/note with icon, title, and short content — for content warnings, advisories, tips, etc.
+
+**Template:** `src/_includes/design-system/callout.html`
+**SCSS:** `src/css/design-system/_callout.scss`
+**HTML root:** `<aside class="callout">`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `variant` | string | `"info"` | Color scheme: `"info"`, `"warning"`, `"success"`, or `"danger"`. |
+| `icon` | string | — | Icon content: Iconify ID (`prefix:name`), emoji, or image path. |
+| `title` | string | — | Bold heading text. |
+| `content` | string | **required** | Markdown content rendered via `renderContent: "md"` inside `.prose`. |
+
+---
+
 ### `video-background`
 
 Auto-playing video background with overlaid text content.

--- a/src/_includes/design-system/callout.html
+++ b/src/_includes/design-system/callout.html
@@ -1,0 +1,33 @@
+{%- comment -%}
+One-column callout/note for content warnings, advisories, tips, etc.
+
+Parameters (via block object):
+  - block.variant: Color scheme ("info" | "warning" | "success" | "danger"). Default: "info".
+  - block.icon: Iconify ID, emoji, or image path
+  - block.title: Bold heading text
+  - block.content: Markdown content rendered in `.prose`
+
+Usage:
+  {% include "design-system/callout.html",
+     block: {
+       variant: "warning",
+       icon: "hugeicons:alert-02",
+       title: "Content warning",
+       content: "Witches, ghosts, rats, body parts, death."
+     }
+  %}
+{%- endcomment -%}
+
+{%- assign variant = block.variant | default: "info" -%}
+
+<aside class="callout callout--{{ variant }}">
+  {%- if block.icon -%}
+    <div class="callout__icon" aria-hidden="true">{%- include "design-system/icon.html", icon: block.icon -%}</div>
+  {%- endif -%}
+  <div class="callout__body">
+    {%- if block.title -%}
+      <strong class="callout__title">{{ block.title }}</strong>
+    {%- endif -%}
+    <div class="callout__content prose">{{ block.content | renderContent: "md" }}</div>
+  </div>
+</aside>

--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -37,6 +37,9 @@ Renders a single block by type. Used by blocks.html.
   {%- when "cta" -%}
     {%- include "design-system/cta.html", block: block -%}
 
+  {%- when "callout" -%}
+    {%- include "design-system/callout.html", block: block -%}
+
   {%- when "markdown" -%}
     <div class="prose">{{ block.content | renderContent: "md" }}</div>
 

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -13,6 +13,7 @@
 
 import * as bunnyVideoBackground from "#utils/block-schema/bunny-video-background.js";
 import * as buyOptions from "#utils/block-schema/buy-options.js";
+import * as callout from "#utils/block-schema/callout.js";
 import * as codeBlock from "#utils/block-schema/code-block.js";
 import * as contactForm from "#utils/block-schema/contact-form.js";
 import * as content from "#utils/block-schema/content.js";
@@ -76,6 +77,7 @@ const BLOCK_MODULES = [
   splitCallout,
   splitFull,
   cta,
+  callout,
   videoBackground,
   bunnyVideoBackground,
   imageBackground,

--- a/src/_lib/utils/block-schema/callout.js
+++ b/src/_lib/utils/block-schema/callout.js
@@ -1,0 +1,45 @@
+import { md, str } from "#utils/block-schema/shared.js";
+
+export const type = "callout";
+
+export const containerWidth = "narrow";
+
+export const schema = ["variant", "icon", "title", "content"];
+
+export const docs = {
+  summary:
+    "One-column callout/note with icon, title, and short content — for content warnings, advisories, tips, etc.",
+  template: "src/_includes/design-system/callout.html",
+  scss: "src/css/design-system/_callout.scss",
+  htmlRoot: '<aside class="callout">',
+  params: {
+    variant: {
+      type: "string",
+      default: '"info"',
+      description:
+        'Color scheme: `"info"`, `"warning"`, `"success"`, or `"danger"`.',
+    },
+    icon: {
+      type: "string",
+      description:
+        "Icon content: Iconify ID (`prefix:name`), emoji, or image path.",
+    },
+    title: {
+      type: "string",
+      description: "Bold heading text.",
+    },
+    content: {
+      type: "string",
+      required: true,
+      description:
+        'Markdown content rendered via `renderContent: "md"` inside `.prose`.',
+    },
+  },
+};
+
+export const cmsFields = {
+  variant: str("Variant (info | warning | success | danger)"),
+  icon: str("Icon (Iconify ID, emoji, or path)"),
+  title: str("Title"),
+  content: md("Content", { required: true }),
+};

--- a/src/css/design-system/_callout.scss
+++ b/src/css/design-system/_callout.scss
@@ -1,0 +1,67 @@
+@use "../variables" as *;
+@use "../mixins" as *;
+
+// =============================================================================
+// CALLOUT
+// =============================================================================
+// One-column callout/note for content warnings, advisories, tips, etc.
+// For a two-column variant with a styled figure, see `_split-callout.scss`.
+
+.design-system {
+  .callout {
+    @include flex-row($space-md, flex-start, flex-start);
+    padding: $space-md $space-lg;
+    border-radius: $radius-lg;
+    border-left: 4px solid currentColor;
+    background: var(--callout-bg);
+    color: var(--callout-fg);
+
+    &--info {
+      --callout-bg: var(--color-tint);
+      --callout-fg: var(--color-link);
+    }
+
+    &--warning {
+      --callout-bg: #fef3c7;
+      --callout-fg: #92400e;
+    }
+
+    &--success {
+      --callout-bg: #d1fae5;
+      --callout-fg: #065f46;
+    }
+
+    &--danger {
+      --callout-bg: #fee2e2;
+      --callout-fg: #991b1b;
+    }
+
+    &__icon {
+      flex: 0 0 auto;
+      font-size: $font-size-xl;
+      line-height: 1;
+
+      .icon {
+        width: 1em;
+        height: 1em;
+      }
+    }
+
+    &__body {
+      @include flex-col($space-xs, stretch, flex-start);
+      flex: 1 1 auto;
+      min-width: 0;
+      color: var(--color-text);
+    }
+
+    &__title {
+      @include heading-sm;
+      color: var(--callout-fg);
+    }
+
+    &__content {
+      > :first-child { margin-top: 0; }
+      > :last-child { margin-bottom: 0; }
+    }
+  }
+}

--- a/src/css/design-system/_index.scss
+++ b/src/css/design-system/_index.scss
@@ -32,6 +32,7 @@
 @forward "stats";
 @forward "specs";
 @forward "cta";
+@forward "callout";
 @forward "split";
 @forward "split-callout";
 @forward "grid";

--- a/test/unit/code-quality/html-in-js.test.js
+++ b/test/unit/code-quality/html-in-js.test.js
@@ -310,6 +310,7 @@ const htmlInJsAnalysis = withAllowlist({
     "src/_lib/utils/block-schema/shared.js",
     "src/_lib/utils/block-schema/bunny-video-background.js",
     "src/_lib/utils/block-schema/buy-options.js",
+    "src/_lib/utils/block-schema/callout.js",
     "src/_lib/utils/block-schema/code-block.js",
     "src/_lib/utils/block-schema/contact-form.js",
     "src/_lib/utils/block-schema/cta.js",


### PR DESCRIPTION
## Summary

Adds a one-column `callout` block — a small attention-getter for content warnings, advisories, tips, and similar notes. Complements the existing two-column `split-callout`.

```yaml
- type: callout
  variant: warning  # info | warning | success | danger
  icon: "hugeicons:alert-02"
  title: Content warning
  content: Witches, ghosts, rats, body parts, death.
```

- Four colour variants: `info` (default), `warning`, `success`, `danger`
- `icon`, `title` optional; `content` rendered as markdown in `.prose`
- `containerWidth: "narrow"` so it doesn't stretch like a hero
- Registered in `render-block.html`, schema aggregator, and SCSS index
- `.pages.yml` and `BLOCKS_LAYOUT.md` regenerated from the schema

## Test plan

- [x] `bun run precommit` passes (lint, typecheck, cpd, tests)
- [x] `bun run build` compiles the block and all four variants end up in `bundle.css`
- [ ] Author a page with a `callout` block in each variant and visually verify

https://claude.ai/code/session_01VCeDeDKzAQYTBZ9KB6MvG9