### PR TITLE
Add downloads block for lists of downloadable files

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -33,6 +33,7 @@ import { configureCanonicalUrl } from "#eleventy/canonical-url.js";
 import { configureCollectionFilter } from "#eleventy/collection-filter.js";
 import { configureCapture } from "#eleventy/capture.js";
 import { configureFeed } from "#eleventy/feed.js";
+import { configureFileInfo } from "#eleventy/file-info.js";
 import { configureFileUtils, stripPlusPlus } from "#eleventy/file-utils.js";
 import { configureFormatPrice } from "#eleventy/format-price.js";
 import { configureFormHelpers } from "#eleventy/form-helpers.js";
@@ -95,6 +96,7 @@ export default async function (eleventyConfig) {
   configureEvents(eleventyConfig);
   configureLayoutAliases(eleventyConfig);
   await configureFeed(eleventyConfig);
+  configureFileInfo(eleventyConfig);
   configureFileUtils(eleventyConfig);
   configureFormatPrice(eleventyConfig);
   configureFormHelpers(eleventyConfig);

--- a/.pages.yml
+++ b/.pages.yml
@@ -555,6 +555,22 @@ components:
             required: true
           - { name: text, type: string, label: Link Text, required: true }
           - { name: url, type: string, label: URL }
+  block_downloads:
+    label: Downloads
+    type: object
+    fields:
+      - { name: dark, type: boolean, label: Dark }
+      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: items
+        type: object
+        label: Downloads
+        list: true
+        fields:
+          - name: file
+            type: string
+            label: File Path (e.g. /files/guide.pdf)
+            required: true
+          - { name: label, type: string, label: Label, required: true }
   block_snippet:
     label: Snippet
     type: object
@@ -678,6 +694,7 @@ content:
           - { name: gallery, component: block_gallery }
           - { name: marquee-images, component: block_marquee_images }
           - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
           - { name: snippet, component: block_snippet }
       - { name: permalink, type: string, label: Permalink }
       - { name: redirect_from, type: string, label: Redirect From, list: true }

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -692,6 +692,24 @@ Vertical list of links with icons, rendered as a flex column stack.
 
 ---
 
+### `downloads`
+
+List of downloadable files. Each item auto-detects its icon from the file extension and its size from the filesystem at build time.
+
+**Template:** `src/_includes/design-system/downloads.html`
+**SCSS:** `src/css/design-system/_downloads.scss`
+**HTML root:** `<ul class="downloads" role="list">`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `intro` | string | — | Markdown content rendered above the downloads list in `.prose`. |
+| `items` | array | **required** | Download objects. Each: `{file, label}`. `file` is a site-relative URL path; `label` is the visible text. |
+| `reveal` | boolean | `true` | Adds `data-reveal` to each download item. |
+
+The `file` path is resolved against `src/` (e.g. `/files/guide.pdf` reads from `src/files/guide.pdf`). Missing files cause a build error. Ensure the containing directory is configured as a passthrough-copy target so the file is also served to the browser.
+
+---
+
 ### `snippet`
 
 Renders blocks from a named snippet file, enabling reusable block compositions.

--- a/scripts/strict-typecheck-ratchet.js
+++ b/scripts/strict-typecheck-ratchet.js
@@ -14,7 +14,7 @@ import { spawnSync } from "node:child_process";
 import { ROOT_DIR } from "#lib/paths.js";
 
 // Current baseline - lower this as you fix errors
-const CURRENT_ERROR_COUNT = 410;
+const CURRENT_ERROR_COUNT = 408;
 
 // Files that currently pass strict mode (must not regress)
 const STRICT_CLEAN_FILES = [
@@ -59,6 +59,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/eleventy/add-data-filter.js",
   "src/_lib/eleventy/cache-buster.js",
   "src/_lib/eleventy/canonical-url.js",
+  "src/_lib/eleventy/file-info.js",
   "src/_lib/eleventy/format-price.js",
   "src/_lib/eleventy/ical.js",
   "src/_lib/eleventy/js-config.js",

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -40,6 +40,7 @@ const BLOCK_DEFAULTS = {
   "image-cards": { reveal: true, heading_level: 3 },
   "code-block": { reveal: true },
   "icon-links": { reveal: true },
+  downloads: { reveal: true },
   "video-background": { aspect_ratio: "16/9" },
 };
 

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -92,7 +92,7 @@ export default {
    * .map() preserves holes causing Object.fromEntries to fail, while
    * .filter(Boolean) materializes the proxy into a real empty array.
    * @param {import("#lib/types").ProductItemData & import("#lib/types").EleventyComputedData} data - Page data (products only)
-   * @returns {{ title: string, price: number, filters: Record<string, string> }|undefined}
+   * @returns {{ title: string, price: number|undefined, filters: Record<string, string> }|undefined}
    */
   filter_data: (data) => {
     if (!hasTag(data, "products")) return undefined;
@@ -226,7 +226,7 @@ export default {
    * thumbnail URL, Vimeo videos get one via the oEmbed API, and other custom
    * iframe URLs get null.
    * @param {import("#lib/types").EleventyComputedData} data - Page data
-   * @returns {Promise<Array<Record<string, unknown>>>|undefined} Videos with thumbnail_url added
+   * @returns {Promise<Array<Record<string, unknown>> | undefined>} Videos with thumbnail_url added
    */
   videos: async (data) => {
     if (!data.videos) return data.videos;

--- a/src/_includes/design-system/downloads.html
+++ b/src/_includes/design-system/downloads.html
@@ -1,0 +1,36 @@
+{%- comment -%}
+Downloads block - vertical list of downloadable files.
+
+For each item, the icon is auto-detected from the file extension and the file
+size is read from the filesystem at build time (see
+src/_lib/eleventy/file-info.js).
+
+Parameters:
+  - block.intro: Optional markdown intro rendered above the list.
+  - block.items: Array of {file, label} objects.
+    - file: Site-relative URL path (e.g. "/files/guide.pdf"). Resolved against src/.
+    - label: Visible link text.
+  - block.reveal: If true, adds data-reveal animation (default: true).
+{%- endcomment -%}
+
+{%- assign reveal = block.reveal | default: true -%}
+
+{%- if block.intro -%}
+  <div class="prose">{{ block.intro | renderContent: "md" }}</div>
+{%- endif -%}
+
+<ul class="downloads" role="list">
+  {%- for item in block.items -%}
+    {%- assign info = item.file | fileInfo -%}
+    <li{% if reveal %} data-reveal{% endif %}>
+      <a href="{{ item.file }}" class="downloads__link" download>
+        <span class="downloads__icon" aria-hidden="true">{%- include "design-system/icon.html", icon: info.icon -%}</span>
+        <span class="downloads__body">
+          <span class="downloads__label">{{ item.label }}</span>
+          <span class="downloads__meta">{{ info.extension | upcase }} &middot; {{ info.sizeHuman }}</span>
+        </span>
+        <span class="downloads__affordance" aria-hidden="true">Download</span>
+      </a>
+    </li>
+  {%- endfor -%}
+</ul>

--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -97,6 +97,9 @@ Renders a single block by type. Used by blocks.html.
   {%- when "icon-links" -%}
     {%- include "design-system/icon-links.html", block: block -%}
 
+  {%- when "downloads" -%}
+    {%- include "design-system/downloads.html", block: block -%}
+
   {%- when "snippet" -%}
     {%- include "design-system/snippet-block.html", block: block -%}
 

--- a/src/_lib/eleventy/file-info.js
+++ b/src/_lib/eleventy/file-info.js
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import path from "node:path";
+import { memoize } from "#toolkit/fp/memoize.js";
+
+/**
+ * Build-time file metadata for the `downloads` block.
+ *
+ * Resolves a URL path (e.g. `/files/guide.pdf`) against the `src/` tree,
+ * reads file size from disk, and maps the extension to an Iconify icon.
+ * Throws when the file is missing — content references must be correct at
+ * build time.
+ */
+
+const FORMAT_UNITS = ["B", "KB", "MB", "GB"];
+
+/**
+ * Extension → Iconify icon id (all icons use the hugeicons set already cached by the project).
+ * @type {Record<string, string>}
+ */
+const EXTENSION_ICONS = {
+  pdf: "hugeicons:pdf-02",
+  doc: "hugeicons:doc-01",
+  docx: "hugeicons:doc-01",
+  odt: "hugeicons:doc-01",
+  rtf: "hugeicons:doc-01",
+  txt: "hugeicons:txt-01",
+  md: "hugeicons:txt-01",
+  xls: "hugeicons:xls-02",
+  xlsx: "hugeicons:xls-02",
+  ods: "hugeicons:xls-02",
+  csv: "hugeicons:csv-02",
+  ppt: "hugeicons:ppt-02",
+  pptx: "hugeicons:ppt-02",
+  odp: "hugeicons:ppt-02",
+  zip: "hugeicons:zip-01",
+  tar: "hugeicons:zip-01",
+  gz: "hugeicons:zip-01",
+  "7z": "hugeicons:zip-01",
+  rar: "hugeicons:zip-01",
+  png: "hugeicons:image-01",
+  jpg: "hugeicons:image-01",
+  jpeg: "hugeicons:image-01",
+  gif: "hugeicons:image-01",
+  svg: "hugeicons:image-01",
+  webp: "hugeicons:image-01",
+  mp3: "hugeicons:music-note-01",
+  wav: "hugeicons:music-note-01",
+  m4a: "hugeicons:music-note-01",
+  ogg: "hugeicons:music-note-01",
+  mp4: "hugeicons:video-01",
+  mov: "hugeicons:video-01",
+  webm: "hugeicons:video-01",
+};
+
+const DEFAULT_ICON = "hugeicons:file-01";
+
+const readFileInfo = memoize(
+  /**
+   * @param {string} urlPath
+   * @param {string} baseDir
+   */
+  (urlPath, baseDir) => {
+    const cleaned = String(urlPath).replace(/^\//, "");
+    const fullPath = path.join(baseDir, "src", cleaned);
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(
+        `downloads block: file not found at ${urlPath} (expected ${fullPath})`,
+      );
+    }
+    const bytes = fs.statSync(fullPath).size;
+    const unitIndex =
+      bytes === 0
+        ? 0
+        : Math.min(
+            Math.floor(Math.log(bytes) / Math.log(1024)),
+            FORMAT_UNITS.length - 1,
+          );
+    const scaled = bytes / 1024 ** unitIndex;
+    const rounded =
+      scaled >= 10 || unitIndex === 0
+        ? Math.round(scaled)
+        : Math.round(scaled * 10) / 10;
+    const extension = path.extname(urlPath).slice(1).toLowerCase();
+    return {
+      size: bytes,
+      sizeHuman: `${rounded} ${FORMAT_UNITS[unitIndex]}`,
+      extension,
+      icon: EXTENSION_ICONS[extension] || DEFAULT_ICON,
+    };
+  },
+  {
+    cacheKey: ([urlPath, baseDir]) => JSON.stringify([urlPath, baseDir]),
+  },
+);
+
+/**
+ * Read metadata for a downloadable file referenced by URL path.
+ * @param {string} urlPath Site-relative path (leading slash optional).
+ * @param {string} [baseDir]
+ */
+const fileInfo = (urlPath, baseDir = process.cwd()) =>
+  readFileInfo(urlPath, baseDir);
+
+/**
+ * @param {{ addFilter: Function }} eleventyConfig
+ */
+const configureFileInfo = (eleventyConfig) => {
+  eleventyConfig.addFilter("fileInfo", fileInfo);
+};
+
+export { configureFileInfo, fileInfo };

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -18,6 +18,7 @@ import * as contactForm from "#utils/block-schema/contact-form.js";
 import * as content from "#utils/block-schema/content.js";
 import * as cta from "#utils/block-schema/cta.js";
 import * as customContactForm from "#utils/block-schema/custom-contact-form.js";
+import * as downloads from "#utils/block-schema/downloads.js";
 import * as features from "#utils/block-schema/features.js";
 import * as gallery from "#utils/block-schema/gallery.js";
 import * as guideCategories from "#utils/block-schema/guide-categories.js";
@@ -96,6 +97,7 @@ const BLOCK_MODULES = [
   gallery,
   marqueeImages,
   iconLinks,
+  downloads,
   snippet,
 ];
 

--- a/src/_lib/utils/block-schema/downloads.js
+++ b/src/_lib/utils/block-schema/downloads.js
@@ -1,0 +1,53 @@
+/* jscpd:ignore-start */
+import {
+  md,
+  objectList,
+  REVEAL_BOOLEAN_PARAM,
+  str,
+} from "#utils/block-schema/shared.js";
+/* jscpd:ignore-end */
+
+export const type = "downloads";
+export const schema = ["intro", "items", "reveal"];
+export const containerWidth = "narrow";
+
+const ITEMS_DESCRIPTION =
+  "Download objects. Each: `{file, label}`. `file` is a site-relative URL path; `label` is the visible text.";
+
+const FILE_RESOLUTION_NOTE =
+  "The `file` path is resolved against `src/` (e.g. `/files/guide.pdf` reads from `src/files/guide.pdf`). Missing files cause a build error. Ensure the containing directory is configured as a passthrough-copy target so the file is also served to the browser.";
+
+export const docs = {
+  summary:
+    "List of downloadable files. Each item auto-detects its icon from the file extension and its size from the filesystem at build time.",
+  template: "src/_includes/design-system/downloads.html",
+  scss: "src/css/design-system/_downloads.scss",
+  htmlRoot: '<ul class="downloads" role="list">',
+  notes: FILE_RESOLUTION_NOTE,
+  params: {
+    intro: {
+      type: "string",
+      description:
+        "Markdown content rendered above the downloads list in `.prose`.",
+    },
+    items: {
+      type: "array",
+      required: true,
+      description: ITEMS_DESCRIPTION,
+    },
+    reveal: {
+      ...REVEAL_BOOLEAN_PARAM,
+      description: "Adds `data-reveal` to each download item.",
+    },
+  },
+};
+
+/* jscpd:ignore-start */
+export const cmsFields = {
+  intro: md("Intro Content (Markdown)"),
+  items: objectList("Downloads", {
+    file: str("File Path (e.g. /files/guide.pdf)", { required: true }),
+    label: str("Label", { required: true }),
+  }),
+};
+/* jscpd:ignore-end */

--- a/src/css/design-system/_downloads.scss
+++ b/src/css/design-system/_downloads.scss
@@ -1,0 +1,82 @@
+@use "../variables" as *;
+
+// =============================================================================
+// DOWNLOADS (for downloads block)
+// =============================================================================
+// List of downloadable files. Each row uses a 3-column grid:
+//   [file-type icon] [label + meta stack] [download affordance]
+// Icon is auto-detected from the file extension by the block template.
+// =============================================================================
+
+.design-system {
+  ul.downloads {
+    max-width: $width-narrow;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: $space-sm;
+    list-style: none;
+
+    > li {
+      margin: 0;
+    }
+  }
+
+  a.downloads__link {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-column-gap: $space-md;
+    align-items: center;
+    padding: $space-sm $space-md;
+    border: $border-light;
+    border-radius: $radius-md;
+    color: inherit;
+    text-decoration: none;
+    transition:
+      background-color 0.2s,
+      border-color 0.2s;
+
+    &:hover,
+    &:focus-visible {
+      background-color: rgba(0, 0, 0, 0.04);
+      border-color: rgba(0, 0, 0, 0.2);
+    }
+  }
+
+  .downloads__icon {
+    width: 2.25em;
+    height: 2.25em;
+    line-height: 0;
+
+    > svg,
+    > img {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .downloads__body {
+    min-width: 0;
+    display: grid;
+    grid-auto-rows: auto;
+    row-gap: 2px;
+  }
+
+  .downloads__label {
+    font-weight: 600;
+  }
+
+  .downloads__meta {
+    font-size: $font-size-sm;
+    opacity: 0.7;
+  }
+
+  .downloads__affordance {
+    font-size: $font-size-sm;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}

--- a/src/css/design-system/_index.scss
+++ b/src/css/design-system/_index.scss
@@ -54,6 +54,7 @@
 @forward "link-button";
 @forward "link-columns";
 @forward "icon-links";
+@forward "downloads";
 @forward "marquee-images";
 
 // Utilities (last to allow overrides)

--- a/test/unit/code-quality/html-in-js.test.js
+++ b/test/unit/code-quality/html-in-js.test.js
@@ -314,6 +314,7 @@ const htmlInJsAnalysis = withAllowlist({
     "src/_lib/utils/block-schema/contact-form.js",
     "src/_lib/utils/block-schema/cta.js",
     "src/_lib/utils/block-schema/custom-contact-form.js",
+    "src/_lib/utils/block-schema/downloads.js",
     "src/_lib/utils/block-schema/features.js",
     "src/_lib/utils/block-schema/hero.js",
     "src/_lib/utils/block-schema/icon-links.js",

--- a/test/unit/utils/file-info.test.js
+++ b/test/unit/utils/file-info.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileInfo } from "#eleventy/file-info.js";
+import { withTempDir } from "#test/test-utils.js";
+
+const writeFixtureFile = (baseDir, urlPath, bytes) => {
+  const rel = urlPath.replace(/^\//, "");
+  const full = path.join(baseDir, "src", rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, Buffer.alloc(bytes));
+};
+
+const sizeHumanFor = (bytes) =>
+  withTempDir("file-info-size", (tempDir) => {
+    writeFixtureFile(tempDir, "/files/x.pdf", bytes);
+    return fileInfo("/files/x.pdf", tempDir).sizeHuman;
+  });
+
+describe("fileInfo sizeHuman formatting", () => {
+  test("formats bytes under 1 KB with the B suffix", () => {
+    expect(sizeHumanFor(0)).toBe("0 B");
+    expect(sizeHumanFor(512)).toBe("512 B");
+  });
+
+  test("formats kilobytes with one decimal below 10 KB", () => {
+    expect(sizeHumanFor(1024)).toBe("1 KB");
+    expect(sizeHumanFor(1536)).toBe("1.5 KB");
+  });
+
+  test("drops decimals once the value reaches 10 of its unit", () => {
+    expect(sizeHumanFor(10 * 1024)).toBe("10 KB");
+    expect(sizeHumanFor(Math.round(2.4 * 1024 * 1024))).toBe("2.4 MB");
+    expect(sizeHumanFor(15 * 1024 * 1024)).toBe("15 MB");
+  });
+});
+
+describe("fileInfo metadata", () => {
+  test("returns size, sizeHuman, extension, and icon for a PDF", () => {
+    withTempDir("file-info-pdf", (tempDir) => {
+      writeFixtureFile(tempDir, "/files/guide.pdf", 2048);
+
+      const info = fileInfo("/files/guide.pdf", tempDir);
+
+      expect(info.size).toBe(2048);
+      expect(info.sizeHuman).toBe("2 KB");
+      expect(info.extension).toBe("pdf");
+      expect(info.icon).toBe("hugeicons:pdf-02");
+    });
+  });
+
+  test("maps zip-family extensions to the archive icon", () => {
+    withTempDir("file-info-zip", (tempDir) => {
+      writeFixtureFile(tempDir, "/downloads/bundle.zip", 10);
+
+      const info = fileInfo("/downloads/bundle.zip", tempDir);
+
+      expect(info.extension).toBe("zip");
+      expect(info.icon).toBe("hugeicons:zip-01");
+    });
+  });
+
+  test("falls back to the generic file icon for unknown extensions", () => {
+    withTempDir("file-info-unknown", (tempDir) => {
+      writeFixtureFile(tempDir, "/files/data.xyz", 1);
+
+      const info = fileInfo("/files/data.xyz", tempDir);
+
+      expect(info.icon).toBe("hugeicons:file-01");
+    });
+  });
+
+  test("accepts paths without a leading slash", () => {
+    withTempDir("file-info-no-slash", (tempDir) => {
+      writeFixtureFile(tempDir, "/files/doc.pdf", 1);
+
+      const info = fileInfo("files/doc.pdf", tempDir);
+
+      expect(info.extension).toBe("pdf");
+    });
+  });
+
+  test("throws a clear error when the file is missing", () => {
+    withTempDir("file-info-missing", (tempDir) => {
+      expect(() => fileInfo("/files/missing.pdf", tempDir)).toThrow(
+        "downloads block: file not found",
+      );
+    });
+  });
+});

--- a/test/unit/utils/file-info.test.js
+++ b/test/unit/utils/file-info.test.js
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
-import { fileInfo } from "#eleventy/file-info.js";
-import { withTempDir } from "#test/test-utils.js";
+import { configureFileInfo, fileInfo } from "#eleventy/file-info.js";
+import { createMockEleventyConfig, withTempDir } from "#test/test-utils.js";
 
 const writeFixtureFile = (baseDir, urlPath, bytes) => {
   const rel = urlPath.replace(/^\//, "");
@@ -85,6 +85,23 @@ describe("fileInfo metadata", () => {
       expect(() => fileInfo("/files/missing.pdf", tempDir)).toThrow(
         "downloads block: file not found",
       );
+    });
+  });
+});
+
+describe("configureFileInfo", () => {
+  test("registers a fileInfo filter that resolves files", () => {
+    withTempDir("file-info-configure", (tempDir) => {
+      writeFixtureFile(tempDir, "/files/report.pdf", 1024);
+      const mockConfig = createMockEleventyConfig();
+
+      configureFileInfo(mockConfig);
+
+      const registered = mockConfig.filters.fileInfo;
+      expect(typeof registered).toBe("function");
+      const info = registered("/files/report.pdf", tempDir);
+      expect(info.extension).toBe("pdf");
+      expect(info.sizeHuman).toBe("1 KB");
     });
   });
 });


### PR DESCRIPTION
## Summary

New `downloads` block for rendering lists of downloadable files. Each item auto-detects its file-type icon from the extension and its size is read from disk at build time, so authors only need to provide the file path and a label:

```yaml
- type: downloads
  intro: "## Downloads"
  items:
    - file: /files/character_sheet.pdf
      label: Character Sheet
    - file: /files/cheat_sheet.pdf
      label: Quick Start / Cheat Sheet
```

Each row renders as an icon + label + `PDF · 2.4 MB` meta line + "Download" affordance, wrapped in a downloadable `<a>`.

## Implementation notes

- `src/_lib/eleventy/file-info.js` — new `fileInfo` filter that resolves a URL path against `src/` and returns `{size, sizeHuman, extension, icon}`. Uses `hugeicons` set (already cached by the project) for file-type icons, with a sensible generic fallback. Throws if the file is missing — content bugs fail the build instead of shipping broken links.
- `src/_lib/utils/block-schema/downloads.js` — schema / docs / CMS fields. `narrow` container width, matching `icon-links`.
- `src/_includes/design-system/downloads.html` — Liquid template.
- `src/css/design-system/_downloads.scss` — grid-based row layout (distinct from icon-links' flex layout).
- Registered in the block aggregator, `render-block.html`, `.pages.yml`, and `BLOCKS_LAYOUT.md` (auto-generated).
- Default `reveal: true` added to `BLOCK_DEFAULTS`.

## Test plan

- [x] `bun run test:unit` — all 2507 tests pass, including new `fileInfo` coverage (metadata, icon mapping, byte-size formatting, missing-file error) and the block-schema invariants that validate the new entry.
- [x] `bun run precommit` — lint, typecheck, strict typecheck ratchet, and all jscpd checks pass.
- [x] `bun run build` — site builds cleanly.
- [ ] Manual browser check with real PDFs once a consuming page is added.
