### PR TITLE
Add .pages.yml component name to BLOCKS_LAYOUT.md

### DIFF
--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -50,6 +50,7 @@ Blocks can use `data-reveal` attributes on elements. Values: `""` (fade up), `"l
 
 Standalone section header with rich text intro.
 
+**Component:** `block_section_header`
 **Template:** `src/_includes/design-system/section-header.html`
 **SCSS:** `src/css/design-system/_base.scss`
 **HTML root:** `<div class="section-header prose">`
@@ -66,6 +67,7 @@ Standalone section header with rich text intro.
 
 Grid of feature cards with optional icons, titles, and descriptions.
 
+**Component:** `block_features`
 **Template:** `src/_includes/design-system/features.html`
 **SCSS:** `src/css/design-system/_feature.scss`
 **HTML root:** `<ul class="features" role="list"> containing <li><article class="feature"> items`
@@ -86,6 +88,7 @@ Grid of feature cards with optional icons, titles, and descriptions.
 
 Grid of cards featuring images with titles and optional descriptions.
 
+**Component:** `block_image_cards`
 **Template:** `src/_includes/design-system/image-cards.html`
 **SCSS:** `src/css/design-system/_items.scss`
 **HTML root:** `<ul class="items" role="list">`
@@ -106,6 +109,7 @@ Grid of cards featuring images with titles and optional descriptions.
 
 Grid of buyable products — image, title, optional subtitle, price, and a buy button. Emits schema.org Product microdata.
 
+**Component:** `block_buy_options`
 **Template:** `src/_includes/design-system/buy-options.html`
 **SCSS:** `src/css/design-system/_items.scss`
 **HTML root:** `<ul class="items" role="list">`
@@ -128,6 +132,7 @@ Each item renders as a `<li>` with `itemscope itemtype="https://schema.org/Produ
 
 Key metrics displayed as large numbers with labels.
 
+**Component:** `block_stats`
 **Template:** `src/_includes/design-system/stats.html`
 **SCSS:** `src/css/design-system/_stats.scss`
 **HTML root:** `<dl class="stats">`
@@ -143,6 +148,7 @@ Key metrics displayed as large numbers with labels.
 
 Terminal-style code display with macOS-like toolbar header.
 
+**Component:** `block_code_block`
 **Template:** `src/_includes/design-system/code-block.html`
 **SCSS:** `src/css/design-system/_code-block.scss`
 **HTML root:** `<div class="code-block">`
@@ -160,6 +166,7 @@ Terminal-style code display with macOS-like toolbar header.
 
 Full-width hero banner with optional badge, title, lead text, and action buttons.
 
+**Component:** `block_hero`
 **Template:** `src/_includes/design-system/hero.html`
 **SCSS:** `src/css/design-system/_hero.scss`
 **HTML root:** `<header class="hero">`
@@ -179,6 +186,7 @@ Full-width hero banner with optional badge, title, lead text, and action buttons
 
 Two-column layout with text content and a responsive image.
 
+**Component:** `block_split_image`
 **Template:** `src/_includes/design-system/split.html`
 **SCSS:** `src/css/design-system/_split.scss`
 **HTML root:** `<div class="split">`
@@ -203,6 +211,7 @@ Two-column layout with text content and a responsive image.
 
 Two-column layout with text content and an embedded video.
 
+**Component:** `block_split_video`
 **Template:** `src/_includes/design-system/split.html`
 **SCSS:** `src/css/design-system/_split.scss`
 **HTML root:** `<div class="split">`
@@ -227,6 +236,7 @@ Two-column layout with text content and an embedded video.
 
 Two-column layout with text content and a code block.
 
+**Component:** `block_split_code`
 **Template:** `src/_includes/design-system/split.html`
 **SCSS:** `src/css/design-system/_split.scss`
 **HTML root:** `<div class="split">`
@@ -251,6 +261,7 @@ Two-column layout with text content and a code block.
 
 Two-column layout with text content and an icon-links list.
 
+**Component:** `block_split_icon_links`
 **Template:** `src/_includes/design-system/split.html`
 **SCSS:** `src/css/design-system/_split.scss`
 **HTML root:** `<div class="split">`
@@ -273,6 +284,7 @@ Two-column layout with text content and an icon-links list.
 
 Two-column layout with text content and custom HTML.
 
+**Component:** `block_split_html`
 **Template:** `src/_includes/design-system/split.html`
 **SCSS:** `src/css/design-system/_split.scss`
 **HTML root:** `<div class="split">`
@@ -295,6 +307,7 @@ Two-column layout with text content and custom HTML.
 
 Two-column layout with text content and a styled callout box with icon, title, and subtitle.
 
+**Component:** `block_split_callout`
 **Template:** `src/_includes/design-system/split-callout.html`
 **SCSS:** `src/css/design-system/_split-callout.scss`
 **HTML root:** `<div class="split-callout">`
@@ -320,6 +333,7 @@ Two-column layout with text content and a styled callout box with icon, title, a
 
 Full-width two-panel layout with distinct background colors per side.
 
+**Component:** `block_split_full`
 **Template:** `src/_includes/design-system/split-full.html`
 **SCSS:** `src/css/design-system/_split.scss`
 **HTML root:** `<div class="split-full">`
@@ -345,6 +359,7 @@ Variants: `"dark-left"` / `"dark-right"` (dark bg + light text), `"primary-left"
 
 Call-to-action banner with gradient background.
 
+**Component:** `block_cta`
 **Template:** `src/_includes/design-system/cta.html`
 **SCSS:** `src/css/design-system/_cta.scss`
 **HTML root:** `<aside class="cta">`
@@ -362,6 +377,7 @@ Call-to-action banner with gradient background.
 
 One-column callout/note with icon, title, and short content — for content warnings, advisories, tips, etc.
 
+**Component:** `block_callout`
 **Template:** `src/_includes/design-system/callout.html`
 **SCSS:** `src/css/design-system/_callout.scss`
 **HTML root:** `<aside class="callout">`
@@ -379,6 +395,7 @@ One-column callout/note with icon, title, and short content — for content warn
 
 Auto-playing video background with overlaid text content.
 
+**Component:** `block_video_background`
 **Template:** `src/_includes/design-system/video-background.html`
 **SCSS:** `src/css/design-system/_video-background.scss`
 **HTML root:** `<div class="video-background">`
@@ -400,6 +417,7 @@ YouTube IDs get `youtube-nocookie.com` embed URLs with `autoplay=1&mute=1&loop=1
 
 Bunny CDN video background with player.js-powered thumbnail that fades when playback starts.
 
+**Component:** `block_bunny_video_background`
 **Template:** `src/_includes/design-system/bunny-video-background.html`
 **SCSS:** `src/css/design-system/_video-background.scss`
 **HTML root:** `<div class="video-background" data-bunny-video>`
@@ -421,6 +439,7 @@ Uses player.js to detect when the video starts playing, then fades out the thumb
 
 Full-width image background with overlaid text and optional parallax.
 
+**Component:** `block_image_background`
 **Template:** `src/_includes/design-system/image-background.html`
 **SCSS:** `src/css/design-system/_image-background.scss`
 **HTML root:** `<div class="image-background">`
@@ -441,6 +460,7 @@ Image processed via `{% image %}` at widths 2560/1920/1280/960/640, cropped to 1
 
 Displays an Eleventy collection as a card grid or horizontal slider.
 
+**Component:** `block_items`
 **Template:** `src/_includes/design-system/items-block.html`
 **SCSS:** `src/css/design-system/_items.scss`
 
@@ -461,6 +481,7 @@ Displays an Eleventy collection as a card grid or horizontal slider.
 
 Renders items from an explicit list of paths. The collection is inferred dynamically from each item's path. Directory paths (ending in `/` or with no `.md` extension) expand to every item in that directory.
 
+**Component:** `block_items_array`
 **Template:** `src/_includes/design-system/items-array-block.html`
 **SCSS:** `src/css/design-system/_items.scss`
 
@@ -477,6 +498,7 @@ Renders items from an explicit list of paths. The collection is inferred dynamic
 
 Renders a collection as a plain-text unordered list of links arranged in responsive CSS columns. Optionally strips matching text via a regex so repetitive prefixes/suffixes can be removed.
 
+**Component:** `block_link_columns`
 **Template:** `src/_includes/design-system/link-columns.html`
 **SCSS:** `src/css/design-system/_link-columns.scss`
 
@@ -496,6 +518,7 @@ Renders a collection as a plain-text unordered list of links arranged in respons
 
 Two-column layout with prose content and a contact form.
 
+**Component:** `block_contact_form`
 **Template:** `src/_includes/design-system/contact-form-block.html`
 **SCSS:** `src/css/design-system/_contact-form-block.scss`
 **HTML root:** `<div class="contact-form-block">`
@@ -513,6 +536,7 @@ Two-column layout with prose content and a contact form.
 
 Contact form block with a custom, block-level field list instead of the site-wide `contactForm.fields`.
 
+**Component:** `block_custom_contact_form`
 **Template:** `src/_includes/design-system/custom-contact-form-block.html`
 **SCSS:** `src/css/design-system/_contact-form-block.scss`
 **HTML root:** `<div class="contact-form-block">`
@@ -533,6 +557,7 @@ Identical layout and styling to `contact-form`, but accepts its own `fields` arr
 
 Renders markdown content as rich text.
 
+**Component:** `block_markdown`
 **SCSS:** `src/css/design-system/_prose.scss`
 **HTML root:** `<div class="prose">`
 
@@ -548,6 +573,8 @@ Inline in `render-block.html` (no separate template file).
 
 Outputs raw HTML without processing.
 
+**Component:** `block_html`
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `content` | string | **required** | Raw HTML. Output directly with `{{ block.content }}`. |
@@ -560,6 +587,7 @@ Inline in `render-block.html` (no separate template file). No wrapping element. 
 
 Third-party iframe embed (itch.io widgets, Buttondown, Bandcamp, Stripe buttons, etc).
 
+**Component:** `block_iframe_embed`
 **Template:** `src/_includes/design-system/iframe-embed.html`
 **SCSS:** `src/css/design-system/_iframe-embed.scss`
 **HTML root:** `<div class="iframe-embed">`
@@ -587,6 +615,7 @@ Provide either `height` for a fixed-height embed or `aspect_ratio` (e.g. `16/9`)
 
 Outputs the page's `content` property (from markdown body below frontmatter).
 
+**Component:** `block_content`
 **Template:** `src/_includes/design-system/content-block.html`
 
 No parameters. Renders `{{ content }}` if non-empty. Used for pages that combine blocks with traditional markdown content.
@@ -596,6 +625,8 @@ No parameters. Renders `{{ content }}` if non-empty. Used for pages that combine
 ### `include`
 
 Includes an arbitrary template file.
+
+**Component:** `block_include`
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -609,6 +640,7 @@ Inline in `render-block.html` — uses `{% include block.file %}`. Escape hatch 
 
 Displays property listings (holiday lets) with filter controls.
 
+**Component:** `block_properties`
 **Template:** `src/_includes/design-system/properties-block.html`
 **SCSS:** `src/css/design-system/_property.scss`
 
@@ -620,6 +652,7 @@ No block-level parameters. Uses the global `collections.properties` and optional
 
 Displays guide categories collection.
 
+**Component:** `block_guide_categories`
 **Template:** `src/_includes/design-system/guide-categories-block.html`
 
 No block-level parameters. Uses the global `collections.guide-categories`.
@@ -630,6 +663,7 @@ No block-level parameters. Uses the global `collections.guide-categories`.
 
 Standalone centered button linking to an anchor or URL.
 
+**Component:** `block_link_button`
 **Template:** `src/_includes/design-system/link-button.html`
 **SCSS:** `src/css/design-system/_link-button.scss`
 **HTML root:** `<div class="link-button">`
@@ -648,6 +682,7 @@ Standalone centered button linking to an anchor or URL.
 
 Renders reviews collection with optional filtering to the current item.
 
+**Component:** `block_reviews`
 **Template:** `src/_includes/design-system/reviews-block.html`
 **SCSS:** `src/css/design-system/_reviews.scss`
 
@@ -663,6 +698,7 @@ Uses `getReviewsFor` filter to match reviews by slug and tags when `current_item
 
 Image grid with optional aspect ratio cropping and captions.
 
+**Component:** `block_gallery`
 **Template:** `src/_includes/design-system/gallery.html`
 **SCSS:** `src/css/design-system/_items.scss`
 **HTML root:** `<ul class="items" role="list">`
@@ -678,6 +714,7 @@ Image grid with optional aspect ratio cropping and captions.
 
 Continuously scrolling marquee of images (e.g. brand logos, partner badges).
 
+**Component:** `block_marquee_images`
 **Template:** `src/_includes/design-system/marquee-images.html`
 **SCSS:** `src/css/design-system/_marquee-images.scss`
 **HTML root:** `<div class="marquee-images">`
@@ -697,6 +734,7 @@ Continuously scrolling marquee of images (e.g. brand logos, partner badges).
 
 Vertical list of links with icons, rendered as a flex column stack.
 
+**Component:** `block_icon_links`
 **Template:** `src/_includes/design-system/icon-links.html`
 **SCSS:** `src/css/design-system/_icon-links.scss`
 **HTML root:** `<ul class="icon-links" role="list">`
@@ -713,6 +751,7 @@ Vertical list of links with icons, rendered as a flex column stack.
 
 List of downloadable files. Each item auto-detects its icon from the file extension and its size from the filesystem at build time.
 
+**Component:** `block_downloads`
 **Template:** `src/_includes/design-system/downloads.html`
 **SCSS:** `src/css/design-system/_downloads.scss`
 **HTML root:** `<ul class="downloads" role="list">`
@@ -730,6 +769,8 @@ The `file` path is resolved against `src/` (e.g. `/files/guide.pdf` reads from `
 ### `snippet`
 
 Renders blocks from a named snippet file, enabling reusable block compositions.
+
+**Component:** `block_snippet`
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|

--- a/scripts/generate-blocks-reference.js
+++ b/scripts/generate-blocks-reference.js
@@ -33,12 +33,14 @@ const renderParamTable = (params) => {
   return `${lines.join("\n")}\n`;
 };
 
-const renderMetaLines = (doc) => {
+const renderMetaLines = (doc, type) => {
   const lines = [];
+  const component = `block_${type.replaceAll("-", "_")}`;
+  lines.push(`**Component:** \`${component}\``);
   if (doc.template) lines.push(`**Template:** \`${doc.template}\``);
   if (doc.scss) lines.push(`**SCSS:** \`${doc.scss}\``);
   if (doc.htmlRoot) lines.push(`**HTML root:** \`${doc.htmlRoot}\``);
-  if (lines.length > 0) lines.push("");
+  lines.push("");
   return lines;
 };
 
@@ -49,7 +51,7 @@ const renderBlock = (type) => {
   }
 
   const lines = [`### \`${type}\`\n`, `${doc.summary}\n`];
-  lines.push(...renderMetaLines(doc));
+  lines.push(...renderMetaLines(doc, type));
 
   const table = renderParamTable(doc.params);
   if (table) lines.push(table);


### PR DESCRIPTION
## Summary

- The BLOCKS_LAYOUT.md generator now includes the `.pages.yml` component name (e.g. `block_hero`) as a metadata line for each block type, matching the existing pattern of listing Template, SCSS, and HTML root
- Component name is computed from the block type (`block_<type_with_underscores>`) so it stays in sync automatically

## Test plan

- [x] All 10 block-docs tests pass, including the freshness check that verifies BLOCKS_LAYOUT.md matches generated output
- [ ] Verify component names match `.pages.yml` entries

https://claude.ai/code/session_01K8fytvChr2jx2uhcBjasSg