### PR TITLE
Unify block schema/docs/CMS into single fields export

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -32,18 +32,19 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: intro, type: rich-text, label: Section Header Intro }
+      - name: intro
+        type: rich-text
+        label: Section Header Intro
+        required: true
   block_features:
     label: Features
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: grid_class, type: string, label: Grid Class }
-      - { name: heading_level, type: number, label: Heading Level }
-      - { name: header_intro, type: rich-text, label: Header Intro }
       - name: items
         type: object
         label: Features
+        required: true
         list: true
         fields:
           - name: icon
@@ -55,34 +56,36 @@ components:
             label: Description
             required: true
           - { name: style, type: string, label: Custom Style }
+      - { name: heading_level, type: number, label: Heading Level }
+      - { name: grid_class, type: string, label: Grid Class }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_image_cards:
     label: Image Cards
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: heading_level, type: number, label: Heading Level }
-      - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
-      - { name: header_intro, type: rich-text, label: Header Intro }
       - name: items
         type: object
         label: Cards
+        required: true
         list: true
         fields:
           - { name: image, type: image, label: Image, required: true }
           - { name: title, type: string, label: Title, required: true }
           - { name: description, type: string, label: Description }
           - { name: link, type: string, label: Link URL }
+      - { name: heading_level, type: number, label: Heading Level }
+      - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_buy_options:
     label: Buy Options
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: heading_level, type: number, label: Heading Level }
-      - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
-      - { name: header_intro, type: rich-text, label: Header Intro }
       - name: items
         type: object
         label: Products
+        required: true
         list: true
         fields:
           - { name: image, type: image, label: Image, required: true }
@@ -96,6 +99,9 @@ components:
             label: Currency (ISO code, e.g. GBP)
           - { name: link, type: string, label: Buy Link, required: true }
           - { name: button_text, type: string, label: Button Text }
+      - { name: heading_level, type: number, label: Heading Level }
+      - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_stats:
     label: Stats
     type: object
@@ -104,6 +110,7 @@ components:
       - name: items
         type: object
         label: Statistics
+        required: true
         list: true
         fields:
           - { name: value, type: string, label: Value, required: true }
@@ -121,7 +128,6 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: class, type: string, label: CSS Class }
       - { name: badge, type: string, label: Badge Text }
       - { name: title, type: string, label: Title, required: true }
       - { name: lead, type: string, label: Lead Text }
@@ -134,6 +140,7 @@ components:
           - { name: href, type: string, label: URL, required: true }
           - { name: variant, type: string, label: Variant }
           - { name: size, type: string, label: Size }
+      - { name: class, type: string, label: CSS Class }
   block_split_image:
     label: Split Image
     type: object
@@ -142,10 +149,10 @@ components:
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
+      - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
       - { name: reveal_content, type: string, label: Reveal Content Animation }
       - { name: reveal_figure, type: string, label: Reveal Figure Animation }
-      - { name: content, type: rich-text, label: Content }
       - name: button
         type: object
         label: Button
@@ -154,7 +161,7 @@ components:
           - { name: href, type: string, label: URL, required: true }
           - { name: variant, type: string, label: Variant }
           - { name: size, type: string, label: Size }
-      - { name: figure_src, type: image, label: Figure Image }
+      - { name: figure_src, type: image, label: Figure Image, required: true }
       - { name: figure_alt, type: string, label: Figure Alt Text }
       - { name: figure_caption, type: string, label: Figure Caption }
   block_split_video:
@@ -165,10 +172,10 @@ components:
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
+      - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
       - { name: reveal_content, type: string, label: Reveal Content Animation }
       - { name: reveal_figure, type: string, label: Reveal Figure Animation }
-      - { name: content, type: rich-text, label: Content }
       - name: button
         type: object
         label: Button
@@ -177,7 +184,10 @@ components:
           - { name: href, type: string, label: URL, required: true }
           - { name: variant, type: string, label: Variant }
           - { name: size, type: string, label: Size }
-      - { name: figure_video_id, type: string, label: Video ID or URL }
+      - name: figure_video_id
+        type: string
+        label: Video ID or URL
+        required: true
       - { name: figure_alt, type: string, label: Video Alt Text }
       - { name: figure_caption, type: string, label: Video Caption }
   block_split_code:
@@ -188,10 +198,10 @@ components:
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
+      - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
       - { name: reveal_content, type: string, label: Reveal Content Animation }
       - { name: reveal_figure, type: string, label: Reveal Figure Animation }
-      - { name: content, type: rich-text, label: Content }
       - name: button
         type: object
         label: Button
@@ -201,7 +211,7 @@ components:
           - { name: variant, type: string, label: Variant }
           - { name: size, type: string, label: Size }
       - { name: figure_filename, type: string, label: Code Filename }
-      - { name: figure_code, type: string, label: Code Content }
+      - { name: figure_code, type: string, label: Code Content, required: true }
       - { name: figure_language, type: string, label: Code Language }
   block_split_icon_links:
     label: Split Icon Links
@@ -211,10 +221,10 @@ components:
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
+      - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
       - { name: reveal_content, type: string, label: Reveal Content Animation }
       - { name: reveal_figure, type: string, label: Reveal Figure Animation }
-      - { name: content, type: rich-text, label: Content }
       - name: button
         type: object
         label: Button
@@ -226,6 +236,7 @@ components:
       - name: figure_items
         type: object
         label: Links
+        required: true
         list: true
         fields:
           - name: icon
@@ -242,10 +253,10 @@ components:
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
+      - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
       - { name: reveal_content, type: string, label: Reveal Content Animation }
       - { name: reveal_figure, type: string, label: Reveal Figure Animation }
-      - { name: content, type: rich-text, label: Content }
       - name: button
         type: object
         label: Button
@@ -254,7 +265,10 @@ components:
           - { name: href, type: string, label: URL, required: true }
           - { name: variant, type: string, label: Variant }
           - { name: size, type: string, label: Size }
-      - { name: figure_html, type: rich-text, label: Figure HTML Content }
+      - name: figure_html
+        type: rich-text
+        label: Figure HTML Content
+        required: true
   block_split_callout:
     label: Split Callout
     type: object
@@ -263,10 +277,10 @@ components:
       - { name: title, type: string, label: Title }
       - { name: title_level, type: number, label: Heading Level }
       - { name: subtitle, type: string, label: Subtitle }
+      - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
       - { name: reveal_content, type: string, label: Reveal Content Animation }
       - { name: reveal_figure, type: string, label: Reveal Figure Animation }
-      - { name: content, type: rich-text, label: Content }
       - name: button
         type: object
         label: Button
@@ -291,8 +305,6 @@ components:
       - { name: dark, type: boolean, label: Dark }
       - { name: variant, type: string, label: Variant }
       - { name: title_level, type: number, label: Heading Level }
-      - { name: reveal_left, type: string, label: Reveal Left Animation }
-      - { name: reveal_right, type: string, label: Reveal Right Animation }
       - { name: left_title, type: string, label: Left Title }
       - { name: left_content, type: rich-text, label: Left Content }
       - name: left_button
@@ -311,6 +323,8 @@ components:
           - { name: text, type: string, label: Button Text, required: true }
           - { name: href, type: string, label: URL, required: true }
           - { name: variant, type: string, label: Variant }
+      - { name: reveal_left, type: string, label: Reveal Left Animation }
+      - { name: reveal_right, type: string, label: Reveal Right Animation }
   block_cta:
     label: Cta
     type: object
@@ -349,7 +363,10 @@ components:
       - { name: video_title, type: string, label: Video Title }
       - { name: aspect_ratio, type: string, label: Aspect Ratio }
       - { name: class, type: string, label: CSS Class }
-      - { name: content, type: rich-text, label: Overlay Content }
+      - name: content
+        type: rich-text
+        label: Overlay Content
+        required: true
   block_bunny_video_background:
     label: Bunny Video Background
     type: object
@@ -366,7 +383,10 @@ components:
       - { name: video_title, type: string, label: Video Title }
       - { name: aspect_ratio, type: string, label: Aspect Ratio }
       - { name: class, type: string, label: CSS Class }
-      - { name: content, type: rich-text, label: Overlay Content }
+      - name: content
+        type: rich-text
+        label: Overlay Content
+        required: true
   block_image_background:
     label: Image Background
     type: object
@@ -374,9 +394,12 @@ components:
       - { name: dark, type: boolean, label: Dark }
       - { name: image, type: image, label: Background Image, required: true }
       - { name: image_alt, type: string, label: Image Alt Text }
-      - { name: parallax, type: boolean, label: Parallax }
+      - name: content
+        type: rich-text
+        label: Overlay Content
+        required: true
       - { name: class, type: string, label: CSS Class }
-      - { name: content, type: rich-text, label: Overlay Content }
+      - { name: parallax, type: boolean, label: Parallax }
   block_items:
     label: Items
     type: object
@@ -389,7 +412,6 @@ components:
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }
-      - { name: header_intro, type: rich-text, label: Header Intro }
       - name: filter
         type: object
         label: Filter
@@ -399,6 +421,7 @@ components:
             label: Property (e.g. url, data.title)
           - { name: includes, type: string, label: Contains }
           - { name: equals, type: string, label: Equals }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_items_array:
     label: Items Array
     type: object
@@ -440,9 +463,11 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: content, type: rich-text, label: Intro Content }
       - name: fields
         type: object
         label: Form Fields
+        required: true
         list: true
         fields:
           - { name: name, type: string, label: Field Name, required: true }
@@ -455,14 +480,13 @@ components:
           - { name: rows, type: number, label: Rows (for textarea) }
           - { name: note, type: string, label: Help Note }
           - { name: fieldClass, type: string, label: CSS Class }
-      - { name: content, type: rich-text, label: Intro Content }
       - { name: header_intro, type: rich-text, label: Header Intro }
   block_markdown:
     label: Markdown
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: content, type: rich-text, label: Markdown }
+      - { name: content, type: rich-text, label: Markdown, required: true }
   block_html:
     label: Html
     type: object
@@ -528,14 +552,15 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: aspect_ratio, type: string, label: Aspect Ratio }
       - name: items
         type: object
         label: Gallery Images
+        required: true
         list: true
         fields:
           - { name: image, type: image, label: Image, required: true }
           - { name: caption, type: string, label: Caption }
+      - { name: aspect_ratio, type: string, label: Aspect Ratio }
   block_marquee_images:
     label: Marquee Images
     type: object
@@ -544,6 +569,7 @@ components:
       - name: items
         type: object
         label: Images
+        required: true
         list: true
         fields:
           - { name: image, type: string, label: Image Path, required: true }
@@ -560,6 +586,7 @@ components:
       - name: items
         type: object
         label: Links
+        required: true
         list: true
         fields:
           - name: icon
@@ -577,6 +604,7 @@ components:
       - name: items
         type: object
         label: Downloads
+        required: true
         list: true
         fields:
           - name: file

--- a/.pages.yml
+++ b/.pages.yml
@@ -394,11 +394,11 @@ components:
       - { name: dark, type: boolean, label: Dark }
       - { name: image, type: image, label: Background Image, required: true }
       - { name: image_alt, type: string, label: Image Alt Text }
+      - { name: class, type: string, label: CSS Class }
       - name: content
         type: rich-text
         label: Overlay Content
         required: true
-      - { name: class, type: string, label: CSS Class }
       - { name: parallax, type: boolean, label: Parallax }
   block_items:
     label: Items

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -73,7 +73,7 @@ Grid of feature cards with optional icons, titles, and descriptions.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `items` | array | **required** | Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji. |
-| `reveal` | boolean | `true` | Adds `data-reveal` to each card. |
+| `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
 | `heading_level` | number | `3` | Heading level for item titles. |
 | `grid_class` | string | `"features"` | CSS class on the `<ul>`. Options: `"features"` (auto-fit grid), `"grid"` (1/2/3 col), `"grid--4"` (1/2/4 col). Can combine: `"grid--4 text-center"`. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
@@ -94,7 +94,7 @@ Grid of cards featuring images with titles and optional descriptions.
 |---|---|---|---|
 | `items` | array | **required** | Card objects. Each: `{image, title, description, link}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
-| `heading_level` | number | `3` | Heading level for titles. |
+| `heading_level` | number | `3` | Heading level for item titles. |
 | `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
 | `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
@@ -114,7 +114,7 @@ Grid of buyable products — image, title, optional subtitle, price, and a buy b
 |---|---|---|---|
 | `items` | array | **required** | Product objects. Each: `{image, title, subtitle, price, currency, link, button_text}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
-| `heading_level` | number | `3` | Heading level for titles. |
+| `heading_level` | number | `3` | Heading level for item titles. |
 | `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
 | `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
@@ -429,8 +429,8 @@ Full-width image background with overlaid text and optional parallax.
 |---|---|---|---|
 | `image` | string | **required** | Image path. |
 | `image_alt` | string | `"Background image"` | Alt text. |
-| `content` | string | **required** | Overlay content. Rendered as markdown in `<figcaption class="prose">`. |
 | `class` | string | — | Extra CSS classes. |
+| `content` | string | **required** | Overlay content. Rendered as markdown in `<figcaption class="prose">`. |
 | `parallax` | boolean | `false` | Enables CSS `animation-timeline: scroll()` parallax effect. |
 
 Image processed via `{% image %}` at widths 2560/1920/1280/960/640, cropped to 16/9. Parallax uses `animation-timeline: scroll()` for native CSS scroll-driven translation.

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -73,9 +73,9 @@ Grid of feature cards with optional icons, titles, and descriptions.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `items` | array | **required** | Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji. |
+| `reveal` | boolean | `true` | Adds `data-reveal` to each card. |
 | `heading_level` | number | `3` | Heading level for item titles. |
 | `grid_class` | string | `"features"` | CSS class on the `<ul>`. Options: `"features"` (auto-fit grid), `"grid"` (1/2/3 col), `"grid--4"` (1/2/4 col). Can combine: `"grid--4 text-center"`. |
-| `reveal` | boolean | `true` | Adds `data-reveal` to each card. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
 | `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
 | `header_class` | string | — | Extra CSS classes on the section header. |
@@ -93,9 +93,9 @@ Grid of cards featuring images with titles and optional descriptions.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `items` | array | **required** | Card objects. Each: `{image, title, description, link}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP. |
+| `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
 | `heading_level` | number | `3` | Heading level for titles. |
 | `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
-| `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
 | `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
 | `header_class` | string | — | Extra CSS classes on the section header. |
@@ -113,9 +113,9 @@ Grid of buyable products — image, title, optional subtitle, price, and a buy b
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `items` | array | **required** | Product objects. Each: `{image, title, subtitle, price, currency, link, button_text}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP. |
+| `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
 | `heading_level` | number | `3` | Heading level for titles. |
 | `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
-| `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
 | `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
 | `header_class` | string | — | Extra CSS classes on the section header. |
@@ -166,8 +166,8 @@ Full-width hero banner with optional badge, title, lead text, and action buttons
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `title` | string | **required** | Main `<h1>` heading. |
 | `badge` | string | — | Small pill label above the title. Renders as `<span class="badge">`. |
+| `title` | string | **required** | Main `<h1>` heading. |
 | `lead` | string | — | Subtitle paragraph. `body-lg` size, muted color, max-width `$width-narrow` (680px). |
 | `buttons` | array | — | Action buttons. Each: `{text, href, variant, size}`. Variants: `"primary"` (filled), `"secondary"` (outlined), `"ghost"` (transparent). Sizes: `"sm"`, `"lg"`, or omit for default. |
 | `class` | string | — | Extra CSS classes on the `<header>`. Use `"gradient"` for gradient bg. |
@@ -386,11 +386,11 @@ Auto-playing video background with overlaid text content.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `video_id` | string | **required** | YouTube video ID or full iframe URL (for Bunny, Vimeo, etc). |
+| `thumbnail_url` | string | — | URL of a thumbnail image displayed behind the iframe while the video loads. |
 | `video_title` | string | `"Background video"` | Accessible `title` on the iframe. |
 | `aspect_ratio` | string | `"16/9"` | CSS aspect-ratio on container. |
-| `content` | string | **required** | Overlay content. Rendered as markdown in `<figcaption class="prose">`. |
 | `class` | string | — | Extra CSS classes. |
-| `thumbnail_url` | string | — | URL of a thumbnail image displayed behind the iframe while the video loads. |
+| `content` | string | **required** | Overlay content. Rendered as markdown in `<figcaption class="prose">`. |
 
 YouTube IDs get `youtube-nocookie.com` embed URLs with `autoplay=1&mute=1&loop=1&controls=0`. Custom URLs (starting with `http`) are used directly.
 
@@ -410,8 +410,8 @@ Bunny CDN video background with player.js-powered thumbnail that fades when play
 | `thumbnail_url` | string | **required** | Thumbnail image URL. Displayed as a placeholder until video playback begins. |
 | `video_title` | string | `"Background video"` | Accessible `title` on the iframe. |
 | `aspect_ratio` | string | `"16/9"` | CSS aspect-ratio on container. |
-| `content` | string | **required** | Overlay content. Rendered as markdown in `<figcaption class="prose">`. |
 | `class` | string | — | Extra CSS classes. |
+| `content` | string | **required** | Overlay content. Rendered as markdown in `<figcaption class="prose">`. |
 
 Uses player.js to detect when the video starts playing, then fades out the thumbnail. The player.js library is bundled into bunny-video.js and only loaded when this block is used.
 

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -1,14 +1,16 @@
 /**
  * Block schema definitions for design system blocks.
  *
- * Each block type has a set of allowed keys. Unknown keys will cause
- * a build error to catch typos like "video_url" instead of "video_id".
+ * Each block module in `./block-schema/<type>.js` exports:
+ *   - `type`   — block type slug
+ *   - `fields` — unified field definitions (CMS + doc info per key)
+ *   - `docs`   — metadata (summary, template, scss, htmlRoot, notes)
+ *   - optionally `containerWidth` ("full" | "narrow"; defaults to "wide")
  *
- * Block definitions live in `./block-schema/<type>.js` — one file per type.
- * Each module exports `type`, `schema`, `docs`, and optionally `cmsFields`.
- * This file aggregates them into `BLOCK_SCHEMAS` (for validation),
- * `BLOCK_CMS_FIELDS` (for CMS generation), and `BLOCK_DOCS` (for documentation
- * generation by scripts/generate-blocks-reference.js).
+ * This file aggregates them into:
+ *   - `BLOCK_SCHEMAS`    — allowed keys per type (for validation)
+ *   - `BLOCK_CMS_FIELDS` — CMS field definitions (for .pages.yml generation)
+ *   - `BLOCK_DOCS`       — documentation (for BLOCKS_LAYOUT.md generation)
  */
 
 import * as bunnyVideoBackground from "#utils/block-schema/bunny-video-background.js";
@@ -115,8 +117,55 @@ const BLOCK_MODULES = [
 const indexByType = (getValue) =>
   Object.fromEntries(BLOCK_MODULES.map((m) => [m.type, getValue(m)]));
 
+// ---------------------------------------------------------------------------
+// Derivation helpers — turn unified `fields` into the three exported maps
+// ---------------------------------------------------------------------------
+
+/** CMS type → doc-friendly type. */
+const DOC_TYPE_MAP = {
+  markdown: "string",
+  image: "string",
+  reference: "string",
+};
+
+/** Derive the documentation-facing type string from a unified field. */
+const toDocType = (field) => {
+  if (field.list) return "array";
+  return DOC_TYPE_MAP[field.type] ?? field.type;
+};
+
+/** Derive documentation params from unified fields. */
+const toDocParams = (fields) =>
+  Object.fromEntries(
+    Object.entries(fields).map(([key, field]) => [
+      key,
+      {
+        type: toDocType(field),
+        ...(field.required && { required: true }),
+        ...(field.default !== undefined && { default: field.default }),
+        description: field.description,
+      },
+    ]),
+  );
+
+/** Extract a CMS-ready field (strip doc-only properties). */
+const extractCmsField = ({ description, default: _default, ...cmsProps }) =>
+  cmsProps;
+
+/** Extract CMS-exposed fields (those with a `label` property). */
+const extractCmsFields = (fields) =>
+  Object.fromEntries(
+    Object.entries(fields)
+      .filter(([, f]) => "label" in f)
+      .map(([key, field]) => [key, extractCmsField(field)]),
+  );
+
+// ---------------------------------------------------------------------------
+// Exported maps
+// ---------------------------------------------------------------------------
+
 /** Allowed keys per block type (excluding common keys and "type"). */
-const BLOCK_SCHEMAS = indexByType((m) => m.schema);
+const BLOCK_SCHEMAS = indexByType((m) => Object.keys(m.fields));
 
 /**
  * Container width per block type. Block modules opt in via an exported
@@ -141,16 +190,14 @@ const getBlockContainerWidth = (blockType) =>
 /**
  * CMS field definitions for block types exposed in Pages CMS.
  *
- * Not every block type in BLOCK_SCHEMAS is exposed in the CMS — only modules
- * that export `cmsFields` are included. CONTAINER_FIELDS (`dark`) are
- * injected here so per-block modules stay focused on block-specific fields.
- * This invariant is enforced by
- * test/unit/utils/block-schema.test.js.
+ * Derived from each module's `fields` export: only fields with a `label`
+ * property are included. CONTAINER_FIELDS (`dark`) are injected here so
+ * per-block modules stay focused on block-specific fields.
  */
 const BLOCK_CMS_FIELDS = Object.fromEntries(
-  BLOCK_MODULES.filter((m) => "cmsFields" in m).map((m) => [
+  BLOCK_MODULES.map((m) => [
     m.type,
-    { ...CONTAINER_FIELDS, ...m.cmsFields },
+    { ...CONTAINER_FIELDS, ...extractCmsFields(m.fields) },
   ]),
 );
 
@@ -158,15 +205,12 @@ const BLOCK_CMS_FIELDS = Object.fromEntries(
  * Documentation metadata for each block type.
  * Used by scripts/generate-blocks-reference.js to auto-generate BLOCKS_LAYOUT.md.
  *
- * Each block has:
- *   summary  - One-line description
- *   template - Path to the include template (omit for inline blocks)
- *   scss     - Path to the SCSS file (omit if none)
- *   htmlRoot - Root HTML element/class
- *   notes    - Optional extra notes rendered after the parameter table
- *   params   - Object of parameter docs: { key: { type, required?, default?, description } }
+ * The `params` object is derived from each module's unified `fields` export.
  */
-const BLOCK_DOCS = indexByType((m) => m.docs);
+const BLOCK_DOCS = indexByType((m) => ({
+  ...m.docs,
+  params: toDocParams(m.fields),
+}));
 
 /** @param {readonly string[]} arr */
 const quoteJoin = (arr) => arr.map((k) => `"${k}"`).join(", ");

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -117,99 +117,48 @@ const BLOCK_MODULES = [
 const indexByType = (getValue) =>
   Object.fromEntries(BLOCK_MODULES.map((m) => [m.type, getValue(m)]));
 
-// ---------------------------------------------------------------------------
-// Derivation helpers — turn unified `fields` into the three exported maps
-// ---------------------------------------------------------------------------
-
-/** CMS type → doc-friendly type. */
 const DOC_TYPE_MAP = {
   markdown: "string",
   image: "string",
   reference: "string",
 };
 
-/** Derive the documentation-facing type string from a unified field. */
-const toDocType = (field) => {
-  if (field.list) return "array";
-  return DOC_TYPE_MAP[field.type] ?? field.type;
-};
+const BLOCK_SCHEMAS = indexByType((m) => Object.keys(m.fields));
 
-/** Derive documentation params from unified fields. */
-const toDocParams = (fields) =>
-  Object.fromEntries(
-    Object.entries(fields).map(([key, field]) => [
+/** @type {Record<string, "full" | "wide" | "narrow">} */
+const BLOCK_CONTAINER_WIDTHS = indexByType((m) =>
+  "containerWidth" in m ? m.containerWidth : "wide",
+);
+
+/** @param {string} blockType */
+const getBlockContainerWidth = (blockType) =>
+  BLOCK_CONTAINER_WIDTHS[blockType] || "wide";
+
+const BLOCK_CMS_FIELDS = indexByType((m) => ({
+  ...CONTAINER_FIELDS,
+  ...Object.fromEntries(
+    Object.entries(m.fields)
+      .filter(([, f]) => "label" in f)
+      .map(([key, { description, default: _default, ...cmsProps }]) => [
+        key,
+        cmsProps,
+      ]),
+  ),
+}));
+
+const BLOCK_DOCS = indexByType((m) => ({
+  ...m.docs,
+  params: Object.fromEntries(
+    Object.entries(m.fields).map(([key, field]) => [
       key,
       {
-        type: toDocType(field),
+        type: field.list ? "array" : DOC_TYPE_MAP[field.type] || field.type,
         ...(field.required && { required: true }),
         ...(field.default !== undefined && { default: field.default }),
         description: field.description,
       },
     ]),
-  );
-
-/** Extract a CMS-ready field (strip doc-only properties). */
-const extractCmsField = ({ description, default: _default, ...cmsProps }) =>
-  cmsProps;
-
-/** Extract CMS-exposed fields (those with a `label` property). */
-const extractCmsFields = (fields) =>
-  Object.fromEntries(
-    Object.entries(fields)
-      .filter(([, f]) => "label" in f)
-      .map(([key, field]) => [key, extractCmsField(field)]),
-  );
-
-// ---------------------------------------------------------------------------
-// Exported maps
-// ---------------------------------------------------------------------------
-
-/** Allowed keys per block type (excluding common keys and "type"). */
-const BLOCK_SCHEMAS = indexByType((m) => Object.keys(m.fields));
-
-/**
- * Container width per block type. Block modules opt in via an exported
- * `containerWidth` constant ("full" or "narrow"); blocks that omit it
- * default to "wide".
- * @type {Record<string, "full" | "wide" | "narrow">}
- */
-const BLOCK_CONTAINER_WIDTHS = Object.fromEntries(
-  BLOCK_MODULES.map((m) => [
-    m.type,
-    "containerWidth" in m ? m.containerWidth : "wide",
-  ]),
-);
-
-/**
- * @param {string} blockType
- * @returns {"full" | "wide" | "narrow"} Container wrapper width
- */
-const getBlockContainerWidth = (blockType) =>
-  BLOCK_CONTAINER_WIDTHS[blockType] || "wide";
-
-/**
- * CMS field definitions for block types exposed in Pages CMS.
- *
- * Derived from each module's `fields` export: only fields with a `label`
- * property are included. CONTAINER_FIELDS (`dark`) are injected here so
- * per-block modules stay focused on block-specific fields.
- */
-const BLOCK_CMS_FIELDS = Object.fromEntries(
-  BLOCK_MODULES.map((m) => [
-    m.type,
-    { ...CONTAINER_FIELDS, ...extractCmsFields(m.fields) },
-  ]),
-);
-
-/**
- * Documentation metadata for each block type.
- * Used by scripts/generate-blocks-reference.js to auto-generate BLOCKS_LAYOUT.md.
- *
- * The `params` object is derived from each module's unified `fields` export.
- */
-const BLOCK_DOCS = indexByType((m) => ({
-  ...m.docs,
-  params: toDocParams(m.fields),
+  ),
 }));
 
 /** @param {readonly string[]} arr */

--- a/src/_lib/utils/block-schema/bunny-video-background.js
+++ b/src/_lib/utils/block-schema/bunny-video-background.js
@@ -1,25 +1,23 @@
-import {
-  CLASS_PARAM,
-  OVERLAY_CONTENT_PARAM,
-  VIDEO_BG_SHARED_PARAMS,
-  videoBgSharedFields,
-} from "#utils/block-schema/shared.js";
-
-/** @param {string} label */
-const requiredString = (label) => ({ type: "string", label, required: true });
+import { str, VIDEO_BG_SHARED_FIELDS } from "#utils/block-schema/shared.js";
 
 export const type = "bunny-video-background";
 
 export const containerWidth = "full";
 
-export const schema = [
-  "video_url",
-  "thumbnail_url",
-  "video_title",
-  "content",
-  "aspect_ratio",
-  "class",
-];
+export const fields = {
+  video_url: {
+    ...str("Bunny Stream Embed URL"),
+    required: true,
+    description: "Bunny Stream embed URL.",
+  },
+  thumbnail_url: {
+    ...str("Thumbnail URL"),
+    required: true,
+    description:
+      "Thumbnail image URL. Displayed as a placeholder until video playback begins.",
+  },
+  ...VIDEO_BG_SHARED_FIELDS,
+};
 
 export const docs = {
   summary:
@@ -29,26 +27,4 @@ export const docs = {
   htmlRoot: '<div class="video-background" data-bunny-video>',
   notes:
     "Uses player.js to detect when the video starts playing, then fades out the thumbnail. The player.js library is bundled into bunny-video.js and only loaded when this block is used.",
-  params: {
-    video_url: {
-      type: "string",
-      required: true,
-      description: "Bunny Stream embed URL.",
-    },
-    thumbnail_url: {
-      type: "string",
-      required: true,
-      description:
-        "Thumbnail image URL. Displayed as a placeholder until video playback begins.",
-    },
-    ...VIDEO_BG_SHARED_PARAMS,
-    content: OVERLAY_CONTENT_PARAM,
-    class: CLASS_PARAM,
-  },
-};
-
-export const cmsFields = {
-  video_url: requiredString("Bunny Stream Embed URL"),
-  thumbnail_url: requiredString("Thumbnail URL"),
-  ...videoBgSharedFields(),
 };

--- a/src/_lib/utils/block-schema/buy-options.js
+++ b/src/_lib/utils/block-schema/buy-options.js
@@ -1,10 +1,7 @@
 /* jscpd:ignore-start */
 import {
-  IMAGE_CARD_GRID_KEYS,
-  IMAGE_CARD_GRID_PARAMS,
-  ITEMS_ARRAY_PARAM,
   ITEMS_GRID_META,
-  imageCardCmsFields,
+  imageCardGridFields,
   img,
   objectList,
   str,
@@ -13,30 +10,9 @@ import {
 
 export const type = "buy-options";
 
-export const schema = IMAGE_CARD_GRID_KEYS;
-
-export const docs = {
-  summary:
-    "Grid of buyable products — image, title, optional subtitle, price, and a buy button. Emits schema.org Product microdata.",
-  template: "src/_includes/design-system/buy-options.html",
-  ...ITEMS_GRID_META,
-  notes:
-    'Each item renders as a `<li>` with `itemscope itemtype="https://schema.org/Product"`. The price is emitted as a nested `Offer` with `priceCurrency` (defaults to `GBP`). Use this block when the buy action is external (Stripe, itch.io, Gumroad); for sitewide shop listings, use the `items` block with a `products` collection.',
-  /* jscpd:ignore-start */
-  params: {
-    items: {
-      ...ITEMS_ARRAY_PARAM,
-      description:
-        "Product objects. Each: `{image, title, subtitle, price, currency, link, button_text}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP.",
-    },
-    ...IMAGE_CARD_GRID_PARAMS,
-  },
-  /* jscpd:ignore-end */
-};
-
 /* jscpd:ignore-start */
-export const cmsFields = imageCardCmsFields(
-  objectList("Products", {
+export const fields = imageCardGridFields({
+  ...objectList("Products", {
     image: img("Image", { required: true }),
     title: str("Title", { required: true }),
     subtitle: str("Subtitle"),
@@ -45,5 +21,17 @@ export const cmsFields = imageCardCmsFields(
     link: str("Buy Link", { required: true }),
     button_text: str("Button Text"),
   }),
-);
+  required: true,
+  description:
+    "Product objects. Each: `{image, title, subtitle, price, currency, link, button_text}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP.",
+});
 /* jscpd:ignore-end */
+
+export const docs = {
+  summary:
+    "Grid of buyable products — image, title, optional subtitle, price, and a buy button. Emits schema.org Product microdata.",
+  template: "src/_includes/design-system/buy-options.html",
+  ...ITEMS_GRID_META,
+  notes:
+    'Each item renders as a `<li>` with `itemscope itemtype="https://schema.org/Product"`. The price is emitted as a nested `Offer` with `priceCurrency` (defaults to `GBP`). Use this block when the buy action is external (Stripe, itch.io, Gumroad); for sitewide shop listings, use the `items` block with a `products` collection.',
+};

--- a/src/_lib/utils/block-schema/callout.js
+++ b/src/_lib/utils/block-schema/callout.js
@@ -4,7 +4,26 @@ export const type = "callout";
 
 export const containerWidth = "narrow";
 
-export const schema = ["variant", "icon", "title", "content"];
+export const fields = {
+  variant: {
+    ...str("Variant (info | warning | success | danger)"),
+    default: '"info"',
+    description:
+      'Color scheme: `"info"`, `"warning"`, `"success"`, or `"danger"`.',
+  },
+  icon: {
+    ...str("Icon (Iconify ID, emoji, or path)"),
+    description:
+      "Icon content: Iconify ID (`prefix:name`), emoji, or image path.",
+  },
+  title: { ...str("Title"), description: "Bold heading text." },
+  content: {
+    ...md("Content"),
+    required: true,
+    description:
+      'Markdown content rendered via `renderContent: "md"` inside `.prose`.',
+  },
+};
 
 export const docs = {
   summary:
@@ -12,34 +31,4 @@ export const docs = {
   template: "src/_includes/design-system/callout.html",
   scss: "src/css/design-system/_callout.scss",
   htmlRoot: '<aside class="callout">',
-  params: {
-    variant: {
-      type: "string",
-      default: '"info"',
-      description:
-        'Color scheme: `"info"`, `"warning"`, `"success"`, or `"danger"`.',
-    },
-    icon: {
-      type: "string",
-      description:
-        "Icon content: Iconify ID (`prefix:name`), emoji, or image path.",
-    },
-    title: {
-      type: "string",
-      description: "Bold heading text.",
-    },
-    content: {
-      type: "string",
-      required: true,
-      description:
-        'Markdown content rendered via `renderContent: "md"` inside `.prose`.',
-    },
-  },
-};
-
-export const cmsFields = {
-  variant: str("Variant (info | warning | success | danger)"),
-  icon: str("Icon (Iconify ID, emoji, or path)"),
-  title: str("Title"),
-  content: md("Content", { required: true }),
 };

--- a/src/_lib/utils/block-schema/code-block.js
+++ b/src/_lib/utils/block-schema/code-block.js
@@ -1,36 +1,33 @@
-import { REVEAL_BOOLEAN_PARAM, str } from "#utils/block-schema/shared.js";
+import { str } from "#utils/block-schema/shared.js";
 
 export const type = "code-block";
 
-export const schema = ["filename", "code", "language", "reveal"];
+export const fields = {
+  filename: {
+    ...str("Filename"),
+    required: true,
+    description: "Displayed in the toolbar header.",
+  },
+  code: {
+    ...str("Code"),
+    required: true,
+    description: "Code content. Rendered in `<pre><code>`.",
+  },
+  language: {
+    ...str("Language"),
+    description:
+      "Sets `data-language` attribute (for future syntax highlighting).",
+  },
+  reveal: {
+    type: "boolean",
+    default: "true",
+    description: "`data-reveal` value.",
+  },
+};
 
 export const docs = {
   summary: "Terminal-style code display with macOS-like toolbar header.",
   template: "src/_includes/design-system/code-block.html",
   scss: "src/css/design-system/_code-block.scss",
   htmlRoot: '<div class="code-block">',
-  params: {
-    filename: {
-      type: "string",
-      required: true,
-      description: "Displayed in the toolbar header.",
-    },
-    code: {
-      type: "string",
-      required: true,
-      description: "Code content. Rendered in `<pre><code>`.",
-    },
-    language: {
-      type: "string",
-      description:
-        "Sets `data-language` attribute (for future syntax highlighting).",
-    },
-    reveal: { ...REVEAL_BOOLEAN_PARAM, description: "`data-reveal` value." },
-  },
-};
-
-export const cmsFields = {
-  filename: str("Filename", { required: true }),
-  code: str("Code", { required: true }),
-  language: str("Language"),
 };

--- a/src/_lib/utils/block-schema/contact-form.js
+++ b/src/_lib/utils/block-schema/contact-form.js
@@ -1,28 +1,20 @@
-import {
-  HEADER_KEYS,
-  HEADER_PARAM_DOCS,
-  md,
-} from "#utils/block-schema/shared.js";
+import { docOnly, HEADER_FIELDS, md } from "#utils/block-schema/shared.js";
 
 export const type = "contact-form";
 
-export const schema = ["content", ...HEADER_KEYS];
+export const fields = {
+  content: {
+    ...md("Content"),
+    description:
+      "Left-side content. Rendered as markdown in `.prose`. Centered text.",
+  },
+  ...HEADER_FIELDS,
+  header_intro: docOnly(HEADER_FIELDS.header_intro),
+};
 
 export const docs = {
   summary: "Two-column layout with prose content and a contact form.",
   template: "src/_includes/design-system/contact-form-block.html",
   scss: "src/css/design-system/_contact-form-block.scss",
   htmlRoot: '<div class="contact-form-block">',
-  params: {
-    content: {
-      type: "string",
-      description:
-        "Left-side content. Rendered as markdown in `.prose`. Centered text.",
-    },
-    ...HEADER_PARAM_DOCS,
-  },
-};
-
-export const cmsFields = {
-  content: md("Content"),
 };

--- a/src/_lib/utils/block-schema/contact-form.js
+++ b/src/_lib/utils/block-schema/contact-form.js
@@ -1,4 +1,7 @@
-import { docOnly, HEADER_FIELDS, md } from "#utils/block-schema/shared.js";
+import {
+  HEADER_FIELDS_DOC_ONLY_INTRO,
+  md,
+} from "#utils/block-schema/shared.js";
 
 export const type = "contact-form";
 
@@ -8,8 +11,7 @@ export const fields = {
     description:
       "Left-side content. Rendered as markdown in `.prose`. Centered text.",
   },
-  ...HEADER_FIELDS,
-  header_intro: docOnly(HEADER_FIELDS.header_intro),
+  ...HEADER_FIELDS_DOC_ONLY_INTRO,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/content.js
+++ b/src/_lib/utils/block-schema/content.js
@@ -1,6 +1,6 @@
 export const type = "content";
 
-export const schema = [];
+export const fields = {};
 
 export const docs = {
   summary:
@@ -8,8 +8,4 @@ export const docs = {
   template: "src/_includes/design-system/content-block.html",
   notes:
     "No parameters. Renders `{{ content }}` if non-empty. Used for pages that combine blocks with traditional markdown content.",
-  params: {},
 };
-
-/** No block-specific fields — only the auto-injected container wrapper fields. */
-export const cmsFields = {};

--- a/src/_lib/utils/block-schema/cta.js
+++ b/src/_lib/utils/block-schema/cta.js
@@ -2,41 +2,29 @@ import {
   BUTTON_FIELDS_WITH_SIZE,
   md,
   objectField,
-  REVEAL_PARAM,
   TITLE_REQUIRED,
 } from "#utils/block-schema/shared.js";
 
 export const type = "cta";
 
-export const schema = ["title", "description", "button", "reveal"];
+export const fields = {
+  title: { ...TITLE_REQUIRED, description: "CTA heading (`<h2>`)." },
+  description: {
+    ...md("Description"),
+    description:
+      "Supporting markdown text. `body-lg`, 0.9 opacity, max-width `$width-narrow`.",
+  },
+  button: {
+    ...objectField("Button", BUTTON_FIELDS_WITH_SIZE),
+    description:
+      '`{text, href, variant, size}`. Default variant: `"secondary"`, default size: `"lg"`.',
+  },
+  reveal: { type: "string", description: "`data-reveal` value." },
+};
 
 export const docs = {
   summary: "Call-to-action banner with gradient background.",
   template: "src/_includes/design-system/cta.html",
   scss: "src/css/design-system/_cta.scss",
   htmlRoot: '<aside class="cta">',
-  params: {
-    title: {
-      type: "string",
-      required: true,
-      description: "CTA heading (`<h2>`).",
-    },
-    description: {
-      type: "string",
-      description:
-        "Supporting markdown text. `body-lg`, 0.9 opacity, max-width `$width-narrow`.",
-    },
-    button: {
-      type: "object",
-      description:
-        '`{text, href, variant, size}`. Default variant: `"secondary"`, default size: `"lg"`.',
-    },
-    reveal: REVEAL_PARAM,
-  },
-};
-
-export const cmsFields = {
-  title: TITLE_REQUIRED,
-  description: md("Description"),
-  button: objectField("Button", BUTTON_FIELDS_WITH_SIZE),
 };

--- a/src/_lib/utils/block-schema/cta.js
+++ b/src/_lib/utils/block-schema/cta.js
@@ -2,6 +2,7 @@ import {
   BUTTON_FIELDS_WITH_SIZE,
   md,
   objectField,
+  REVEAL_STRING_FIELD,
   TITLE_REQUIRED,
 } from "#utils/block-schema/shared.js";
 
@@ -19,7 +20,7 @@ export const fields = {
     description:
       '`{text, href, variant, size}`. Default variant: `"secondary"`, default size: `"lg"`.',
   },
-  reveal: { type: "string", description: "`data-reveal` value." },
+  reveal: REVEAL_STRING_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/custom-contact-form.js
+++ b/src/_lib/utils/block-schema/custom-contact-form.js
@@ -1,7 +1,6 @@
 import {
   bool,
-  HEADER_KEYS,
-  HEADER_PARAM_DOCS,
+  HEADER_FIELDS,
   md,
   num,
   objectList,
@@ -9,32 +8,6 @@ import {
 } from "#utils/block-schema/shared.js";
 
 export const type = "custom-contact-form";
-
-export const schema = ["content", "fields", ...HEADER_KEYS];
-
-export const docs = {
-  summary:
-    "Contact form block with a custom, block-level field list instead of the site-wide `contactForm.fields`.",
-  template: "src/_includes/design-system/custom-contact-form-block.html",
-  scss: "src/css/design-system/_contact-form-block.scss",
-  htmlRoot: '<div class="contact-form-block">',
-  notes:
-    'Identical layout and styling to `contact-form`, but accepts its own `fields` array. Each field object follows the same shape as entries in `src/_data/contact-form.json` — e.g. `{name, label, type, placeholder, required, rows, options, note, fieldClass, showOn, defaultFromPageTitle}`. Supported `type` values: `"text"` (default), `"email"`, `"tel"`, `"textarea"`, `"select"`, `"radio"`, `"heading"`.',
-  params: {
-    content: {
-      type: "string",
-      description:
-        "Left-side content. Rendered as markdown in `.prose`. Centered text.",
-    },
-    fields: {
-      type: "array",
-      required: true,
-      description:
-        "Array of field definitions for this form. Replaces `contactForm.fields` for this block only.",
-    },
-    ...HEADER_PARAM_DOCS,
-  },
-};
 
 const FORM_FIELD_DEFINITIONS = objectList("Form Fields", {
   name: str("Field Name", { required: true }),
@@ -47,8 +20,27 @@ const FORM_FIELD_DEFINITIONS = objectList("Form Fields", {
   fieldClass: str("CSS Class"),
 });
 
-export const cmsFields = {
-  fields: FORM_FIELD_DEFINITIONS,
-  content: md("Intro Content"),
-  header_intro: md("Header Intro"),
+export const fields = {
+  content: {
+    ...md("Intro Content"),
+    description:
+      "Left-side content. Rendered as markdown in `.prose`. Centered text.",
+  },
+  fields: {
+    ...FORM_FIELD_DEFINITIONS,
+    required: true,
+    description:
+      "Array of field definitions for this form. Replaces `contactForm.fields` for this block only.",
+  },
+  ...HEADER_FIELDS,
+};
+
+export const docs = {
+  summary:
+    "Contact form block with a custom, block-level field list instead of the site-wide `contactForm.fields`.",
+  template: "src/_includes/design-system/custom-contact-form-block.html",
+  scss: "src/css/design-system/_contact-form-block.scss",
+  htmlRoot: '<div class="contact-form-block">',
+  notes:
+    'Identical layout and styling to `contact-form`, but accepts its own `fields` array. Each field object follows the same shape as entries in `src/_data/contact-form.json` — e.g. `{name, label, type, placeholder, required, rows, options, note, fieldClass, showOn, defaultFromPageTitle}`. Supported `type` values: `"text"` (default), `"email"`, `"tel"`, `"textarea"`, `"select"`, `"radio"`, `"heading"`.',
 };

--- a/src/_lib/utils/block-schema/downloads.js
+++ b/src/_lib/utils/block-schema/downloads.js
@@ -1,14 +1,8 @@
 /* jscpd:ignore-start */
-import {
-  md,
-  objectList,
-  REVEAL_BOOLEAN_PARAM,
-  str,
-} from "#utils/block-schema/shared.js";
+import { md, objectList, str } from "#utils/block-schema/shared.js";
 /* jscpd:ignore-end */
 
 export const type = "downloads";
-export const schema = ["intro", "items", "reveal"];
 export const containerWidth = "narrow";
 
 const ITEMS_DESCRIPTION =
@@ -17,6 +11,28 @@ const ITEMS_DESCRIPTION =
 const FILE_RESOLUTION_NOTE =
   "The `file` path is resolved against `src/` (e.g. `/files/guide.pdf` reads from `src/files/guide.pdf`). Missing files cause a build error. Ensure the containing directory is configured as a passthrough-copy target so the file is also served to the browser.";
 
+export const fields = {
+  intro: {
+    ...md("Intro Content (Markdown)"),
+    description:
+      "Markdown content rendered above the downloads list in `.prose`.",
+  },
+  items: {
+    ...objectList("Downloads", {
+      file: str("File Path (e.g. /files/guide.pdf)", { required: true }),
+      label: str("Label", { required: true }),
+    }),
+    required: true,
+    description: ITEMS_DESCRIPTION,
+  },
+  reveal: {
+    type: "boolean",
+    default: "true",
+    description: "Adds `data-reveal` to each download item.",
+  },
+};
+
+/* jscpd:ignore-start */
 export const docs = {
   summary:
     "List of downloadable files. Each item auto-detects its icon from the file extension and its size from the filesystem at build time.",
@@ -24,30 +40,5 @@ export const docs = {
   scss: "src/css/design-system/_downloads.scss",
   htmlRoot: '<ul class="downloads" role="list">',
   notes: FILE_RESOLUTION_NOTE,
-  params: {
-    intro: {
-      type: "string",
-      description:
-        "Markdown content rendered above the downloads list in `.prose`.",
-    },
-    items: {
-      type: "array",
-      required: true,
-      description: ITEMS_DESCRIPTION,
-    },
-    reveal: {
-      ...REVEAL_BOOLEAN_PARAM,
-      description: "Adds `data-reveal` to each download item.",
-    },
-  },
-};
-
-/* jscpd:ignore-start */
-export const cmsFields = {
-  intro: md("Intro Content (Markdown)"),
-  items: objectList("Downloads", {
-    file: str("File Path (e.g. /files/guide.pdf)", { required: true }),
-    label: str("Label", { required: true }),
-  }),
 };
 /* jscpd:ignore-end */

--- a/src/_lib/utils/block-schema/features.js
+++ b/src/_lib/utils/block-schema/features.js
@@ -1,8 +1,9 @@
 import {
   HEADER_FIELDS,
+  HEADING_LEVEL_FIELD,
   md,
-  num,
   objectList,
+  REVEAL_BOOLEAN_FIELD,
   str,
   TITLE_REQUIRED,
 } from "#utils/block-schema/shared.js";
@@ -21,16 +22,8 @@ export const fields = {
     description:
       'Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji.',
   },
-  reveal: {
-    type: "boolean",
-    default: "true",
-    description: "Adds `data-reveal` to each card.",
-  },
-  heading_level: {
-    ...num("Heading Level"),
-    default: "3",
-    description: "Heading level for item titles.",
-  },
+  reveal: REVEAL_BOOLEAN_FIELD,
+  heading_level: HEADING_LEVEL_FIELD,
   grid_class: {
     ...str("Grid Class"),
     default: '"features"',

--- a/src/_lib/utils/block-schema/features.js
+++ b/src/_lib/utils/block-schema/features.js
@@ -1,23 +1,44 @@
 import {
-  HEADER_KEYS,
-  HEADER_PARAM_DOCS,
+  HEADER_FIELDS,
   md,
   num,
   objectList,
-  REVEAL_BOOLEAN_PARAM,
   str,
   TITLE_REQUIRED,
 } from "#utils/block-schema/shared.js";
 
 export const type = "features";
 
-export const schema = [
-  "items",
-  "reveal",
-  "heading_level",
-  "grid_class",
-  ...HEADER_KEYS,
-];
+export const fields = {
+  items: {
+    ...objectList("Features", {
+      icon: str("Icon (Iconify ID or HTML entity)"),
+      title: TITLE_REQUIRED,
+      description: md("Description", { required: true }),
+      style: str("Custom Style"),
+    }),
+    required: true,
+    description:
+      'Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji.',
+  },
+  reveal: {
+    type: "boolean",
+    default: "true",
+    description: "Adds `data-reveal` to each card.",
+  },
+  heading_level: {
+    ...num("Heading Level"),
+    default: "3",
+    description: "Heading level for item titles.",
+  },
+  grid_class: {
+    ...str("Grid Class"),
+    default: '"features"',
+    description:
+      'CSS class on the `<ul>`. Options: `"features"` (auto-fit grid), `"grid"` (1/2/3 col), `"grid--4"` (1/2/4 col). Can combine: `"grid--4 text-center"`.',
+  },
+  ...HEADER_FIELDS,
+};
 
 export const docs = {
   summary:
@@ -26,37 +47,4 @@ export const docs = {
   scss: "src/css/design-system/_feature.scss",
   htmlRoot:
     '<ul class="features" role="list"> containing <li><article class="feature"> items',
-  params: {
-    items: {
-      type: "array",
-      required: true,
-      description:
-        'Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji.',
-    },
-    heading_level: {
-      type: "number",
-      default: "3",
-      description: "Heading level for item titles.",
-    },
-    grid_class: {
-      type: "string",
-      default: '"features"',
-      description:
-        'CSS class on the `<ul>`. Options: `"features"` (auto-fit grid), `"grid"` (1/2/3 col), `"grid--4"` (1/2/4 col). Can combine: `"grid--4 text-center"`.',
-    },
-    reveal: REVEAL_BOOLEAN_PARAM,
-    ...HEADER_PARAM_DOCS,
-  },
-};
-
-export const cmsFields = {
-  grid_class: str("Grid Class"),
-  heading_level: num("Heading Level"),
-  header_intro: md("Header Intro"),
-  items: objectList("Features", {
-    icon: str("Icon (Iconify ID or HTML entity)"),
-    title: TITLE_REQUIRED,
-    description: md("Description", { required: true }),
-    style: str("Custom Style"),
-  }),
 };

--- a/src/_lib/utils/block-schema/gallery.js
+++ b/src/_lib/utils/block-schema/gallery.js
@@ -1,5 +1,4 @@
 import {
-  ITEMS_ARRAY_PARAM,
   ITEMS_GRID_META,
   img,
   objectList,
@@ -8,30 +7,25 @@ import {
 
 export const type = "gallery";
 
-export const schema = ["items", "aspect_ratio"];
+export const fields = {
+  items: {
+    ...objectList("Gallery Images", {
+      image: img("Image", { required: true }),
+      caption: str("Caption"),
+    }),
+    required: true,
+    description:
+      "Image objects. Each: `{image, caption}`. Images processed by `{% image %}` shortcode.",
+  },
+  aspect_ratio: {
+    ...str("Aspect Ratio"),
+    description:
+      'Aspect ratio for images (e.g. `"16/9"`, `"1/1"`, `"4/3"`). Default: no cropping.',
+  },
+};
 
 export const docs = {
   summary: "Image grid with optional aspect ratio cropping and captions.",
   template: "src/_includes/design-system/gallery.html",
   ...ITEMS_GRID_META,
-  params: {
-    items: {
-      ...ITEMS_ARRAY_PARAM,
-      description:
-        "Image objects. Each: `{image, caption}`. Images processed by `{% image %}` shortcode.",
-    },
-    aspect_ratio: {
-      type: "string",
-      description:
-        'Aspect ratio for images (e.g. `"16/9"`, `"1/1"`, `"4/3"`). Default: no cropping.',
-    },
-  },
-};
-
-export const cmsFields = {
-  aspect_ratio: str("Aspect Ratio"),
-  items: objectList("Gallery Images", {
-    image: img("Image", { required: true }),
-    caption: str("Caption"),
-  }),
 };

--- a/src/_lib/utils/block-schema/guide-categories.js
+++ b/src/_lib/utils/block-schema/guide-categories.js
@@ -1,14 +1,10 @@
 export const type = "guide-categories";
 
-export const schema = [];
+export const fields = {};
 
 export const docs = {
   summary: "Displays guide categories collection.",
   template: "src/_includes/design-system/guide-categories-block.html",
   notes:
     "No block-level parameters. Uses the global `collections.guide-categories`.",
-  params: {},
 };
-
-/** No block-specific fields — only the auto-injected container wrapper fields. */
-export const cmsFields = {};

--- a/src/_lib/utils/block-schema/hero.js
+++ b/src/_lib/utils/block-schema/hero.js
@@ -1,7 +1,6 @@
 import {
   BUTTON_FIELDS_WITH_SIZE,
   objectList,
-  REVEAL_PARAM,
   str,
   TITLE_REQUIRED,
 } from "#utils/block-schema/shared.js";
@@ -10,7 +9,33 @@ export const type = "hero";
 
 export const containerWidth = "full";
 
-export const schema = ["badge", "title", "lead", "buttons", "class", "reveal"];
+export const fields = {
+  badge: {
+    ...str("Badge Text"),
+    description:
+      'Small pill label above the title. Renders as `<span class="badge">`.',
+  },
+  title: {
+    ...TITLE_REQUIRED,
+    description: "Main `<h1>` heading.",
+  },
+  lead: {
+    ...str("Lead Text"),
+    description:
+      "Subtitle paragraph. `body-lg` size, muted color, max-width `$width-narrow` (680px).",
+  },
+  buttons: {
+    ...objectList("Buttons", BUTTON_FIELDS_WITH_SIZE),
+    description:
+      'Action buttons. Each: `{text, href, variant, size}`. Variants: `"primary"` (filled), `"secondary"` (outlined), `"ghost"` (transparent). Sizes: `"sm"`, `"lg"`, or omit for default.',
+  },
+  class: {
+    ...str("CSS Class"),
+    description:
+      'Extra CSS classes on the `<header>`. Use `"gradient"` for gradient bg.',
+  },
+  reveal: { type: "string", description: "`data-reveal` value." },
+};
 
 export const docs = {
   summary:
@@ -18,40 +43,4 @@ export const docs = {
   template: "src/_includes/design-system/hero.html",
   scss: "src/css/design-system/_hero.scss",
   htmlRoot: '<header class="hero">',
-  params: {
-    title: {
-      type: "string",
-      required: true,
-      description: "Main `<h1>` heading.",
-    },
-    badge: {
-      type: "string",
-      description:
-        'Small pill label above the title. Renders as `<span class="badge">`.',
-    },
-    lead: {
-      type: "string",
-      description:
-        "Subtitle paragraph. `body-lg` size, muted color, max-width `$width-narrow` (680px).",
-    },
-    buttons: {
-      type: "array",
-      description:
-        'Action buttons. Each: `{text, href, variant, size}`. Variants: `"primary"` (filled), `"secondary"` (outlined), `"ghost"` (transparent). Sizes: `"sm"`, `"lg"`, or omit for default.',
-    },
-    class: {
-      type: "string",
-      description:
-        'Extra CSS classes on the `<header>`. Use `"gradient"` for gradient bg.',
-    },
-    reveal: REVEAL_PARAM,
-  },
-};
-
-export const cmsFields = {
-  class: str("CSS Class"),
-  badge: str("Badge Text"),
-  title: TITLE_REQUIRED,
-  lead: str("Lead Text"),
-  buttons: objectList("Buttons", BUTTON_FIELDS_WITH_SIZE),
 };

--- a/src/_lib/utils/block-schema/hero.js
+++ b/src/_lib/utils/block-schema/hero.js
@@ -1,6 +1,7 @@
 import {
   BUTTON_FIELDS_WITH_SIZE,
   objectList,
+  REVEAL_STRING_FIELD,
   str,
   TITLE_REQUIRED,
 } from "#utils/block-schema/shared.js";
@@ -34,7 +35,7 @@ export const fields = {
     description:
       'Extra CSS classes on the `<header>`. Use `"gradient"` for gradient bg.',
   },
-  reveal: { type: "string", description: "`data-reveal` value." },
+  reveal: REVEAL_STRING_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/html.js
+++ b/src/_lib/utils/block-schema/html.js
@@ -2,21 +2,16 @@ import { str } from "#utils/block-schema/shared.js";
 
 export const type = "html";
 
-export const schema = ["content"];
+export const fields = {
+  content: {
+    ...str("Raw HTML"),
+    required: true,
+    description: "Raw HTML. Output directly with `{{ block.content }}`.",
+  },
+};
 
 export const docs = {
   summary: "Outputs raw HTML without processing.",
   notes:
     "Inline in `render-block.html` (no separate template file). No wrapping element. Useful for custom embeds, iframes, or one-off HTML.",
-  params: {
-    content: {
-      type: "string",
-      required: true,
-      description: "Raw HTML. Output directly with `{{ block.content }}`.",
-    },
-  },
-};
-
-export const cmsFields = {
-  content: str("Raw HTML", { required: true }),
 };

--- a/src/_lib/utils/block-schema/icon-links.js
+++ b/src/_lib/utils/block-schema/icon-links.js
@@ -1,15 +1,33 @@
-import {
-  md,
-  objectList,
-  REVEAL_BOOLEAN_PARAM,
-  str,
-} from "#utils/block-schema/shared.js";
+import { md, objectList, str } from "#utils/block-schema/shared.js";
 
 export const type = "icon-links";
 
 export const containerWidth = "narrow";
 
-export const schema = ["intro", "items", "reveal"];
+/** Reusable CMS field for an icon-links item list (also used by split-icon-links). */
+export const ICON_LINKS_ITEMS_FIELD = objectList("Links", {
+  icon: str("Icon (Iconify ID or HTML entity)", { required: true }),
+  text: str("Link Text", { required: true }),
+  url: str("URL"),
+});
+
+export const fields = {
+  intro: {
+    ...md("Intro Content (Markdown)"),
+    description: "Markdown content rendered above the links list in `.prose`.",
+  },
+  items: {
+    ...ICON_LINKS_ITEMS_FIELD,
+    required: true,
+    description:
+      'Link objects. Each: `{icon, text, url}`. `url` is optional — items without it render as plain text. Icon can be an Iconify ID (`"prefix:name"`), image path, or raw HTML/emoji.',
+  },
+  reveal: {
+    type: "boolean",
+    default: "true",
+    description: "Adds `data-reveal` to each link item.",
+  },
+};
 
 export const docs = {
   summary:
@@ -17,33 +35,4 @@ export const docs = {
   template: "src/_includes/design-system/icon-links.html",
   scss: "src/css/design-system/_icon-links.scss",
   htmlRoot: '<ul class="icon-links" role="list">',
-  params: {
-    intro: {
-      type: "string",
-      description:
-        "Markdown content rendered above the links list in `.prose`.",
-    },
-    items: {
-      type: "array",
-      required: true,
-      description:
-        'Link objects. Each: `{icon, text, url}`. `url` is optional — items without it render as plain text. Icon can be an Iconify ID (`"prefix:name"`), image path, or raw HTML/emoji.',
-    },
-    reveal: {
-      ...REVEAL_BOOLEAN_PARAM,
-      description: "Adds `data-reveal` to each link item.",
-    },
-  },
-};
-
-/** Reusable CMS field for an icon-links item list. */
-export const ICON_LINKS_ITEMS_FIELD = objectList("Links", {
-  icon: str("Icon (Iconify ID or HTML entity)", { required: true }),
-  text: str("Link Text", { required: true }),
-  url: str("URL"),
-});
-
-export const cmsFields = {
-  intro: md("Intro Content (Markdown)"),
-  items: ICON_LINKS_ITEMS_FIELD,
 };

--- a/src/_lib/utils/block-schema/iframe-embed.js
+++ b/src/_lib/utils/block-schema/iframe-embed.js
@@ -1,25 +1,51 @@
-import {
-  HEADER_KEYS,
-  HEADER_PARAM_DOCS,
-  md,
-  num,
-  str,
-} from "#utils/block-schema/shared.js";
+import { HEADER_FIELDS, num, str } from "#utils/block-schema/shared.js";
 
 export const type = "iframe-embed";
 
-export const schema = [
-  "src",
-  "title",
-  "width",
-  "height",
-  "aspect_ratio",
-  "max_width",
-  "sandbox",
-  "allow",
-  "scrolling",
-  ...HEADER_KEYS,
-];
+export const fields = {
+  src: {
+    ...str("Iframe URL"),
+    required: true,
+    description: "Full URL of the iframe to embed.",
+  },
+  title: {
+    ...str("Accessible Title"),
+    required: true,
+    description: "Accessible title for the iframe.",
+  },
+  width: {
+    ...num("Width (px)"),
+    description: "Fixed pixel width. Omit to fill the container.",
+  },
+  height: {
+    ...num("Height (px)"),
+    description:
+      "Fixed pixel height. Required for non-responsive embeds unless `aspect_ratio` is set.",
+  },
+  aspect_ratio: {
+    ...str("Aspect Ratio (e.g. 16/9)"),
+    description:
+      'CSS `aspect-ratio` for responsive height, e.g. `"16/9"`. Alternative to `height`.',
+  },
+  max_width: {
+    ...str("Max Width (CSS, e.g. 560px)"),
+    description: 'CSS max-width on the wrapper, e.g. `"560px"`.',
+  },
+  sandbox: {
+    ...str("Sandbox"),
+    description:
+      'Space-separated sandbox tokens, e.g. `"allow-scripts allow-same-origin allow-forms"`.',
+  },
+  allow: {
+    ...str("Allow (permissions policy)"),
+    description: "`allow` attribute for iframe permissions policy.",
+  },
+  scrolling: {
+    ...str("Scrolling"),
+    description: 'Legacy `scrolling` attribute, e.g. `"no"`.',
+  },
+  ...HEADER_FIELDS,
+};
 
 export const docs = {
   summary:
@@ -29,61 +55,4 @@ export const docs = {
   htmlRoot: '<div class="iframe-embed">',
   notes:
     "Provide either `height` for a fixed-height embed or `aspect_ratio` (e.g. `16/9`) for a responsive one. Use `max_width` to cap the embed width within the container.",
-  params: {
-    src: {
-      type: "string",
-      required: true,
-      description: "Full URL of the iframe to embed.",
-    },
-    title: {
-      type: "string",
-      required: true,
-      description: "Accessible title for the iframe.",
-    },
-    width: {
-      type: "number",
-      description: "Fixed pixel width. Omit to fill the container.",
-    },
-    height: {
-      type: "number",
-      description:
-        "Fixed pixel height. Required for non-responsive embeds unless `aspect_ratio` is set.",
-    },
-    aspect_ratio: {
-      type: "string",
-      description:
-        'CSS `aspect-ratio` for responsive height, e.g. `"16/9"`. Alternative to `height`.',
-    },
-    max_width: {
-      type: "string",
-      description: 'CSS max-width on the wrapper, e.g. `"560px"`.',
-    },
-    sandbox: {
-      type: "string",
-      description:
-        'Space-separated sandbox tokens, e.g. `"allow-scripts allow-same-origin allow-forms"`.',
-    },
-    allow: {
-      type: "string",
-      description: "`allow` attribute for iframe permissions policy.",
-    },
-    scrolling: {
-      type: "string",
-      description: 'Legacy `scrolling` attribute, e.g. `"no"`.',
-    },
-    ...HEADER_PARAM_DOCS,
-  },
-};
-
-export const cmsFields = {
-  src: str("Iframe URL", { required: true }),
-  title: str("Accessible Title", { required: true }),
-  width: num("Width (px)"),
-  height: num("Height (px)"),
-  aspect_ratio: str("Aspect Ratio (e.g. 16/9)"),
-  max_width: str("Max Width (CSS, e.g. 560px)"),
-  sandbox: str("Sandbox"),
-  allow: str("Allow (permissions policy)"),
-  scrolling: str("Scrolling"),
-  header_intro: md("Header Intro"),
 };

--- a/src/_lib/utils/block-schema/image-background.js
+++ b/src/_lib/utils/block-schema/image-background.js
@@ -1,4 +1,9 @@
-import { bool, img, md, str } from "#utils/block-schema/shared.js";
+import {
+  bool,
+  img,
+  OVERLAY_CONTENT_FIELDS,
+  str,
+} from "#utils/block-schema/shared.js";
 
 export const type = "image-background";
 
@@ -15,13 +20,7 @@ export const fields = {
     default: '"Background image"',
     description: "Alt text.",
   },
-  content: {
-    ...md("Overlay Content"),
-    required: true,
-    description:
-      'Overlay content. Rendered as markdown in `<figcaption class="prose">`.',
-  },
-  class: { ...str("CSS Class"), description: "Extra CSS classes." },
+  ...OVERLAY_CONTENT_FIELDS,
   parallax: {
     ...bool("Parallax"),
     default: "false",

--- a/src/_lib/utils/block-schema/image-background.js
+++ b/src/_lib/utils/block-schema/image-background.js
@@ -1,17 +1,33 @@
-import {
-  bool,
-  CLASS_PARAM,
-  img,
-  md,
-  OVERLAY_CONTENT_PARAM,
-  str,
-} from "#utils/block-schema/shared.js";
+import { bool, img, md, str } from "#utils/block-schema/shared.js";
 
 export const type = "image-background";
 
 export const containerWidth = "full";
 
-export const schema = ["image", "image_alt", "content", "class", "parallax"];
+export const fields = {
+  image: {
+    ...img("Background Image"),
+    required: true,
+    description: "Image path.",
+  },
+  image_alt: {
+    ...str("Image Alt Text"),
+    default: '"Background image"',
+    description: "Alt text.",
+  },
+  content: {
+    ...md("Overlay Content"),
+    required: true,
+    description:
+      'Overlay content. Rendered as markdown in `<figcaption class="prose">`.',
+  },
+  class: { ...str("CSS Class"), description: "Extra CSS classes." },
+  parallax: {
+    ...bool("Parallax"),
+    default: "false",
+    description: "Enables CSS `animation-timeline: scroll()` parallax effect.",
+  },
+};
 
 export const docs = {
   summary:
@@ -21,32 +37,4 @@ export const docs = {
   htmlRoot: '<div class="image-background">',
   notes:
     "Image processed via `{% image %}` at widths 2560/1920/1280/960/640, cropped to 16/9. Parallax uses `animation-timeline: scroll()` for native CSS scroll-driven translation.",
-  params: {
-    image: {
-      type: "string",
-      required: true,
-      description: "Image path.",
-    },
-    image_alt: {
-      type: "string",
-      default: '"Background image"',
-      description: "Alt text.",
-    },
-    content: OVERLAY_CONTENT_PARAM,
-    class: CLASS_PARAM,
-    parallax: {
-      type: "boolean",
-      default: "false",
-      description:
-        "Enables CSS `animation-timeline: scroll()` parallax effect.",
-    },
-  },
-};
-
-export const cmsFields = {
-  image: img("Background Image", { required: true }),
-  image_alt: str("Image Alt Text"),
-  parallax: bool("Parallax"),
-  class: str("CSS Class"),
-  content: md("Overlay Content"),
 };

--- a/src/_lib/utils/block-schema/image-cards.js
+++ b/src/_lib/utils/block-schema/image-cards.js
@@ -1,10 +1,7 @@
 /* jscpd:ignore-start */
 import {
-  IMAGE_CARD_GRID_KEYS,
-  IMAGE_CARD_GRID_PARAMS,
-  ITEMS_ARRAY_PARAM,
   ITEMS_GRID_META,
-  imageCardCmsFields,
+  imageCardGridFields,
   img,
   objectList,
   str,
@@ -13,28 +10,21 @@ import {
 
 export const type = "image-cards";
 
-export const schema = IMAGE_CARD_GRID_KEYS;
+export const fields = imageCardGridFields({
+  ...objectList("Cards", {
+    image: img("Image", { required: true }),
+    title: str("Title", { required: true }),
+    description: str("Description"),
+    link: str("Link URL"),
+  }),
+  required: true,
+  description:
+    "Card objects. Each: `{image, title, description, link}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP.",
+});
 
 export const docs = {
   summary:
     "Grid of cards featuring images with titles and optional descriptions.",
   template: "src/_includes/design-system/image-cards.html",
   ...ITEMS_GRID_META,
-  params: {
-    items: {
-      ...ITEMS_ARRAY_PARAM,
-      description:
-        "Card objects. Each: `{image, title, description, link}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP.",
-    },
-    ...IMAGE_CARD_GRID_PARAMS,
-  },
 };
-
-export const cmsFields = imageCardCmsFields(
-  objectList("Cards", {
-    image: img("Image", { required: true }),
-    title: str("Title", { required: true }),
-    description: str("Description"),
-    link: str("Link URL"),
-  }),
-);

--- a/src/_lib/utils/block-schema/include.js
+++ b/src/_lib/utils/block-schema/include.js
@@ -2,21 +2,16 @@ import { str } from "#utils/block-schema/shared.js";
 
 export const type = "include";
 
-export const schema = ["file"];
+export const fields = {
+  file: {
+    ...str("Template File Path"),
+    required: true,
+    description: "Path to the template file to include.",
+  },
+};
 
 export const docs = {
   summary: "Includes an arbitrary template file.",
   notes:
     "Inline in `render-block.html` — uses `{% include block.file %}`. Escape hatch for custom content that doesn't fit the block system.",
-  params: {
-    file: {
-      type: "string",
-      required: true,
-      description: "Path to the template file to include.",
-    },
-  },
-};
-
-export const cmsFields = {
-  file: str("Template File Path", { required: true }),
 };

--- a/src/_lib/utils/block-schema/items-array.js
+++ b/src/_lib/utils/block-schema/items-array.js
@@ -1,34 +1,26 @@
 import {
-  ITEMS_CMS_SHARED_FIELDS,
-  ITEMS_COMMON_PARAMS,
+  ITEMS_COMMON_FIELDS,
   ITEMS_GRID_META,
   str,
 } from "#utils/block-schema/shared.js";
 
 export const type = "items-array";
 
-export const schema = ["items", "intro", "horizontal", "masonry"];
+export const fields = {
+  items: {
+    ...str("Items"),
+    list: true,
+    description:
+      "Array of path strings. Each entry may be a file path (e.g. `src/products/widget.md`) or a directory path (e.g. `locations/fulchester` or `locations/fulchester/`), in which case every item in that directory is included in place.",
+  },
+  intro: ITEMS_COMMON_FIELDS.intro,
+  horizontal: ITEMS_COMMON_FIELDS.horizontal,
+  masonry: ITEMS_COMMON_FIELDS.masonry,
+};
 
 export const docs = {
   summary:
     "Renders items from an explicit list of paths. The collection is inferred dynamically from each item's path. Directory paths (ending in `/` or with no `.md` extension) expand to every item in that directory.",
   template: "src/_includes/design-system/items-array-block.html",
   scss: ITEMS_GRID_META.scss,
-  params: {
-    items: {
-      type: "array",
-      description:
-        "Array of path strings. Each entry may be a file path (e.g. `src/products/widget.md`) or a directory path (e.g. `locations/fulchester` or `locations/fulchester/`), in which case every item in that directory is included in place.",
-    },
-    intro: ITEMS_COMMON_PARAMS.intro,
-    horizontal: ITEMS_COMMON_PARAMS.horizontal,
-    masonry: ITEMS_COMMON_PARAMS.masonry,
-  },
-};
-
-export const cmsFields = {
-  items: str("Items", { list: true }),
-  intro: ITEMS_CMS_SHARED_FIELDS.intro,
-  horizontal: ITEMS_CMS_SHARED_FIELDS.horizontal,
-  masonry: ITEMS_CMS_SHARED_FIELDS.masonry,
 };

--- a/src/_lib/utils/block-schema/items.js
+++ b/src/_lib/utils/block-schema/items.js
@@ -1,21 +1,20 @@
-import {
-  buildItemsDocs,
-  ITEMS_CMS_SHARED_FIELDS,
-  ITEMS_COMMON_KEYS,
-} from "#utils/block-schema/shared.js";
+import { ITEMS_COMMON_FIELDS, str } from "#utils/block-schema/shared.js";
 
 export const type = "items";
 
-export const schema = ["collection", ...ITEMS_COMMON_KEYS];
+export const fields = {
+  collection: {
+    ...str("Collection Name"),
+    required: true,
+    description:
+      'Name of an Eleventy collection (e.g. `"featuredProducts"`, `"events"`, `"news"`).',
+  },
+  ...ITEMS_COMMON_FIELDS,
+};
 
-export const docs = buildItemsDocs({
+export const docs = {
   summary:
     "Displays an Eleventy collection as a card grid or horizontal slider.",
   template: "src/_includes/design-system/items-block.html",
-  collectionDescription:
-    'Name of an Eleventy collection (e.g. `"featuredProducts"`, `"events"`, `"news"`).',
-});
-
-export const cmsFields = {
-  ...ITEMS_CMS_SHARED_FIELDS,
+  scss: "src/css/design-system/_items.scss",
 };

--- a/src/_lib/utils/block-schema/items.js
+++ b/src/_lib/utils/block-schema/items.js
@@ -1,14 +1,14 @@
-import { ITEMS_COMMON_FIELDS, str } from "#utils/block-schema/shared.js";
+import {
+  collectionField,
+  ITEMS_COMMON_FIELDS,
+} from "#utils/block-schema/shared.js";
 
 export const type = "items";
 
 export const fields = {
-  collection: {
-    ...str("Collection Name"),
-    required: true,
-    description:
-      'Name of an Eleventy collection (e.g. `"featuredProducts"`, `"events"`, `"news"`).',
-  },
+  collection: collectionField(
+    'Name of an Eleventy collection (e.g. `"featuredProducts"`, `"events"`, `"news"`).',
+  ),
   ...ITEMS_COMMON_FIELDS,
 };
 

--- a/src/_lib/utils/block-schema/link-button.js
+++ b/src/_lib/utils/block-schema/link-button.js
@@ -1,43 +1,36 @@
-import {
-  BUTTON_FIELDS_WITH_SIZE,
-  REVEAL_PARAM,
-  str,
-} from "#utils/block-schema/shared.js";
+import { str } from "#utils/block-schema/shared.js";
 
 export const type = "link-button";
 
-export const schema = ["text", "href", "variant", "size", "reveal"];
+export const fields = {
+  text: {
+    ...str("Button Text"),
+    required: true,
+    description: "Button label.",
+  },
+  href: {
+    ...str("URL"),
+    required: true,
+    description: 'Link URL or anchor (e.g. `"#contact"`, `"/about"`).',
+  },
+  variant: {
+    ...str("Variant"),
+    default: '"primary"',
+    description: '`"primary"`, `"secondary"`, or `"ghost"`.',
+  },
+  size: {
+    ...str("Size"),
+    description: '`"sm"`, `"lg"`, or omit for default.',
+  },
+  reveal: {
+    ...str("Reveal Animation"),
+    description: "`data-reveal` value.",
+  },
+};
 
 export const docs = {
   summary: "Standalone centered button linking to an anchor or URL.",
   template: "src/_includes/design-system/link-button.html",
   scss: "src/css/design-system/_link-button.scss",
   htmlRoot: '<div class="link-button">',
-  params: {
-    text: {
-      type: "string",
-      required: true,
-      description: "Button label.",
-    },
-    href: {
-      type: "string",
-      required: true,
-      description: 'Link URL or anchor (e.g. `"#contact"`, `"/about"`).',
-    },
-    variant: {
-      type: "string",
-      default: '"primary"',
-      description: '`"primary"`, `"secondary"`, or `"ghost"`.',
-    },
-    size: {
-      type: "string",
-      description: '`"sm"`, `"lg"`, or omit for default.',
-    },
-    reveal: REVEAL_PARAM,
-  },
-};
-
-export const cmsFields = {
-  ...BUTTON_FIELDS_WITH_SIZE,
-  reveal: str("Reveal Animation"),
 };

--- a/src/_lib/utils/block-schema/link-columns.js
+++ b/src/_lib/utils/block-schema/link-columns.js
@@ -1,48 +1,35 @@
 import {
-  COLLECTION_PARAM,
   FILTER_FIELD,
-  HEADER_KEYS,
-  HEADER_PARAM_DOCS,
-  ITEMS_CMS_SHARED_FIELDS,
-  ITEMS_COMMON_PARAMS,
-  md,
+  HEADER_FIELDS,
+  ITEMS_COMMON_FIELDS,
   str,
 } from "#utils/block-schema/shared.js";
 
 export const type = "link-columns";
 
-export const schema = [
-  "collection",
-  "intro",
-  "filter",
-  "remove_text",
-  ...HEADER_KEYS,
-];
+export const fields = {
+  collection: {
+    ...str("Collection Name"),
+    required: true,
+    description:
+      'Name of an Eleventy collection (e.g. `"locations"`, `"services"`).',
+  },
+  intro: ITEMS_COMMON_FIELDS.intro,
+  filter: {
+    ...FILTER_FIELD,
+    description: ITEMS_COMMON_FIELDS.filter.description,
+  },
+  remove_text: {
+    ...str("Remove Text (Regex)"),
+    description:
+      'Regex pattern (JavaScript syntax, global flag implied). Each match is removed from every link\'s display text and the result is trimmed. Useful for stripping repetitive prefixes like `"Service in "` so links render tidier.',
+  },
+  ...HEADER_FIELDS,
+};
 
 export const docs = {
   summary:
     "Renders a collection as a plain-text unordered list of links arranged in responsive CSS columns. Optionally strips matching text via a regex so repetitive prefixes/suffixes can be removed.",
   template: "src/_includes/design-system/link-columns.html",
   scss: "src/css/design-system/_link-columns.scss",
-  params: {
-    collection: COLLECTION_PARAM(
-      'Name of an Eleventy collection (e.g. `"locations"`, `"services"`).',
-    ),
-    intro: ITEMS_COMMON_PARAMS.intro,
-    filter: ITEMS_COMMON_PARAMS.filter,
-    remove_text: {
-      type: "string",
-      description:
-        'Regex pattern (JavaScript syntax, global flag implied). Each match is removed from every link\'s display text and the result is trimmed. Useful for stripping repetitive prefixes like `"Service in "` so links render tidier.',
-    },
-    ...HEADER_PARAM_DOCS,
-  },
-};
-
-export const cmsFields = {
-  collection: ITEMS_CMS_SHARED_FIELDS.collection,
-  intro: md("Intro Content (Markdown)"),
-  filter: FILTER_FIELD,
-  remove_text: str("Remove Text (Regex)"),
-  header_intro: md("Header Intro"),
 };

--- a/src/_lib/utils/block-schema/link-columns.js
+++ b/src/_lib/utils/block-schema/link-columns.js
@@ -1,4 +1,5 @@
 import {
+  collectionField,
   FILTER_FIELD,
   HEADER_FIELDS,
   ITEMS_COMMON_FIELDS,
@@ -8,12 +9,9 @@ import {
 export const type = "link-columns";
 
 export const fields = {
-  collection: {
-    ...str("Collection Name"),
-    required: true,
-    description:
-      'Name of an Eleventy collection (e.g. `"locations"`, `"services"`).',
-  },
+  collection: collectionField(
+    'Name of an Eleventy collection (e.g. `"locations"`, `"services"`).',
+  ),
   intro: ITEMS_COMMON_FIELDS.intro,
   filter: {
     ...FILTER_FIELD,

--- a/src/_lib/utils/block-schema/markdown.js
+++ b/src/_lib/utils/block-schema/markdown.js
@@ -2,23 +2,18 @@ import { md } from "#utils/block-schema/shared.js";
 
 export const type = "markdown";
 
-export const schema = ["content"];
+export const fields = {
+  content: {
+    ...md("Markdown"),
+    required: true,
+    description:
+      'Markdown content. Passed through `renderContent: "md"` filter.',
+  },
+};
 
 export const docs = {
   summary: "Renders markdown content as rich text.",
   htmlRoot: '<div class="prose">',
   scss: "src/css/design-system/_prose.scss",
   notes: "Inline in `render-block.html` (no separate template file).",
-  params: {
-    content: {
-      type: "string",
-      required: true,
-      description:
-        'Markdown content. Passed through `renderContent: "md"` filter.',
-    },
-  },
-};
-
-export const cmsFields = {
-  content: md("Markdown"),
 };

--- a/src/_lib/utils/block-schema/marquee-images.js
+++ b/src/_lib/utils/block-schema/marquee-images.js
@@ -1,7 +1,6 @@
 import {
-  HEADER_KEYS,
-  HEADER_PARAM_DOCS,
-  ITEMS_ARRAY_PARAM,
+  docOnly,
+  HEADER_FIELDS,
   objectList,
   str,
 } from "#utils/block-schema/shared.js";
@@ -10,7 +9,32 @@ export const type = "marquee-images";
 
 export const containerWidth = "full";
 
-export const schema = ["items", "speed", "height", ...HEADER_KEYS];
+export const fields = {
+  items: {
+    ...objectList("Images", {
+      image: str("Image Path", { required: true }),
+      alt: str("Alt Text"),
+      link_url: str("Link URL"),
+    }),
+    required: true,
+    description:
+      "Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are processed via the `{% image %}` shortcode for responsive formats and proper URL normalization.",
+  },
+  speed: {
+    ...str("Scroll Speed (e.g. 30s)"),
+    default: '"30s"',
+    description:
+      'CSS animation duration for one full scroll cycle (e.g. `"20s"`, `"45s"`). Slower = longer duration.',
+  },
+  height: {
+    ...str("Image Height (e.g. 50px)"),
+    default: '"50px"',
+    description:
+      'CSS height for the images (e.g. `"60px"`, `"80px"`). Width scales proportionally.',
+  },
+  ...HEADER_FIELDS,
+  header_intro: docOnly(HEADER_FIELDS.header_intro),
+};
 
 export const docs = {
   summary:
@@ -18,34 +42,4 @@ export const docs = {
   template: "src/_includes/design-system/marquee-images.html",
   scss: "src/css/design-system/_marquee-images.scss",
   htmlRoot: '<div class="marquee-images">',
-  params: {
-    items: {
-      ...ITEMS_ARRAY_PARAM,
-      description:
-        "Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are processed via the `{% image %}` shortcode for responsive formats and proper URL normalization.",
-    },
-    speed: {
-      type: "string",
-      default: '"30s"',
-      description:
-        'CSS animation duration for one full scroll cycle (e.g. `"20s"`, `"45s"`). Slower = longer duration.',
-    },
-    height: {
-      type: "string",
-      default: '"50px"',
-      description:
-        'CSS height for the images (e.g. `"60px"`, `"80px"`). Width scales proportionally.',
-    },
-    ...HEADER_PARAM_DOCS,
-  },
-};
-
-export const cmsFields = {
-  items: objectList("Images", {
-    image: str("Image Path", { required: true }),
-    alt: str("Alt Text"),
-    link_url: str("Link URL"),
-  }),
-  speed: str("Scroll Speed (e.g. 30s)"),
-  height: str("Image Height (e.g. 50px)"),
 };

--- a/src/_lib/utils/block-schema/marquee-images.js
+++ b/src/_lib/utils/block-schema/marquee-images.js
@@ -1,6 +1,5 @@
 import {
-  docOnly,
-  HEADER_FIELDS,
+  HEADER_FIELDS_DOC_ONLY_INTRO,
   objectList,
   str,
 } from "#utils/block-schema/shared.js";
@@ -32,8 +31,7 @@ export const fields = {
     description:
       'CSS height for the images (e.g. `"60px"`, `"80px"`). Width scales proportionally.',
   },
-  ...HEADER_FIELDS,
-  header_intro: docOnly(HEADER_FIELDS.header_intro),
+  ...HEADER_FIELDS_DOC_ONLY_INTRO,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/properties.js
+++ b/src/_lib/utils/block-schema/properties.js
@@ -1,6 +1,6 @@
 export const type = "properties";
 
-export const schema = [];
+export const fields = {};
 
 export const docs = {
   summary: "Displays property listings (holiday lets) with filter controls.",
@@ -8,8 +8,4 @@ export const docs = {
   scss: "src/css/design-system/_property.scss",
   notes:
     "No block-level parameters. Uses the global `collections.properties` and optional `filterPage` data for URL-based filtering.",
-  params: {},
 };
-
-/** No block-specific fields — only the auto-injected container wrapper fields. */
-export const cmsFields = {};

--- a/src/_lib/utils/block-schema/reviews.js
+++ b/src/_lib/utils/block-schema/reviews.js
@@ -2,7 +2,13 @@ import { bool } from "#utils/block-schema/shared.js";
 
 export const type = "reviews";
 
-export const schema = ["current_item"];
+export const fields = {
+  current_item: {
+    ...bool("Filter to Current Item"),
+    description:
+      "If true, filters reviews to the current item by slug and tags.",
+  },
+};
 
 export const docs = {
   summary:
@@ -11,15 +17,4 @@ export const docs = {
   scss: "src/css/design-system/_reviews.scss",
   notes:
     "Uses `getReviewsFor` filter to match reviews by slug and tags when `current_item` is true.",
-  params: {
-    current_item: {
-      type: "boolean",
-      description:
-        "If true, filters reviews to the current item by slug and tags.",
-    },
-  },
-};
-
-export const cmsFields = {
-  current_item: bool("Filter to Current Item"),
 };

--- a/src/_lib/utils/block-schema/section-header.js
+++ b/src/_lib/utils/block-schema/section-header.js
@@ -1,30 +1,25 @@
-import { CLASS_PARAM, md } from "#utils/block-schema/shared.js";
+import { md } from "#utils/block-schema/shared.js";
 
 export const type = "section-header";
 
-export const schema = ["intro", "align", "class"];
+export const fields = {
+  intro: {
+    ...md("Section Header Intro"),
+    required: true,
+    description:
+      "Rich text content rendered as markdown. Use headings and body text together.",
+  },
+  align: {
+    type: "string",
+    default: '"center"',
+    description: 'Text alignment. `"center"` adds `.text-center`.',
+  },
+  class: { type: "string", description: "Extra CSS classes." },
+};
 
 export const docs = {
   summary: "Standalone section header with rich text intro.",
   template: "src/_includes/design-system/section-header.html",
   scss: "src/css/design-system/_base.scss",
   htmlRoot: '<div class="section-header prose">',
-  params: {
-    intro: {
-      type: "string",
-      required: true,
-      description:
-        "Rich text content rendered as markdown. Use headings and body text together.",
-    },
-    align: {
-      type: "string",
-      default: '"center"',
-      description: 'Text alignment. `"center"` adds `.text-center`.',
-    },
-    class: CLASS_PARAM,
-  },
-};
-
-export const cmsFields = {
-  intro: md("Section Header Intro"),
 };

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -1,203 +1,9 @@
 /**
- * Shared constants and parameter documentation used by multiple block modules.
- */
-
-/** Keys for optional section-header rendering within a block. */
-export const HEADER_KEYS = ["header_intro", "header_align", "header_class"];
-
-/** @type {Record<string, {type: string, default?: string, description: string}>} */
-export const HEADER_PARAM_DOCS = {
-  header_intro: {
-    type: "string",
-    description: "Section header content rendered as markdown above the block.",
-  },
-  header_align: {
-    type: "string",
-    description: 'Header text alignment. `"center"` adds `.text-center`.',
-  },
-  header_class: {
-    type: "string",
-    description: "Extra CSS classes on the section header.",
-  },
-};
-
-/** Reveal param doc for blocks that accept a string reveal value. */
-export const REVEAL_PARAM = {
-  type: "string",
-  description: "`data-reveal` value.",
-};
-
-/** Reveal param doc for blocks where reveal is boolean (default true). */
-export const REVEAL_BOOLEAN_PARAM = {
-  type: "boolean",
-  default: "true",
-  description: "Adds `data-reveal` to each card.",
-};
-
-/** Extra CSS classes param doc. */
-export const CLASS_PARAM = {
-  type: "string",
-  description: "Extra CSS classes.",
-};
-
-/** Shared schema keys for items and items-array blocks. */
-export const ITEMS_COMMON_KEYS = [
-  "intro",
-  "horizontal",
-  "masonry",
-  "filter",
-  ...HEADER_KEYS,
-];
-
-/** Shared param docs for items and items-array blocks (includes header params). */
-export const ITEMS_COMMON_PARAMS = {
-  intro: {
-    type: "string",
-    description: "Markdown content rendered above items in `.prose`.",
-  },
-  horizontal: {
-    type: "boolean",
-    default: "false",
-    description:
-      "If true, renders as a horizontal slider instead of a wrapping grid.",
-  },
-  masonry: {
-    type: "boolean",
-    default: "false",
-    description:
-      "If true, renders as a masonry grid using uWrap for zero-reflow height prediction.",
-  },
-  filter: {
-    type: "object",
-    description:
-      'Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value.',
-  },
-  ...HEADER_PARAM_DOCS,
-};
-
-/** Shared param docs for video background blocks (video-background and bunny-video-background). */
-export const VIDEO_BG_SHARED_PARAMS = {
-  video_title: {
-    type: "string",
-    default: '"Background video"',
-    description: "Accessible `title` on the iframe.",
-  },
-  aspect_ratio: {
-    type: "string",
-    default: '"16/9"',
-    description: "CSS aspect-ratio on container.",
-  },
-};
-
-/**
- * Shared CMS fields for video-background and bunny-video-background.
- * Gets spread into each block's cmsFields alongside its block-specific fields,
- * and also keeps the two modules from having identical field lists (which
- * would be flagged as duplication).
- */
-export const videoBgSharedFields = () => ({
-  video_title: str("Video Title"),
-  aspect_ratio: str("Aspect Ratio"),
-  class: str("CSS Class"),
-  content: md("Overlay Content"),
-});
-
-/** Overlay content param doc for video-background and image-background. */
-export const OVERLAY_CONTENT_PARAM = {
-  type: "string",
-  required: true,
-  description:
-    'Overlay content. Rendered as markdown in `<figcaption class="prose">`.',
-};
-
-/** Shared SCSS and htmlRoot for card-grid blocks (image-cards, gallery). */
-export const ITEMS_GRID_META = {
-  scss: "src/css/design-system/_items.scss",
-  htmlRoot: '<ul class="items" role="list">',
-};
-
-/** Shared collection param for items and items-array blocks. */
-export const COLLECTION_PARAM = (description) => ({
-  type: "string",
-  required: true,
-  description,
-});
-
-/**
- * Factory for items/items-array block docs.
- * Both blocks share an identical docs shape modulo the summary, template,
- * collection description, and any extra params (like the `items` array).
- */
-export const buildItemsDocs = ({
-  summary,
-  template,
-  collectionDescription,
-  extraParams = {},
-}) => ({
-  summary,
-  template,
-  scss: ITEMS_GRID_META.scss,
-  params: {
-    collection: COLLECTION_PARAM(collectionDescription),
-    ...extraParams,
-    ...ITEMS_COMMON_PARAMS,
-  },
-});
-
-/** Required items array param (image-cards, gallery). */
-export const ITEMS_ARRAY_PARAM = {
-  type: "array",
-  required: true,
-};
-
-/**
- * Shared schema keys for image-card-style grid blocks (image-cards, buy-options).
- * These blocks render an items array as a responsive card grid with optional
- * per-item image aspect ratio and section header.
- */
-export const IMAGE_CARD_GRID_KEYS = [
-  "items",
-  "reveal",
-  "heading_level",
-  "image_aspect_ratio",
-  ...HEADER_KEYS,
-];
-
-/** Shared docs params for image-card-style grid blocks. */
-export const IMAGE_CARD_GRID_PARAMS = {
-  heading_level: {
-    type: "number",
-    default: "3",
-    description: "Heading level for titles.",
-  },
-  image_aspect_ratio: {
-    type: "string",
-    description: 'Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`.',
-  },
-  reveal: {
-    ...REVEAL_BOOLEAN_PARAM,
-    description: "Adds `data-reveal` to each item.",
-  },
-  ...HEADER_PARAM_DOCS,
-};
-
-/**
- * Build the full cmsFields object for image-card-style grid blocks.
- * Provide an objectList item field (e.g. `objectList("Cards", {...})`) and
- * this helper injects the common heading/aspect/header-intro fields around
- * it so each block module doesn't restate them.
- * @param {object} itemsField - objectList field for the items array
- */
-export const imageCardCmsFields = (itemsField) => ({
-  heading_level: num("Heading Level"),
-  image_aspect_ratio: str("Image Aspect Ratio"),
-  header_intro: md("Header Intro"),
-  items: itemsField,
-});
-
-/**
- * CMS field factory functions.
- * These create the field-shape objects consumed by scripts/customise-cms/generator.js.
+ * Shared constants and field factories for block modules.
+ *
+ * Each unified field object combines CMS metadata (type, label, required,
+ * fields, list) with documentation metadata (description, default).
+ * Fields WITH a `label` are CMS-exposed; fields WITHOUT are doc-only.
  */
 
 /** @param {string} label @param {object} [extras] */
@@ -224,10 +30,11 @@ export const objectField = (label, fields) => ({
   fields,
 });
 
+/** Strip the CMS `label` so a field becomes doc-only (schema + docs, not CMS). */
+export const docOnly = ({ label, ...rest }) => rest;
+
 /** Container wrapper fields common to every CMS block. */
-export const CONTAINER_FIELDS = {
-  dark: bool("Dark"),
-};
+export const CONTAINER_FIELDS = { dark: bool("Dark") };
 
 /** Button fields shared between hero, split, and cta blocks. */
 export const BUTTON_FIELDS_BASE = {
@@ -252,12 +59,97 @@ export const FILTER_FIELD = objectField("Filter", {
   equals: str("Equals"),
 });
 
-/** CMS fields shared between items and items-array blocks. */
-export const ITEMS_CMS_SHARED_FIELDS = {
-  collection: str("Collection Name", { required: true }),
-  intro: md("Intro Content (Markdown)"),
-  horizontal: bool("Horizontal Slider"),
-  masonry: bool("Masonry Grid"),
-  header_intro: md("Header Intro"),
-  filter: FILTER_FIELD,
+/** Shared SCSS and htmlRoot for card-grid blocks (image-cards, gallery). */
+export const ITEMS_GRID_META = {
+  scss: "src/css/design-system/_items.scss",
+  htmlRoot: '<ul class="items" role="list">',
+};
+
+/** Unified header fields. `header_intro` is CMS-exposed; align/class are doc-only. */
+export const HEADER_FIELDS = {
+  header_intro: {
+    ...md("Header Intro"),
+    description: "Section header content rendered as markdown above the block.",
+  },
+  header_align: {
+    type: "string",
+    description: 'Header text alignment. `"center"` adds `.text-center`.',
+  },
+  header_class: {
+    type: "string",
+    description: "Extra CSS classes on the section header.",
+  },
+};
+
+/** Unified fields shared between items and items-array blocks. */
+export const ITEMS_COMMON_FIELDS = {
+  intro: {
+    ...md("Intro Content (Markdown)"),
+    description: "Markdown content rendered above items in `.prose`.",
+  },
+  horizontal: {
+    ...bool("Horizontal Slider"),
+    default: "false",
+    description:
+      "If true, renders as a horizontal slider instead of a wrapping grid.",
+  },
+  masonry: {
+    ...bool("Masonry Grid"),
+    default: "false",
+    description:
+      "If true, renders as a masonry grid using uWrap for zero-reflow height prediction.",
+  },
+  filter: {
+    ...FILTER_FIELD,
+    description:
+      'Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value.',
+  },
+  ...HEADER_FIELDS,
+};
+
+/**
+ * Build unified fields for image-card-style grid blocks (image-cards, buy-options).
+ * @param {object} itemsField - Unified field for the items array (with CMS + doc info)
+ */
+export const imageCardGridFields = (itemsField) => ({
+  items: itemsField,
+  reveal: {
+    type: "boolean",
+    default: "true",
+    description: "Adds `data-reveal` to each item.",
+  },
+  heading_level: {
+    ...num("Heading Level"),
+    default: "3",
+    description: "Heading level for titles.",
+  },
+  image_aspect_ratio: {
+    ...str("Image Aspect Ratio"),
+    description: 'Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`.',
+  },
+  ...HEADER_FIELDS,
+});
+
+/** Unified fields shared between video-background and bunny-video-background. */
+export const VIDEO_BG_SHARED_FIELDS = {
+  video_title: {
+    ...str("Video Title"),
+    default: '"Background video"',
+    description: "Accessible `title` on the iframe.",
+  },
+  aspect_ratio: {
+    ...str("Aspect Ratio"),
+    default: '"16/9"',
+    description: "CSS aspect-ratio on container.",
+  },
+  class: {
+    ...str("CSS Class"),
+    description: "Extra CSS classes.",
+  },
+  content: {
+    ...md("Overlay Content"),
+    required: true,
+    description:
+      'Overlay content. Rendered as markdown in `<figcaption class="prose">`.',
+  },
 };

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -107,22 +107,39 @@ export const ITEMS_COMMON_FIELDS = {
   ...HEADER_FIELDS,
 };
 
-/**
- * Build unified fields for image-card-style grid blocks (image-cards, buy-options).
- * @param {object} itemsField - Unified field for the items array (with CMS + doc info)
- */
+export const REVEAL_BOOLEAN_FIELD = {
+  type: "boolean",
+  default: "true",
+  description: "Adds `data-reveal` to each item.",
+};
+
+export const HEADING_LEVEL_FIELD = {
+  ...num("Heading Level"),
+  default: "3",
+  description: "Heading level for item titles.",
+};
+
+export const REVEAL_STRING_FIELD = {
+  type: "string",
+  description: "`data-reveal` value.",
+};
+
+export const collectionField = (description) => ({
+  ...str("Collection Name"),
+  required: true,
+  description,
+});
+
+export const HEADER_FIELDS_DOC_ONLY_INTRO = {
+  ...HEADER_FIELDS,
+  header_intro: docOnly(HEADER_FIELDS.header_intro),
+};
+
+/** @param {object} itemsField */
 export const imageCardGridFields = (itemsField) => ({
   items: itemsField,
-  reveal: {
-    type: "boolean",
-    default: "true",
-    description: "Adds `data-reveal` to each item.",
-  },
-  heading_level: {
-    ...num("Heading Level"),
-    default: "3",
-    description: "Heading level for titles.",
-  },
+  reveal: REVEAL_BOOLEAN_FIELD,
+  heading_level: HEADING_LEVEL_FIELD,
   image_aspect_ratio: {
     ...str("Image Aspect Ratio"),
     description: 'Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`.',
@@ -130,7 +147,17 @@ export const imageCardGridFields = (itemsField) => ({
   ...HEADER_FIELDS,
 });
 
-/** Unified fields shared between video-background and bunny-video-background. */
+/** Overlay content + class fields shared between background blocks. */
+export const OVERLAY_CONTENT_FIELDS = {
+  class: { ...str("CSS Class"), description: "Extra CSS classes." },
+  content: {
+    ...md("Overlay Content"),
+    required: true,
+    description:
+      'Overlay content. Rendered as markdown in `<figcaption class="prose">`.',
+  },
+};
+
 export const VIDEO_BG_SHARED_FIELDS = {
   video_title: {
     ...str("Video Title"),
@@ -142,14 +169,5 @@ export const VIDEO_BG_SHARED_FIELDS = {
     default: '"16/9"',
     description: "CSS aspect-ratio on container.",
   },
-  class: {
-    ...str("CSS Class"),
-    description: "Extra CSS classes.",
-  },
-  content: {
-    ...md("Overlay Content"),
-    required: true,
-    description:
-      'Overlay content. Rendered as markdown in `<figcaption class="prose">`.',
-  },
+  ...OVERLAY_CONTENT_FIELDS,
 };

--- a/src/_lib/utils/block-schema/snippet.js
+++ b/src/_lib/utils/block-schema/snippet.js
@@ -1,26 +1,19 @@
 export const type = "snippet";
 
-export const schema = ["reference"];
+export const fields = {
+  reference: {
+    type: "reference",
+    label: "Snippet",
+    options: { collection: "snippets" },
+    required: true,
+    description:
+      "Filename of the snippet (without `.md` extension) from `src/snippets/`.",
+  },
+};
 
 export const docs = {
   summary:
     "Renders blocks from a named snippet file, enabling reusable block compositions.",
   notes:
     "The referenced snippet must exist in `src/snippets/` and have a `blocks` frontmatter array. The snippet block is transparent — it renders no wrapping section element, so each inner block renders its own section directly.",
-  params: {
-    reference: {
-      type: "string",
-      required: true,
-      description:
-        "Filename of the snippet (without `.md` extension) from `src/snippets/`.",
-    },
-  },
-};
-
-export const cmsFields = {
-  reference: {
-    type: "reference",
-    label: "Snippet",
-    options: { collection: "snippets" },
-  },
 };

--- a/src/_lib/utils/block-schema/split-callout.js
+++ b/src/_lib/utils/block-schema/split-callout.js
@@ -1,21 +1,32 @@
 /* jscpd:ignore-start */
-import {
-  SPLIT_BASE_CMS_FIELDS,
-  SPLIT_BASE_PARAMS,
-  SPLIT_BASE_SCHEMA,
-  str,
-} from "#utils/block-schema/split-shared.js";
+import { SPLIT_BASE_FIELDS, str } from "#utils/block-schema/split-shared.js";
 /* jscpd:ignore-end */
 
 export const type = "split-callout";
 
-export const schema = [
-  ...SPLIT_BASE_SCHEMA,
-  "figure_icon",
-  "figure_title",
-  "figure_subtitle",
-  "figure_variant",
-];
+export const fields = {
+  ...SPLIT_BASE_FIELDS,
+  figure_icon: {
+    ...str("Icon (Iconify ID, emoji, or path)"),
+    description:
+      "Icon content: Iconify ID (`prefix:name`), emoji, or image path.",
+  },
+  figure_title: {
+    ...str("Callout Title"),
+    required: true,
+    description: "Bold heading text in the callout box.",
+  },
+  figure_subtitle: {
+    ...str("Callout Subtitle"),
+    description: "Supporting text below the title.",
+  },
+  figure_variant: {
+    ...str("Callout Color Variant"),
+    default: '"primary"',
+    description:
+      'Color scheme: `"primary"`, `"secondary"`, `"gradient"`, or a custom CSS gradient string.',
+  },
+};
 
 export const docs = {
   summary:
@@ -23,35 +34,4 @@ export const docs = {
   template: "src/_includes/design-system/split-callout.html",
   scss: "src/css/design-system/_split-callout.scss",
   htmlRoot: '<div class="split-callout">',
-  params: {
-    ...SPLIT_BASE_PARAMS,
-    figure_icon: {
-      type: "string",
-      description:
-        "Icon content: Iconify ID (`prefix:name`), emoji, or image path.",
-    },
-    figure_title: {
-      type: "string",
-      required: true,
-      description: "Bold heading text in the callout box.",
-    },
-    figure_subtitle: {
-      type: "string",
-      description: "Supporting text below the title.",
-    },
-    figure_variant: {
-      type: "string",
-      default: '"primary"',
-      description:
-        'Color scheme: `"primary"`, `"secondary"`, `"gradient"`, or a custom CSS gradient string.',
-    },
-  },
-};
-
-export const cmsFields = {
-  ...SPLIT_BASE_CMS_FIELDS,
-  figure_icon: str("Icon (Iconify ID, emoji, or path)"),
-  figure_title: str("Callout Title", { required: true }),
-  figure_subtitle: str("Callout Subtitle"),
-  figure_variant: str("Callout Color Variant"),
 };

--- a/src/_lib/utils/block-schema/split-code.js
+++ b/src/_lib/utils/block-schema/split-code.js
@@ -1,46 +1,31 @@
 /* jscpd:ignore-start */
 import {
-  SPLIT_BASE_CMS_FIELDS,
   SPLIT_BASE_DOCS,
-  SPLIT_BASE_PARAMS,
-  SPLIT_BASE_SCHEMA,
+  SPLIT_BASE_FIELDS,
   str,
 } from "#utils/block-schema/split-shared.js";
 /* jscpd:ignore-end */
 
 export const type = "split-code";
 
-export const schema = [
-  ...SPLIT_BASE_SCHEMA,
-  "figure_filename",
-  "figure_code",
-  "figure_language",
-];
+export const fields = {
+  ...SPLIT_BASE_FIELDS,
+  figure_filename: {
+    ...str("Code Filename"),
+    description: "Displayed filename in the code block header.",
+  },
+  figure_code: {
+    ...str("Code Content"),
+    required: true,
+    description: "Code content.",
+  },
+  figure_language: {
+    ...str("Code Language"),
+    description: "Syntax highlighting language.",
+  },
+};
 
 export const docs = {
   summary: "Two-column layout with text content and a code block.",
   ...SPLIT_BASE_DOCS,
-  params: {
-    ...SPLIT_BASE_PARAMS,
-    figure_filename: {
-      type: "string",
-      description: "Displayed filename in the code block header.",
-    },
-    figure_code: {
-      type: "string",
-      required: true,
-      description: "Code content.",
-    },
-    figure_language: {
-      type: "string",
-      description: "Syntax highlighting language.",
-    },
-  },
-};
-
-export const cmsFields = {
-  ...SPLIT_BASE_CMS_FIELDS,
-  figure_filename: str("Code Filename"),
-  figure_code: str("Code Content"),
-  figure_language: str("Code Language"),
 };

--- a/src/_lib/utils/block-schema/split-full.js
+++ b/src/_lib/utils/block-schema/split-full.js
@@ -10,18 +10,50 @@ export const type = "split-full";
 
 export const containerWidth = "full";
 
-export const schema = [
-  "variant",
-  "title_level",
-  "left_title",
-  "left_content",
-  "left_button",
-  "right_title",
-  "right_content",
-  "right_button",
-  "reveal_left",
-  "reveal_right",
-];
+export const fields = {
+  variant: {
+    ...str("Variant"),
+    description:
+      'Color scheme: `"dark-left"`, `"dark-right"`, `"primary-left"`, `"primary-right"`.',
+  },
+  title_level: {
+    ...num("Heading Level"),
+    default: "2",
+    description: "Heading level for both sides.",
+  },
+  left_title: {
+    ...str("Left Title"),
+    description: "Left panel heading.",
+  },
+  left_content: {
+    ...md("Left Content"),
+    description: "Left panel content (rendered as markdown via `.prose`).",
+  },
+  left_button: {
+    ...objectField("Left Button", BUTTON_FIELDS_BASE),
+    description: "`{text, href, variant}`.",
+  },
+  right_title: {
+    ...str("Right Title"),
+    description: "Right panel heading.",
+  },
+  right_content: {
+    ...md("Right Content"),
+    description: "Right panel content (rendered as markdown via `.prose`).",
+  },
+  right_button: {
+    ...objectField("Right Button", BUTTON_FIELDS_BASE),
+    description: "`{text, href, variant}`.",
+  },
+  reveal_left: {
+    ...str("Reveal Left Animation"),
+    description: "`data-reveal` for left panel.",
+  },
+  reveal_right: {
+    ...str("Reveal Right Animation"),
+    description: "`data-reveal` for right panel.",
+  },
+};
 
 export const docs = {
   summary:
@@ -31,61 +63,4 @@ export const docs = {
   htmlRoot: '<div class="split-full">',
   notes:
     'Variants: `"dark-left"` / `"dark-right"` (dark bg + light text), `"primary-left"` / `"primary-right"` (`--color-link` bg + contrast text). Button colors automatically invert in dark/primary panels. The parent `<section>` has zero padding — panels handle their own padding.',
-  params: {
-    variant: {
-      type: "string",
-      description:
-        'Color scheme: `"dark-left"`, `"dark-right"`, `"primary-left"`, `"primary-right"`.',
-    },
-    title_level: {
-      type: "number",
-      default: "2",
-      description: "Heading level for both sides.",
-    },
-    left_title: {
-      type: "string",
-      description: "Left panel heading.",
-    },
-    left_content: {
-      type: "string",
-      description: "Left panel content (rendered as markdown via `.prose`).",
-    },
-    left_button: {
-      type: "object",
-      description: "`{text, href, variant}`.",
-    },
-    right_title: {
-      type: "string",
-      description: "Right panel heading.",
-    },
-    right_content: {
-      type: "string",
-      description: "Right panel content (rendered as markdown via `.prose`).",
-    },
-    right_button: {
-      type: "object",
-      description: "`{text, href, variant}`.",
-    },
-    reveal_left: {
-      type: "string",
-      description: "`data-reveal` for left panel.",
-    },
-    reveal_right: {
-      type: "string",
-      description: "`data-reveal` for right panel.",
-    },
-  },
-};
-
-export const cmsFields = {
-  variant: str("Variant"),
-  title_level: num("Heading Level"),
-  reveal_left: str("Reveal Left Animation"),
-  reveal_right: str("Reveal Right Animation"),
-  left_title: str("Left Title"),
-  left_content: md("Left Content"),
-  left_button: objectField("Left Button", BUTTON_FIELDS_BASE),
-  right_title: str("Right Title"),
-  right_content: md("Right Content"),
-  right_button: objectField("Right Button", BUTTON_FIELDS_BASE),
 };

--- a/src/_lib/utils/block-schema/split-html.js
+++ b/src/_lib/utils/block-schema/split-html.js
@@ -1,29 +1,21 @@
 import {
   md,
-  SPLIT_BASE_CMS_FIELDS,
   SPLIT_BASE_DOCS,
-  SPLIT_BASE_PARAMS,
-  SPLIT_BASE_SCHEMA,
+  SPLIT_BASE_FIELDS,
 } from "#utils/block-schema/split-shared.js";
 
 export const type = "split-html";
 
-export const schema = [...SPLIT_BASE_SCHEMA, "figure_html"];
+export const fields = {
+  ...SPLIT_BASE_FIELDS,
+  figure_html: {
+    ...md("Figure HTML Content"),
+    required: true,
+    description: "Raw HTML content for the figure side.",
+  },
+};
 
 export const docs = {
   summary: "Two-column layout with text content and custom HTML.",
   ...SPLIT_BASE_DOCS,
-  params: {
-    ...SPLIT_BASE_PARAMS,
-    figure_html: {
-      type: "string",
-      required: true,
-      description: "Raw HTML content for the figure side.",
-    },
-  },
-};
-
-export const cmsFields = {
-  ...SPLIT_BASE_CMS_FIELDS,
-  figure_html: md("Figure HTML Content"),
 };

--- a/src/_lib/utils/block-schema/split-icon-links.js
+++ b/src/_lib/utils/block-schema/split-icon-links.js
@@ -1,30 +1,22 @@
 import { ICON_LINKS_ITEMS_FIELD } from "#utils/block-schema/icon-links.js";
 import {
-  SPLIT_BASE_CMS_FIELDS,
   SPLIT_BASE_DOCS,
-  SPLIT_BASE_PARAMS,
-  SPLIT_BASE_SCHEMA,
+  SPLIT_BASE_FIELDS,
 } from "#utils/block-schema/split-shared.js";
 
 export const type = "split-icon-links";
 
-export const schema = [...SPLIT_BASE_SCHEMA, "figure_items"];
+export const fields = {
+  ...SPLIT_BASE_FIELDS,
+  figure_items: {
+    ...ICON_LINKS_ITEMS_FIELD,
+    required: true,
+    description:
+      'Icon-link objects. Each: `{icon, text, url}`. `url` is optional. Icon can be an Iconify ID (`"prefix:name"`), image path, or raw HTML/emoji.',
+  },
+};
 
 export const docs = {
   summary: "Two-column layout with text content and an icon-links list.",
   ...SPLIT_BASE_DOCS,
-  params: {
-    ...SPLIT_BASE_PARAMS,
-    figure_items: {
-      type: "array",
-      required: true,
-      description:
-        'Icon-link objects. Each: `{icon, text, url}`. `url` is optional. Icon can be an Iconify ID (`"prefix:name"`), image path, or raw HTML/emoji.',
-    },
-  },
-};
-
-export const cmsFields = {
-  ...SPLIT_BASE_CMS_FIELDS,
-  figure_items: ICON_LINKS_ITEMS_FIELD,
 };

--- a/src/_lib/utils/block-schema/split-image.js
+++ b/src/_lib/utils/block-schema/split-image.js
@@ -1,46 +1,32 @@
 /* jscpd:ignore-start */
 import {
-  SPLIT_BASE_CMS_FIELDS,
   SPLIT_BASE_DOCS,
-  SPLIT_BASE_PARAMS,
-  SPLIT_BASE_SCHEMA,
+  SPLIT_BASE_FIELDS,
   str,
 } from "#utils/block-schema/split-shared.js";
 /* jscpd:ignore-end */
 
 export const type = "split-image";
 
-export const schema = [
-  ...SPLIT_BASE_SCHEMA,
-  "figure_src",
-  "figure_alt",
-  "figure_caption",
-];
+export const fields = {
+  ...SPLIT_BASE_FIELDS,
+  figure_src: {
+    type: "image",
+    label: "Figure Image",
+    required: true,
+    description: "Image path.",
+  },
+  figure_alt: {
+    ...str("Figure Alt Text"),
+    description: "Alt text for the image.",
+  },
+  figure_caption: {
+    ...str("Figure Caption"),
+    description: "Visible caption below the image.",
+  },
+};
 
 export const docs = {
   summary: "Two-column layout with text content and a responsive image.",
   ...SPLIT_BASE_DOCS,
-  params: {
-    ...SPLIT_BASE_PARAMS,
-    figure_src: {
-      type: "string",
-      required: true,
-      description: "Image path.",
-    },
-    figure_alt: {
-      type: "string",
-      description: "Alt text for the image.",
-    },
-    figure_caption: {
-      type: "string",
-      description: "Visible caption below the image.",
-    },
-  },
-};
-
-export const cmsFields = {
-  ...SPLIT_BASE_CMS_FIELDS,
-  figure_src: { type: "image", label: "Figure Image" },
-  figure_alt: str("Figure Alt Text"),
-  figure_caption: str("Figure Caption"),
 };

--- a/src/_lib/utils/block-schema/split-shared.js
+++ b/src/_lib/utils/block-schema/split-shared.js
@@ -1,5 +1,5 @@
 /**
- * Shared constants for all split-* block types.
+ * Shared unified fields for all split-* block types.
  *
  * Every split variant (split-image, split-video, split-code, split-icon-links,
  * split-html) shares the same text-side fields. This module centralizes them
@@ -17,54 +17,42 @@ import {
 // Re-export so split variants only need one import source.
 export { md, str } from "#utils/block-schema/shared.js";
 
-/** Schema keys shared by all split variants. */
-export const SPLIT_BASE_SCHEMA = [
-  "title",
-  "title_level",
-  "subtitle",
-  "content",
-  "reverse",
-  "reveal_content",
-  "reveal_figure",
-  "button",
-];
-
-/** Documentation for shared split params. */
-export const SPLIT_BASE_PARAMS = {
-  title: { type: "string", description: "Section heading." },
+/** Unified fields shared by all split variants. */
+export const SPLIT_BASE_FIELDS = {
+  title: { ...str("Title"), description: "Section heading." },
   title_level: {
-    type: "number",
+    ...num("Heading Level"),
     default: "2",
     description: "Heading level.",
   },
   subtitle: {
-    type: "string",
+    ...str("Subtitle"),
     description: "Subtitle with `.text-muted` styling.",
   },
   content: {
-    type: "string",
+    ...md("Content"),
     description:
       'Main content. Rendered through `renderContent: "md"` filter (supports markdown). Wrapped in `.prose`.',
   },
   reverse: {
-    type: "boolean",
+    ...bool("Reverse Layout"),
     default: "false",
     description:
       "Reverses column order (content right, figure left) on desktop.",
   },
   reveal_content: {
-    type: "string",
+    ...str("Reveal Content Animation"),
     default: '"left"',
     description:
       '`data-reveal` for the text side. Auto-set to `"right"` when `reverse` is true.',
   },
   reveal_figure: {
-    type: "string",
+    ...str("Reveal Figure Animation"),
     default: '"scale"',
     description: "`data-reveal` for the figure side.",
   },
   button: {
-    type: "object",
+    ...objectField("Button", BUTTON_FIELDS_WITH_SIZE),
     description:
       '`{text, href, variant}`. Rendered below content. Default variant: `"secondary"`.',
   },
@@ -75,16 +63,4 @@ export const SPLIT_BASE_DOCS = {
   template: "src/_includes/design-system/split.html",
   scss: "src/css/design-system/_split.scss",
   htmlRoot: '<div class="split">',
-};
-
-/** CMS fields shared by all split variants. */
-export const SPLIT_BASE_CMS_FIELDS = {
-  title: str("Title"),
-  title_level: num("Heading Level"),
-  subtitle: str("Subtitle"),
-  reverse: bool("Reverse Layout"),
-  reveal_content: str("Reveal Content Animation"),
-  reveal_figure: str("Reveal Figure Animation"),
-  content: md("Content"),
-  button: objectField("Button", BUTTON_FIELDS_WITH_SIZE),
 };

--- a/src/_lib/utils/block-schema/split-video.js
+++ b/src/_lib/utils/block-schema/split-video.js
@@ -1,46 +1,31 @@
 /* jscpd:ignore-start */
 import {
-  SPLIT_BASE_CMS_FIELDS,
   SPLIT_BASE_DOCS,
-  SPLIT_BASE_PARAMS,
-  SPLIT_BASE_SCHEMA,
+  SPLIT_BASE_FIELDS,
   str,
 } from "#utils/block-schema/split-shared.js";
 /* jscpd:ignore-end */
 
 export const type = "split-video";
 
-export const schema = [
-  ...SPLIT_BASE_SCHEMA,
-  "figure_video_id",
-  "figure_alt",
-  "figure_caption",
-];
+export const fields = {
+  ...SPLIT_BASE_FIELDS,
+  figure_video_id: {
+    ...str("Video ID or URL"),
+    required: true,
+    description: "YouTube video ID or custom iframe URL.",
+  },
+  figure_alt: {
+    ...str("Video Alt Text"),
+    description: "Accessible title for the video iframe.",
+  },
+  figure_caption: {
+    ...str("Video Caption"),
+    description: "Visible caption below the video.",
+  },
+};
 
 export const docs = {
   summary: "Two-column layout with text content and an embedded video.",
   ...SPLIT_BASE_DOCS,
-  params: {
-    ...SPLIT_BASE_PARAMS,
-    figure_video_id: {
-      type: "string",
-      required: true,
-      description: "YouTube video ID or custom iframe URL.",
-    },
-    figure_alt: {
-      type: "string",
-      description: "Accessible title for the video iframe.",
-    },
-    figure_caption: {
-      type: "string",
-      description: "Visible caption below the video.",
-    },
-  },
-};
-
-export const cmsFields = {
-  ...SPLIT_BASE_CMS_FIELDS,
-  figure_video_id: str("Video ID or URL"),
-  figure_alt: str("Video Alt Text"),
-  figure_caption: str("Video Caption"),
 };

--- a/src/_lib/utils/block-schema/stats.js
+++ b/src/_lib/utils/block-schema/stats.js
@@ -2,6 +2,7 @@ import { objectList, str } from "#utils/block-schema/shared.js";
 
 export const type = "stats";
 
+/* jscpd:ignore-start */
 export const fields = {
   items: {
     ...objectList("Statistics", {
@@ -12,6 +13,7 @@ export const fields = {
     description:
       'Stat objects: `{value, label}` or pipe-delimited strings `"value|label"`.',
   },
+  /* jscpd:ignore-end */
   reveal: {
     type: "boolean",
     default: "true",

--- a/src/_lib/utils/block-schema/stats.js
+++ b/src/_lib/utils/block-schema/stats.js
@@ -1,35 +1,27 @@
-import {
-  objectList,
-  REVEAL_BOOLEAN_PARAM,
-  str,
-} from "#utils/block-schema/shared.js";
+import { objectList, str } from "#utils/block-schema/shared.js";
 
 export const type = "stats";
 
-export const schema = ["items", "reveal"];
+export const fields = {
+  items: {
+    ...objectList("Statistics", {
+      value: str("Value", { required: true }),
+      label: str("Label", { required: true }),
+    }),
+    required: true,
+    description:
+      'Stat objects: `{value, label}` or pipe-delimited strings `"value|label"`.',
+  },
+  reveal: {
+    type: "boolean",
+    default: "true",
+    description: "Adds `data-reveal` to each stat.",
+  },
+};
 
 export const docs = {
   summary: "Key metrics displayed as large numbers with labels.",
   template: "src/_includes/design-system/stats.html",
   scss: "src/css/design-system/_stats.scss",
   htmlRoot: '<dl class="stats">',
-  params: {
-    items: {
-      type: "array",
-      required: true,
-      description:
-        'Stat objects: `{value, label}` or pipe-delimited strings `"value|label"`.',
-    },
-    reveal: {
-      ...REVEAL_BOOLEAN_PARAM,
-      description: "Adds `data-reveal` to each stat.",
-    },
-  },
-};
-
-export const cmsFields = {
-  items: objectList("Statistics", {
-    value: str("Value", { required: true }),
-    label: str("Label", { required: true }),
-  }),
 };

--- a/src/_lib/utils/block-schema/video-background.js
+++ b/src/_lib/utils/block-schema/video-background.js
@@ -1,23 +1,22 @@
-import {
-  CLASS_PARAM,
-  OVERLAY_CONTENT_PARAM,
-  str,
-  VIDEO_BG_SHARED_PARAMS,
-  videoBgSharedFields,
-} from "#utils/block-schema/shared.js";
+import { str, VIDEO_BG_SHARED_FIELDS } from "#utils/block-schema/shared.js";
 
 export const type = "video-background";
 
 export const containerWidth = "full";
 
-export const schema = [
-  "video_id",
-  "video_title",
-  "content",
-  "aspect_ratio",
-  "class",
-  "thumbnail_url",
-];
+export const fields = {
+  video_id: {
+    ...str("Video Embed URL"),
+    required: true,
+    description: "YouTube video ID or full iframe URL (for Bunny, Vimeo, etc).",
+  },
+  thumbnail_url: {
+    ...str("Thumbnail URL"),
+    description:
+      "URL of a thumbnail image displayed behind the iframe while the video loads.",
+  },
+  ...VIDEO_BG_SHARED_FIELDS,
+};
 
 export const docs = {
   summary: "Auto-playing video background with overlaid text content.",
@@ -26,26 +25,4 @@ export const docs = {
   htmlRoot: '<div class="video-background">',
   notes:
     "YouTube IDs get `youtube-nocookie.com` embed URLs with `autoplay=1&mute=1&loop=1&controls=0`. Custom URLs (starting with `http`) are used directly.",
-  params: {
-    video_id: {
-      type: "string",
-      required: true,
-      description:
-        "YouTube video ID or full iframe URL (for Bunny, Vimeo, etc).",
-    },
-    ...VIDEO_BG_SHARED_PARAMS,
-    content: OVERLAY_CONTENT_PARAM,
-    class: CLASS_PARAM,
-    thumbnail_url: {
-      type: "string",
-      description:
-        "URL of a thumbnail image displayed behind the iframe while the video loads.",
-    },
-  },
-};
-
-export const cmsFields = {
-  video_id: str("Video Embed URL", { required: true }),
-  thumbnail_url: str("Thumbnail URL"),
-  ...videoBgSharedFields(),
 };

--- a/test/unit/utils/block-docs.test.js
+++ b/test/unit/utils/block-docs.test.js
@@ -5,11 +5,7 @@ import { join } from "node:path";
 import YAML from "yaml";
 import { rootDir } from "#test/test-utils.js";
 import { collectBlockReferences } from "#test/unit/utils/pages-yml-helpers.js";
-import {
-  BLOCK_CMS_FIELDS,
-  BLOCK_DOCS,
-  BLOCK_SCHEMAS,
-} from "#utils/block-schema.js";
+import { BLOCK_DOCS, BLOCK_SCHEMAS } from "#utils/block-schema.js";
 
 const RENDER_BLOCK_PATH = join(
   rootDir,
@@ -30,37 +26,7 @@ const getRenderedBlockTypes = () => {
     .sort();
 };
 
-describe("BLOCK_DOCS completeness", () => {
-  test("every BLOCK_SCHEMAS type has a BLOCK_DOCS entry", () => {
-    const schemaTypes = Object.keys(BLOCK_SCHEMAS).sort();
-    const docTypes = Object.keys(BLOCK_DOCS).sort();
-    expect(docTypes).toEqual(schemaTypes);
-  });
-
-  test("every BLOCK_DOCS param key exists in BLOCK_SCHEMAS", () => {
-    const mismatches = Object.entries(BLOCK_DOCS).flatMap(([type, doc]) => {
-      const schemaKeys = new Set(BLOCK_SCHEMAS[type]);
-      return Object.keys(doc.params)
-        .filter((key) => !schemaKeys.has(key))
-        .map(
-          (key) => `${type}: "${key}" in BLOCK_DOCS but not in BLOCK_SCHEMAS`,
-        );
-    });
-    expect(mismatches).toEqual([]);
-  });
-
-  test("every BLOCK_SCHEMAS key has a BLOCK_DOCS param entry", () => {
-    const mismatches = Object.entries(BLOCK_SCHEMAS).flatMap(([type, keys]) => {
-      const docKeys = new Set(Object.keys(BLOCK_DOCS[type].params));
-      return keys
-        .filter((key) => !docKeys.has(key))
-        .map(
-          (key) => `${type}: "${key}" in BLOCK_SCHEMAS but not in BLOCK_DOCS`,
-        );
-    });
-    expect(mismatches).toEqual([]);
-  });
-
+describe("BLOCK_DOCS quality", () => {
   test("every BLOCK_DOCS entry has a summary", () => {
     const missing = Object.entries(BLOCK_DOCS)
       .filter(([, doc]) => !doc.summary)
@@ -108,8 +74,6 @@ describe("BLOCKS_LAYOUT.md freshness", () => {
 
 describe(".pages.yml ↔ BLOCKS_LAYOUT.md coverage", () => {
   const parsedPagesYml = YAML.parse(readFileSync(PAGES_YML_PATH, "utf-8"));
-  // Every block type reachable through the CMS UI — each must have
-  // user-facing docs in BLOCKS_LAYOUT.md.
   const cmsReachableTypes = new Set(
     collectBlockReferences(parsedPagesYml).map((r) => r.name),
   );
@@ -119,25 +83,5 @@ describe(".pages.yml ↔ BLOCKS_LAYOUT.md coverage", () => {
       .filter((type) => !BLOCK_DOCS[type]?.summary)
       .sort();
     expect(missing).toEqual([]);
-  });
-
-  test("every CMS-reachable block's CMS field is documented in BLOCK_DOCS.params", () => {
-    // `dark` is injected by the generator for every block and documented once
-    // in the "Common Block Properties" table at the top of BLOCKS_LAYOUT.md —
-    // skip it here.
-    const containerFields = new Set(["dark"]);
-    const violations = [...cmsReachableTypes].flatMap((type) => {
-      const docParams = Object.keys(BLOCK_DOCS[type]?.params || {});
-      const cmsFieldNames = Object.keys(BLOCK_CMS_FIELDS[type] || {});
-      return cmsFieldNames
-        .filter(
-          (name) => !containerFields.has(name) && !docParams.includes(name),
-        )
-        .map(
-          (name) =>
-            `${type}: CMS field "${name}" has no matching BLOCK_DOCS.params entry`,
-        );
-    });
-    expect(violations).toEqual([]);
   });
 });

--- a/test/unit/utils/block-schema.test.js
+++ b/test/unit/utils/block-schema.test.js
@@ -1,37 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
-  BLOCK_CMS_FIELDS,
   BLOCK_DOCS,
   BLOCK_SCHEMAS,
   getBlockContainerWidth,
   validateBlocks,
 } from "#utils/block-schema.js";
-
-describe("BLOCK_SCHEMAS / BLOCK_CMS_FIELDS / BLOCK_DOCS invariants", () => {
-  test("every CMS field block is also a validator-known block", () => {
-    for (const blockType of Object.keys(BLOCK_CMS_FIELDS)) {
-      expect(BLOCK_SCHEMAS[blockType]).toBeDefined();
-    }
-  });
-
-  test("every schema-known block is also CMS-editable", () => {
-    // If you intentionally want a code-only block, remove it from
-    // BLOCK_SCHEMAS. Otherwise export `cmsFields` from its block-schema
-    // module (use `{}` for blocks with no block-specific fields —
-    // the wrapper `dark` field is auto-injected).
-    const missing = Object.keys(BLOCK_SCHEMAS)
-      .filter((type) => !(type in BLOCK_CMS_FIELDS))
-      .sort();
-    expect(missing).toEqual([]);
-  });
-
-  test("every schema-known block also has docs", () => {
-    const missing = Object.keys(BLOCK_SCHEMAS)
-      .filter((type) => !(type in BLOCK_DOCS))
-      .sort();
-    expect(missing).toEqual([]);
-  });
-});
 
 describe("BLOCK_DOCS shape", () => {
   // One test per block so the failure message identifies the broken module.
@@ -40,21 +13,6 @@ describe("BLOCK_DOCS shape", () => {
       expect(typeof docs.summary).toBe("string");
       expect(docs.summary.length).toBeGreaterThan(0);
       expect(docs.params).toEqual(expect.any(Object));
-    });
-  }
-});
-
-describe("BLOCK_CMS_FIELDS field keys pass validateBlocks", () => {
-  // Data-driven: every CMS-exposed field must also be accepted by the
-  // production validator, or the CMS would let authors write blocks
-  // that fail to build.
-  for (const [blockType, fields] of Object.entries(BLOCK_CMS_FIELDS)) {
-    test(`${blockType}: all CMS field keys validate`, () => {
-      const block = { type: blockType };
-      for (const fieldKey of Object.keys(fields)) {
-        block[fieldKey] = fieldKey === "dark" ? true : "test-value";
-      }
-      expect(() => validateBlocks([block])).not.toThrow();
     });
   }
 });


### PR DESCRIPTION
## Summary

- **Collapses triple declaration pattern** (schema keys + docs params + CMS fields) into a single unified `fields` export per block module, eliminating ~553 lines net across the codebase
- **Derives `BLOCK_SCHEMAS`, `BLOCK_CMS_FIELDS`, and `BLOCK_DOCS`** automatically in the aggregator (`block-schema.js`) from each module's unified `fields` — CMS exposure is determined by whether a field has a `label` property
- **Removes tautological tests** that verified alignment between schema/CMS/docs maps (now guaranteed by construction since all three are derived from one source)

## Details

Each block module previously maintained three separate exports that had to stay in sync:
1. `schema` — array of allowed key names
2. `docs.params` — object with type/description per param
3. `cmsFields` — object with CMS widget config per param

Now each module exports a single `fields` object where each field carries both CMS metadata (`type`, `label`, `required`) and doc metadata (`description`, `default`). The aggregator derives all three maps:
- `BLOCK_SCHEMAS` = `Object.keys(fields)` per block
- `BLOCK_CMS_FIELDS` = fields filtered to those with a `label`, with doc-only props stripped
- `BLOCK_DOCS` = fields mapped to doc-friendly types

Shared constants (`HEADER_FIELDS`, `SPLIT_BASE_FIELDS`, `VIDEO_BG_SHARED_FIELDS`, etc.) were similarly unified. A `docOnly()` helper handles the few cases where a shared field should appear in docs/schema but not CMS.

**Stats:** 45 files changed, 900 insertions, 1,453 deletions (net -553 lines). All 202 tests pass, lint clean.

## Test plan

- [x] `bun test` — all 202 tests pass
- [x] `bun run lint` — no violations
- [x] BLOCKS_LAYOUT.md freshness test passes (regenerated)
- [x] .pages.yml freshness test passes (regenerated)
- [x] validateBlocks accepts all schema-declared keys for every block type
- [x] BLOCK_DOCS shape tests pass (summary + param type/description)
- [x] render-block.html sync tests pass (schema ↔ template alignment)

https://claude.ai/code/session_019ksKxcWSW16E9eMnNkBGTS