### PR TITLE
Use text input for dynamic item/event/property contact form fields

### DIFF
--- a/src/_data/contact-form.json
+++ b/src/_data/contact-form.json
@@ -19,28 +19,22 @@
 		},
 		{
 			"name": "item",
-			"type": "textarea",
 			"label": "Item",
 			"required": true,
-			"rows": 6,
 			"showOn": "products",
 			"defaultFromPageTitle": true
 		},
 		{
 			"name": "event",
-			"type": "textarea",
 			"label": "Event",
 			"required": true,
-			"rows": 6,
 			"showOn": "events",
 			"defaultFromPageTitle": true
 		},
 		{
 			"name": "property",
-			"type": "textarea",
 			"label": "Property",
 			"required": true,
-			"rows": 6,
 			"showOn": "properties",
 			"defaultFromPageTitle": true
 		},

--- a/src/_includes/form-field-input.html
+++ b/src/_includes/form-field-input.html
@@ -4,7 +4,8 @@
     type="{% if field.type %}{{ field.type }}{% else %}text{% endif %}"
     id="{{ field.name }}"
     name="{{ field.name }}"
-    placeholder="{{ field.placeholder }}"
+    placeholder="{% if field.defaultFromPageTitle %}{{ pageTitle }}{% else %}{{ field.placeholder }}{% endif %}"
+    {%- if field.defaultFromPageTitle %} value="{{ pageTitle }}"{% endif %}
     {%- if field.required %} required{%- endif %}
   />
   {%- include "form-field-note.html" -%}


### PR DESCRIPTION
## Summary

- Changed "Item", "Event", and "Property" contact form fields from `textarea` to plain text inputs
- These fields are shown contextually based on page tags and pre-fill with the page title — a single-line input is more appropriate
- Updated `form-field-input.html` to support `defaultFromPageTitle` for both `value` and `placeholder` attributes (previously only the textarea template handled this)

## Test plan

- [ ] Visit a product page with a contact form — "Item" field should be a single-line text input pre-filled with the product title
- [ ] Visit an event page — "Event" field should be a single-line text input pre-filled with the event title
- [ ] Visit a property page — "Property" field should be a single-line text input pre-filled with the property title
- [ ] Confirm the "Message" field remains a textarea

https://claude.ai/code/session_01JjXLnNN18xLrQNAtaHpuSn