### PR TITLE
Add split-buy-options block for single-product split layout

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -298,6 +298,49 @@ components:
         required: true
       - { name: figure_subtitle, type: string, label: Callout Subtitle }
       - { name: figure_variant, type: string, label: Callout Color Variant }
+  block_split_buy_options:
+    label: Split Buy Options
+    type: object
+    fields:
+      - { name: dark, type: boolean, label: Dark }
+      - { name: title, type: string, label: Title }
+      - { name: title_level, type: number, label: Heading Level }
+      - { name: subtitle, type: string, label: Subtitle }
+      - { name: content, type: rich-text, label: Content }
+      - { name: reverse, type: boolean, label: Reverse Layout }
+      - { name: reveal_content, type: string, label: Reveal Content Animation }
+      - { name: reveal_figure, type: string, label: Reveal Figure Animation }
+      - name: button
+        type: object
+        label: Button
+        fields:
+          - { name: text, type: string, label: Button Text, required: true }
+          - { name: href, type: string, label: URL, required: true }
+          - { name: variant, type: string, label: Variant }
+          - { name: size, type: string, label: Size }
+      - name: figure_image
+        type: image
+        label: Product Image
+        required: true
+      - name: figure_title
+        type: string
+        label: Product Title
+        required: true
+      - { name: figure_subtitle, type: string, label: Product Subtitle }
+      - name: figure_price
+        type: string
+        label: Product Price (display, e.g. £15)
+      - name: figure_currency
+        type: string
+        label: Product Currency (ISO code, e.g. GBP)
+      - { name: figure_link, type: string, label: Buy Link, required: true }
+      - { name: figure_button_text, type: string, label: Buy Button Text }
+      - name: figure_heading_level
+        type: number
+        label: Product Heading Level
+      - name: figure_image_aspect_ratio
+        type: string
+        label: Product Image Aspect Ratio
   block_split_full:
     label: Split Full
     type: object
@@ -712,6 +755,7 @@ content:
           - { name: split-icon-links, component: block_split_icon_links }
           - { name: split-html, component: block_split_html }
           - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
           - { name: split-full, component: block_split_full }
           - { name: cta, component: block_cta }
           - { name: callout, component: block_callout }

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -329,6 +329,39 @@ Two-column layout with text content and a styled callout box with icon, title, a
 
 ---
 
+### `split-buy-options`
+
+Two-column layout with text content and a single buyable product card. Emits schema.org Product microdata.
+
+**Component:** `block_split_buy_options`
+**Template:** `src/_includes/design-system/split.html`
+**SCSS:** `src/css/design-system/_split.scss`
+**HTML root:** `<div class="split">`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `title` | string | — | Section heading. |
+| `title_level` | number | `2` | Heading level. |
+| `subtitle` | string | — | Subtitle with `.text-muted` styling. |
+| `content` | string | — | Main content. Rendered through `renderContent: "md"` filter (supports markdown). Wrapped in `.prose`. |
+| `reverse` | boolean | `false` | Reverses column order (content right, figure left) on desktop. |
+| `reveal_content` | string | `"left"` | `data-reveal` for the text side. Auto-set to `"right"` when `reverse` is true. |
+| `reveal_figure` | string | `"scale"` | `data-reveal` for the figure side. |
+| `button` | object | — | `{text, href, variant}`. Rendered below content. Default variant: `"secondary"`. |
+| `figure_image` | string | **required** | Product image path. Processed by `{% image %}` shortcode for responsive srcset + LQIP. |
+| `figure_title` | string | **required** | Product name. Schema.org `name`. |
+| `figure_subtitle` | string | — | Optional subtitle, e.g. `Print edition`. Rendered italic. |
+| `figure_price` | string | — | Display price. Currency symbols are stripped for schema.org `price`. |
+| `figure_currency` | string | `"GBP"` | ISO currency code for schema.org `priceCurrency`. |
+| `figure_link` | string | **required** | Buy URL. |
+| `figure_button_text` | string | `"Buy now"` | Button label. |
+| `figure_heading_level` | number | `3` | Heading level for the product title. |
+| `figure_image_aspect_ratio` | string | — | Aspect ratio, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
+
+Figure renders as `<figure itemscope itemtype="https://schema.org/Product">` with the same card markup as each item in the `buy-options` block (shared partial `src/_includes/design-system/buy-option-card.html`). Use this when you have a single buy action to promote alongside text; use `buy-options` for a grid of products.
+
+---
+
 ### `split-full`
 
 Full-width two-panel layout with distinct background colors per side.

--- a/src/_includes/design-system/buy-option-card.html
+++ b/src/_includes/design-system/buy-option-card.html
@@ -1,0 +1,46 @@
+{%- comment -%}
+Product card contents for a buy-option. Used by buy-options.html (rendered
+inside a `<li itemscope itemtype="https://schema.org/Product">`) and by
+split.html for the `split-buy-options` block (rendered inside a
+`<figure itemscope itemtype="https://schema.org/Product">`).
+
+Parameters (passed directly via include):
+  - image: Image path (optional)
+  - title: Product name (required)
+  - subtitle: Short secondary line, e.g. "Print edition" (optional)
+  - price: Display price string, e.g. "£15" (optional)
+  - currency: ISO currency code for schema.org (default: "GBP")
+  - link: Buy URL (required)
+  - button_text: Button label (default: "Buy now")
+  - heading_level: Heading level for the title (default: 3)
+  - image_aspect_ratio: Aspect ratio for the image (optional)
+{%- endcomment -%}
+{%- assign _price_value = price
+   | replace: "£", ""
+   | replace: "$", ""
+   | replace: "€", ""
+   | replace: ",", ""
+   | strip -%}
+{%- assign _currency = currency | default: "GBP" -%}
+{%- assign _button_text = button_text | default: "Buy now" -%}
+{%- assign _heading_level = heading_level | default: 3 -%}
+{%- if image -%}
+  <a class="image-link" href="{{ link }}">
+    {%- image image, title, "", "", "", image_aspect_ratio -%}
+    <meta itemprop="image" content="{{ image }}">
+  </a>
+{%- endif -%}
+<h{{ _heading_level }} itemprop="name">
+  <a href="{{ link }}">{{ title }}</a>
+</h{{ _heading_level }}>
+{%- if subtitle -%}
+  <p class="subtitle">{{ subtitle }}</p>
+{%- endif -%}
+{%- if price -%}
+  <p class="price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+    <span itemprop="priceCurrency" content="{{ _currency }}"></span>
+    <meta itemprop="price" content="{{ _price_value }}">
+    <span>{{ price }}</span>
+  </p>
+{%- endif -%}
+<a class="button" href="{{ link }}" itemprop="url">{{ _button_text }}</a>

--- a/src/_includes/design-system/buy-options.html
+++ b/src/_includes/design-system/buy-options.html
@@ -2,6 +2,9 @@
 Buy-options grid — cards for purchasable products with schema.org Product
 microdata. Renders on top of the shared .items grid styles.
 
+Per-item card markup comes from buy-option-card.html, which is also used by
+the split-buy-options block.
+
 Parameters (via block object):
   - block.items: Array of product objects with properties:
     - image: Image path (required)
@@ -30,35 +33,17 @@ Parameters (via block object):
 
 <ul class="items buy-options" role="list">
   {%- for item in block.items -%}
-    {%- assign price_value = item.price
-       | replace: "£", ""
-       | replace: "$", ""
-       | replace: "€", ""
-       | replace: ",", ""
-       | strip -%}
-    {%- assign currency = item.currency | default: "GBP" -%}
-    {%- assign button_text = item.button_text | default: "Buy now" -%}
     <li itemscope itemtype="https://schema.org/Product"{% if reveal %} data-reveal{% endif %}>
-      {%- if item.image -%}
-        <a class="image-link" href="{{ item.link }}">
-          {%- image item.image, item.title, "", "", "", block.image_aspect_ratio -%}
-          <meta itemprop="image" content="{{ item.image }}">
-        </a>
-      {%- endif -%}
-      <h{{ heading_level }} itemprop="name">
-        <a href="{{ item.link }}">{{ item.title }}</a>
-      </h{{ heading_level }}>
-      {%- if item.subtitle -%}
-        <p class="subtitle">{{ item.subtitle }}</p>
-      {%- endif -%}
-      {%- if item.price -%}
-        <p class="price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-          <span itemprop="priceCurrency" content="{{ currency }}"></span>
-          <meta itemprop="price" content="{{ price_value }}">
-          <span>{{ item.price }}</span>
-        </p>
-      {%- endif -%}
-      <a class="button" href="{{ item.link }}" itemprop="url">{{ button_text }}</a>
+      {%- include "design-system/buy-option-card.html",
+         image: item.image,
+         title: item.title,
+         subtitle: item.subtitle,
+         price: item.price,
+         currency: item.currency,
+         link: item.link,
+         button_text: item.button_text,
+         heading_level: heading_level,
+         image_aspect_ratio: block.image_aspect_ratio -%}
     </li>
   {%- endfor -%}
 </ul>

--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -25,7 +25,7 @@ Renders a single block by type. Used by blocks.html.
   {%- when "hero" -%}
     {%- include "design-system/hero.html", block: block -%}
 
-  {%- when "split-image", "split-video", "split-code", "split-icon-links", "split-html" -%}
+  {%- when "split-image", "split-video", "split-code", "split-icon-links", "split-html", "split-buy-options" -%}
     {%- include "design-system/split.html", block: block -%}
 
   {%- when "split-callout" -%}

--- a/src/_includes/design-system/split.html
+++ b/src/_includes/design-system/split.html
@@ -1,6 +1,7 @@
 {%- comment -%}
 Split layout with text content and a figure. Used by all split-* block types:
-split-image, split-video, split-code, split-icon-links, split-html.
+split-image, split-video, split-code, split-icon-links, split-html,
+split-buy-options.
 
 The figure type is derived from the block type (e.g., "split-image" → "image").
 
@@ -16,19 +17,27 @@ Parameters (via block object):
     - block.button: Optional button object { text, href, variant }
 
   Figure fields per block type:
-    split-image:      figure_src, figure_alt, figure_caption
-    split-video:      figure_video_id, figure_alt, figure_caption
-    split-code:       figure_filename, figure_code, figure_language
-    split-icon-links: figure_items (array of {icon, text, url})
-    split-html:       figure_html
+    split-image:        figure_src, figure_alt, figure_caption
+    split-video:        figure_video_id, figure_alt, figure_caption
+    split-code:         figure_filename, figure_code, figure_language
+    split-icon-links:   figure_items (array of {icon, text, url})
+    split-html:         figure_html
+    split-buy-options:  figure_image, figure_title, figure_subtitle,
+                        figure_price, figure_currency, figure_link,
+                        figure_button_text, figure_heading_level,
+                        figure_image_aspect_ratio
 {%- endcomment -%}
 
 {%- assign reveal_content = block.reveal_content | default: "left" -%}
 {%- assign reveal_figure = block.reveal_figure | default: "scale" -%}
+{%- assign is_buy_options = false -%}
+{%- if block.type == "split-buy-options" -%}
+  {%- assign is_buy_options = true -%}
+{%- endif -%}
 
 <div class="split{% if block.reverse %} split--reverse{% endif %}">
   {%- include "design-system/split-article.html", block: block, reveal_content: reveal_content -%}
-  <figure data-reveal="{{ reveal_figure }}">
+  <figure data-reveal="{{ reveal_figure }}"{% if is_buy_options %} class="buy-option-figure" itemscope itemtype="https://schema.org/Product"{% endif %}>
     {%- case block.type -%}
       {%- when "split-image" -%}
         {% image block.figure_src, block.figure_alt %}
@@ -52,6 +61,17 @@ Parameters (via block object):
         {%- include "design-system/icon-links.html", items: block.figure_items -%}
       {%- when "split-html" -%}
         {{ block.figure_html }}
+      {%- when "split-buy-options" -%}
+        {%- include "design-system/buy-option-card.html",
+           image: block.figure_image,
+           title: block.figure_title,
+           subtitle: block.figure_subtitle,
+           price: block.figure_price,
+           currency: block.figure_currency,
+           link: block.figure_link,
+           button_text: block.figure_button_text,
+           heading_level: block.figure_heading_level,
+           image_aspect_ratio: block.figure_image_aspect_ratio -%}
     {%- endcase -%}
   </figure>
 </div>

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -43,6 +43,7 @@ import * as reviews from "#utils/block-schema/reviews.js";
 import * as sectionHeader from "#utils/block-schema/section-header.js";
 import { CONTAINER_FIELDS } from "#utils/block-schema/shared.js";
 import * as snippet from "#utils/block-schema/snippet.js";
+import * as splitBuyOptions from "#utils/block-schema/split-buy-options.js";
 import * as splitCallout from "#utils/block-schema/split-callout.js";
 import * as splitCode from "#utils/block-schema/split-code.js";
 import * as splitFull from "#utils/block-schema/split-full.js";
@@ -78,6 +79,7 @@ const BLOCK_MODULES = [
   splitIconLinks,
   splitHtml,
   splitCallout,
+  splitBuyOptions,
   splitFull,
   cta,
   callout,

--- a/src/_lib/utils/block-schema/split-buy-options.js
+++ b/src/_lib/utils/block-schema/split-buy-options.js
@@ -1,0 +1,66 @@
+/* jscpd:ignore-start */
+import { img, num } from "#utils/block-schema/shared.js";
+import {
+  SPLIT_BASE_DOCS,
+  SPLIT_BASE_FIELDS,
+  str,
+} from "#utils/block-schema/split-shared.js";
+/* jscpd:ignore-end */
+
+export const type = "split-buy-options";
+
+export const fields = {
+  ...SPLIT_BASE_FIELDS,
+  figure_image: {
+    ...img("Product Image"),
+    required: true,
+    description:
+      "Product image path. Processed by `{% image %}` shortcode for responsive srcset + LQIP.",
+  },
+  figure_title: {
+    ...str("Product Title"),
+    required: true,
+    description: "Product name. Schema.org `name`.",
+  },
+  figure_subtitle: {
+    ...str("Product Subtitle"),
+    description: "Optional subtitle, e.g. `Print edition`. Rendered italic.",
+  },
+  figure_price: {
+    ...str("Product Price (display, e.g. £15)"),
+    description:
+      "Display price. Currency symbols are stripped for schema.org `price`.",
+  },
+  figure_currency: {
+    ...str("Product Currency (ISO code, e.g. GBP)"),
+    default: '"GBP"',
+    description: "ISO currency code for schema.org `priceCurrency`.",
+  },
+  figure_link: {
+    ...str("Buy Link"),
+    required: true,
+    description: "Buy URL.",
+  },
+  figure_button_text: {
+    ...str("Buy Button Text"),
+    default: '"Buy now"',
+    description: "Button label.",
+  },
+  figure_heading_level: {
+    ...num("Product Heading Level"),
+    default: "3",
+    description: "Heading level for the product title.",
+  },
+  figure_image_aspect_ratio: {
+    ...str("Product Image Aspect Ratio"),
+    description: 'Aspect ratio, e.g. `"16/9"`, `"1/1"`, `"4/3"`.',
+  },
+};
+
+export const docs = {
+  summary:
+    "Two-column layout with text content and a single buyable product card. Emits schema.org Product microdata.",
+  ...SPLIT_BASE_DOCS,
+  notes:
+    'Figure renders as `<figure itemscope itemtype="https://schema.org/Product">` with the same card markup as each item in the `buy-options` block (shared partial `src/_includes/design-system/buy-option-card.html`). Use this when you have a single buy action to promote alongside text; use `buy-options` for a grid of products.',
+};

--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -234,6 +234,25 @@
   }
 }
 
+// Product card title + price typography. Used by the `.items` grid cards
+// (_items.scss) and the single-card `.buy-option-figure` in the
+// `split-buy-options` block (_buy-options.scss).
+@mixin product-card-typography($heading-selector: "h3") {
+  #{$heading-selector} {
+    @include heading-sm;
+
+    a {
+      @include link-card;
+    }
+  }
+
+  .price {
+    @include body-base;
+    font-weight: 600;
+    color: var(--color-link);
+  }
+}
+
 // FAQ definition list: question/answer pairs
 @mixin faqs-list {
   @include flex-col($space-md);

--- a/src/css/design-system/_buy-options.scss
+++ b/src/css/design-system/_buy-options.scss
@@ -1,23 +1,75 @@
 @use "../variables" as *;
+@use "../mixins" as *;
 
 // =============================================================================
 // BUY OPTIONS
 // =============================================================================
 // Product cards for inline buy-now lists. Builds on `.items` grid styles
 // from _items.scss; this file only adds product-specific tweaks.
+//
+// `.buy-option-figure` is the single-card variant rendered by the
+// `split-buy-options` block inside a `<figure>` on the split layout. It
+// reuses the same per-card styling.
 
 .design-system {
+  @mixin buy-option-card-content {
+    .subtitle {
+      font-style: italic;
+    }
+
+    .price {
+      display: flex;
+      align-items: baseline;
+      gap: $space-xs;
+    }
+  }
+
   ul.items.buy-options {
     > li {
-      .subtitle {
-        font-style: italic;
-      }
+      @include buy-option-card-content;
+    }
+  }
 
-      .price {
-        display: flex;
-        align-items: baseline;
-        gap: $space-xs;
+  .split > figure.buy-option-figure {
+    --buy-option-padding: #{$space-md};
+
+    display: flex;
+    flex-direction: column;
+    gap: $space-sm;
+    padding-bottom: var(--buy-option-padding);
+
+    @include buy-option-card-content;
+
+    > :not(.image-link) {
+      padding-inline: var(--buy-option-padding);
+    }
+
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      @include heading-sm;
+
+      a {
+        @include link-card;
       }
+    }
+
+    .price {
+      @include body-base;
+      font-weight: 600;
+      color: var(--color-link);
+    }
+
+    p.subtitle {
+      @include body-sm;
+      color: var(--color-text-muted);
+    }
+
+    > .button {
+      @include button-primary;
+      margin-block-start: auto;
     }
   }
 }

--- a/src/css/design-system/_buy-options.scss
+++ b/src/css/design-system/_buy-options.scss
@@ -44,23 +44,7 @@
       padding-inline: var(--buy-option-padding);
     }
 
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      @include heading-sm;
-
-      a {
-        @include link-card;
-      }
-    }
-
-    .price {
-      @include body-base;
-      font-weight: 600;
-      color: var(--color-link);
-    }
+    @include product-card-typography("h2, h3, h4, h5, h6");
 
     p.subtitle {
       @include body-sm;

--- a/src/css/design-system/_items.scss
+++ b/src/css/design-system/_items.scss
@@ -125,19 +125,7 @@
       // TEXT CONTENT
       // =======================================================================
 
-      h3 {
-        @include heading-sm;
-
-        a {
-          @include link-card;
-        }
-      }
-
-      .price {
-        @include body-base;
-        font-weight: 600;
-        color: var(--color-link);
-      }
+      @include product-card-typography;
 
       p:not(.price) {
         @include body-sm;

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -218,6 +218,21 @@ blocks:
     figure_subtitle: Let visitors preview themes instantly (in the bottom right)
     figure_variant: gradient
 
+  # Single-product promo (split layout + buy card with schema.org Product)
+  - type: split-buy-options
+    title: Featured Product
+    reveal_content: left
+    content: |
+      A single buy-option promoted alongside explanatory copy — same product
+      card as the `buy-options` grid, but framed as a split hero.
+    figure_image: src/images/breakfast.jpg
+    figure_title: Sample Product
+    figure_subtitle: Limited edition
+    figure_price: "£15"
+    figure_currency: GBP
+    figure_link: https://example.chobble.com
+    figure_button_text: Buy now
+
   # E-Commerce Features (with header, grid--4 layout, custom colors)
   - type: features
 


### PR DESCRIPTION
## Summary

- New `split-buy-options` block: a split layout where the figure side is a single buy-option card (image, title, subtitle, price, buy button) with schema.org Product microdata — the same card as each item in the existing `buy-options` grid, but a single product (not an array).
- Refactored `buy-options.html` to delegate per-card markup to a new shared `buy-option-card.html` partial. The split variant reuses the same partial so the two blocks stay visually and semantically consistent.
- Shared split base fields (`title`, `content`, `button`, `reverse`, `reveal_*`, etc.) are inherited via `SPLIT_BASE_FIELDS`; product-side fields use the `figure_*` prefix (`figure_image`, `figure_title`, `figure_price`, `figure_link`, …) following the convention of the other split variants.
- Added schema registration, `.pages.yml` component + block entry, render-block.html routing, CSS for the single-card figure, a demo usage in `src/pages/chobble-template.md`, and regenerated `BLOCKS_LAYOUT.md`.

## Test plan

- [x] `bun test` — 2583/2583 passing (schema validation, pages-yml sync, BLOCKS_LAYOUT freshness, design-system scoping, etc.)
- [x] `bun run build` — site builds; rendered `<figure itemscope itemtype="https://schema.org/Product">` contains image, title, subtitle, price with Offer microdata, and buy button
- [ ] Visual check in browser for the split layout (content side + product card side, reverse layout, dark variant)

https://claude.ai/code/session_01QWWasgQYGPGNZ9G7oADWNJ