### PR TITLE
Replace features grid_class field with center boolean

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -57,7 +57,7 @@ components:
             required: true
           - { name: style, type: string, label: Custom Style }
       - { name: heading_level, type: number, label: Heading Level }
-      - { name: grid_class, type: string, label: Grid Class }
+      - { name: center, type: boolean, label: Centered }
       - { name: header_intro, type: rich-text, label: Header Intro }
   block_image_cards:
     label: Image Cards

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -77,7 +77,7 @@ Grid of feature cards with optional icons, titles, and descriptions.
 | `items` | array | **required** | Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
 | `heading_level` | number | `3` | Heading level for item titles. |
-| `grid_class` | string | `"features"` | CSS class on the `<ul>`. Options: `"features"` (auto-fit grid), `"grid"` (1/2/3 col), `"grid--4"` (1/2/4 col). Can combine: `"grid--4 text-center"`. |
+| `center` | boolean | `false` | If true, centers feature text. |
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
 | `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
 | `header_class` | string | — | Extra CSS classes on the section header. |

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -28,7 +28,7 @@ const hasTag = (data, tag) => (data.tags || []).includes(tag);
  * @type {Record<string, Record<string, unknown>>}
  */
 const BLOCK_DEFAULTS = {
-  features: { reveal: true, heading_level: 3, grid_class: "features" },
+  features: { reveal: true, heading_level: 3, center: false },
   stats: { reveal: true },
   "split-image": { title_level: 2, reveal_figure: "scale" },
   "split-video": { title_level: 2, reveal_figure: "scale" },

--- a/src/_includes/design-system/features.html
+++ b/src/_includes/design-system/features.html
@@ -13,8 +13,7 @@ Parameters (via block object):
     - style: Optional inline styles (e.g., for custom colors)
   - block.reveal: If true, adds data-reveal animation (default: true)
   - block.heading_level: Heading level for titles, defaults to 3 (h3)
-  - block.grid_class: CSS class for grid container (default: "features")
-               Use "grid--4" for 4-column layout, "grid" for 3-column, etc.
+  - block.center: If true, centers feature text (default: false)
   - block.header_intro: Optional section header intro (rich text, renders section-header before grid)
   - block.header_align: Text alignment for section header (default: "center")
   - block.header_class: Additional CSS classes for section header
@@ -32,17 +31,10 @@ Usage:
 
 {%- assign reveal = block.reveal | default: true -%}
 {%- assign heading_level = block.heading_level | default: 3 -%}
-{%- assign grid_class = block.grid_class | default: "features" -%}
 
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-     intro: block.header_intro,
-     align: block.header_align,
-     header_class: block.header_class
-  -%}
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 
-<ul class="{{ grid_class }}" role="list">
+<ul class="features{% if block.center %} text-center{% endif %}" role="list">
   {%- for item in block.items -%}
   <li>
     <article class="feature"{% if reveal %} data-reveal{% endif %}{% if item.style %} style="{{ item.style }}"{% endif %}>

--- a/src/_lib/utils/block-schema/features.js
+++ b/src/_lib/utils/block-schema/features.js
@@ -1,4 +1,5 @@
 import {
+  bool,
   HEADER_FIELDS,
   HEADING_LEVEL_FIELD,
   md,
@@ -24,11 +25,10 @@ export const fields = {
   },
   reveal: REVEAL_BOOLEAN_FIELD,
   heading_level: HEADING_LEVEL_FIELD,
-  grid_class: {
-    ...str("Grid Class"),
-    default: '"features"',
-    description:
-      'CSS class on the `<ul>`. Options: `"features"` (auto-fit grid), `"grid"` (1/2/3 col), `"grid--4"` (1/2/4 col). Can combine: `"grid--4 text-center"`.',
+  center: {
+    ...bool("Centered"),
+    default: "false",
+    description: "If true, centers feature text.",
   },
   ...HEADER_FIELDS,
 };

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -233,14 +233,14 @@ blocks:
     figure_link: https://example.chobble.com
     figure_button_text: Buy now
 
-  # E-Commerce Features (with header, grid--4 layout, custom colors)
+  # E-Commerce Features (with header, centered, custom colors)
   - type: features
 
     header_intro: |-
       ## Commerce Options
 
       Sell products, take quotes, or both. Card payments and enquiry forms are built in.
-    grid_class: grid--4 text-center
+    center: true
     heading_level: 4
     items:
       - icon: "hugeicons:credit-card"
@@ -279,7 +279,6 @@ blocks:
       ## Built-in SEO
 
       Structured data is generated automatically from your content.
-    grid_class: grid
     heading_level: 4
     items:
       - title: Schema.org Markup

--- a/test/unit/data/eleventy-computed.test.js
+++ b/test/unit/data/eleventy-computed.test.js
@@ -424,7 +424,7 @@ describe("eleventyComputed", () => {
         items: [],
         reveal: true,
         heading_level: 3,
-        grid_class: "features",
+        center: false,
         dark: false,
       });
     });
@@ -544,7 +544,7 @@ describe("eleventyComputed", () => {
       const result = eleventyComputed.blocks(data);
       expect(result[0].reveal).toBe(false);
       expect(result[0].heading_level).toBe(2);
-      expect(result[0].grid_class).toBe("features"); // default still applied
+      expect(result[0].center).toBe(false); // default still applied
     });
 
     test("Explicit dark overrides default false", () => {


### PR DESCRIPTION
## Summary

- Drop the `grid_class` string field from the features block entirely — `.features` auto-fit already handles any item count, and the only real-world override was to center text
- Always render `<ul class="features">`, and add a single `center: boolean` field that applies `.text-center` when true
- Features template now reuses the shared `block-intro.html` partial to avoid duplication with `image-cards.html`

## Test plan

- [x] `bun test` — 2583 pass, 0 fail
- [x] `bun run build` — site builds clean
- [x] Verified output: default features block renders `<ul class="features">`, `center: true` renders `<ul class="features text-center">`

https://claude.ai/code/session_01XohQMaS26txpgqUNoqdLgV