### PR TITLE
Remove border-top from .design-system .section

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -94,7 +94,6 @@
 @mixin section {
   padding-top: var(--section-padding-y);
   padding-bottom: var(--section-padding-y);
-  border-top: 1px solid var(--color-accent);
 }
 
 // Compact section padding override


### PR DESCRIPTION
Removes the 1px solid accent border-top from the `.section` mixin that applies to all sections within `.design-system`.