### PR TITLE
Support Bunny Stream thumbnails on split-video figure_video_id

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -188,6 +188,7 @@ components:
         type: string
         label: Video ID or URL
         required: true
+      - { name: figure_thumbnail_url, type: string, label: Thumbnail URL }
       - { name: figure_alt, type: string, label: Video Alt Text }
       - { name: figure_caption, type: string, label: Video Caption }
   block_split_code:

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -226,7 +226,8 @@ Two-column layout with text content and an embedded video.
 | `reveal_content` | string | `"left"` | `data-reveal` for the text side. Auto-set to `"right"` when `reverse` is true. |
 | `reveal_figure` | string | `"scale"` | `data-reveal` for the figure side. |
 | `button` | object | — | `{text, href, variant}`. Rendered below content. Default variant: `"secondary"`. |
-| `figure_video_id` | string | **required** | YouTube video ID or custom iframe URL. |
+| `figure_video_id` | string | **required** | YouTube video ID or custom iframe URL (e.g. Bunny Stream, Vimeo). |
+| `figure_thumbnail_url` | string | — | Thumbnail image URL shown in the click-to-play facade. Required for non-YouTube URLs (Bunny Stream, Vimeo, etc.); YouTube thumbnails are fetched automatically when this is omitted. |
 | `figure_alt` | string | — | Accessible title for the video iframe. |
 | `figure_caption` | string | — | Visible caption below the video. |
 

--- a/src/_includes/design-system/split.html
+++ b/src/_includes/design-system/split.html
@@ -18,7 +18,8 @@ Parameters (via block object):
 
   Figure fields per block type:
     split-image:        figure_src, figure_alt, figure_caption
-    split-video:        figure_video_id, figure_alt, figure_caption
+    split-video:        figure_video_id, figure_thumbnail_url, figure_alt,
+                        figure_caption
     split-code:         figure_filename, figure_code, figure_language
     split-icon-links:   figure_items (array of {icon, text, url})
     split-html:         figure_html
@@ -45,8 +46,9 @@ Parameters (via block object):
           <figcaption>{{ block.figure_caption }}</figcaption>
         {%- endif -%}
       {%- when "split-video" -%}
-        {%- assign _is_youtube = block.figure_video_id | is_youtube_id -%}
-        {%- if _is_youtube -%}
+        {%- if block.figure_thumbnail_url -%}
+          {%- assign _thumbnail = block.figure_thumbnail_url -%}
+        {%- elsif block.figure_video_id | is_youtube_id -%}
           {%- assign _thumbnail = block.figure_video_id | youtube_thumbnail -%}
         {%- else -%}
           {%- assign _thumbnail = null -%}

--- a/src/_lib/utils/block-schema/split-video.js
+++ b/src/_lib/utils/block-schema/split-video.js
@@ -13,7 +13,13 @@ export const fields = {
   figure_video_id: {
     ...str("Video ID or URL"),
     required: true,
-    description: "YouTube video ID or custom iframe URL.",
+    description:
+      "YouTube video ID or custom iframe URL (e.g. Bunny Stream, Vimeo).",
+  },
+  figure_thumbnail_url: {
+    ...str("Thumbnail URL"),
+    description:
+      "Thumbnail image URL shown in the click-to-play facade. Required for non-YouTube URLs (Bunny Stream, Vimeo, etc.); YouTube thumbnails are fetched automatically when this is omitted.",
   },
   figure_alt: {
     ...str("Video Alt Text"),


### PR DESCRIPTION
## Summary

- Add optional `figure_thumbnail_url` field to the `split-video` block schema, mirroring the `thumbnail_url` pattern that `bunny-video-background` already uses for Bunny Stream URLs.
- Update `split.html` to prefer `figure_thumbnail_url` when provided, falling back to the auto-derived YouTube thumbnail for plain video IDs.
- Regenerate `.pages.yml` and `BLOCKS_LAYOUT.md` from the schema.

Previously, putting a Bunny Stream (or any non-YouTube) iframe URL in `figure_video_id` rendered a bare play button with no preview image because only YouTube IDs had an auto-derived thumbnail. Bunny Stream thumbnails aren't derivable from the embed URL (they live on a per-library pull zone), so the fix mirrors `bunny-video-background` and lets the author provide the thumbnail URL explicitly.

## Test plan

- [x] `bun run test` (lint + typecheck + cpd + build + tests)
- [ ] Manually set a `split-video` block with a Bunny Stream `figure_video_id` and a `figure_thumbnail_url`, confirm the facade shows the thumbnail and clicking it loads the iframe.

https://claude.ai/code/session_01FS6BMRXv4kgHkfPW5i8uUV