### PR TITLE
Limit review height to 300px

### DIFF
--- a/src/css/design-system/_reviews.scss
+++ b/src/css/design-system/_reviews.scss
@@ -42,6 +42,9 @@
     }
 
     .review {
+      max-height: 300px;
+      overflow-y: auto;
+
       p {
         padding-inline: 0 !important;
       }


### PR DESCRIPTION
## Summary

- Added `max-height: 300px` to `.review` elements
- Added `overflow-y: auto` to enable scrolling for longer reviews

This prevents review text from taking up excessive vertical space on the page while still allowing users to read the full content by scrolling.