### PR TITLE
Add socials block with per-instance directory field

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -475,6 +475,25 @@ components:
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }
+  block_socials:
+    label: Socials
+    type: object
+    fields:
+      - { name: dark, type: boolean, label: Dark }
+      - { name: directory, type: string, label: Directory, required: true }
+      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - { name: horizontal, type: boolean, label: Horizontal Slider }
+      - { name: masonry, type: boolean, label: Masonry Grid }
+      - name: filter
+        type: object
+        label: Filter
+        fields:
+          - name: property
+            type: string
+            label: Property (e.g. url, data.title)
+          - { name: includes, type: string, label: Contains }
+          - { name: equals, type: string, label: Equals }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_link_columns:
     label: Link Columns
     type: object
@@ -766,6 +785,7 @@ content:
           - { name: image-background, component: block_image_background }
           - { name: items, component: block_items }
           - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
           - { name: link-columns, component: block_link_columns }
           - { name: contact-form, component: block_contact_form }
           - { name: custom-contact-form, component: block_custom_contact_form }

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -528,6 +528,29 @@ Renders items from an explicit list of paths. The collection is inferred dynamic
 
 ---
 
+### `socials`
+
+Renders social-media posts loaded from a directory of JSON files as a card grid or horizontal slider.
+
+**Component:** `block_socials`
+**Template:** `src/_includes/design-system/socials-block.html`
+**SCSS:** `src/css/design-system/_items.scss`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `directory` | string | **required** | Directory (relative to `src/`) containing social-post JSON files — e.g. `"instagram-posts"` or `"mastodon-posts"`. Each `*.json` file must have `url`, `date`, `title`, and `thumbnail` keys. |
+| `intro` | string | — | Markdown content rendered above items in `.prose`. |
+| `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
+| `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
+| `filter` | object | — | Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value. |
+| `header_intro` | string | — | Section header content rendered as markdown above the block. |
+| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
+| `header_class` | string | — | Extra CSS classes on the section header. |
+
+Posts are loaded per-block from the given directory, so the same template works for Instagram, Mastodon, or any other source. External `url` values open in a new tab.
+
+---
+
 ### `link-columns`
 
 Renders a collection as a plain-text unordered list of links arranged in responsive CSS columns. Optionally strips matching text via a regex so repetitive prefixes/suffixes can be removed.

--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -79,6 +79,9 @@ Renders a single block by type. Used by blocks.html.
   {%- when "items-array" -%}
     {%- include "design-system/items-array-block.html", block: block -%}
 
+  {%- when "socials" -%}
+    {%- include "design-system/socials-block.html", block: block -%}
+
   {%- when "link-columns" -%}
     {%- include "design-system/link-columns.html", block: block -%}
 

--- a/src/_includes/design-system/socials-block.html
+++ b/src/_includes/design-system/socials-block.html
@@ -1,0 +1,16 @@
+{%- comment -%}
+Socials block: renders social-media posts loaded from a directory of JSON files.
+
+Parameters (from block):
+  directory   - Directory under `src/` containing `*.json` post files (e.g. "instagram-posts")
+  intro       - Optional markdown content rendered above the items
+  horizontal  - If true, renders as a horizontal slider
+  masonry     - If true, renders as a masonry grid
+  filter      - Optional object to filter the posts:
+                  property: dot-notation path (e.g. "url", "data.title")
+                  includes: string the property must contain
+                  equals:   exact value the property must match
+{%- endcomment -%}
+
+{%- assign blockItems = block.directory | loadSocials -%}
+{%- include "design-system/render-items-block.html" -%}

--- a/src/_lib/collections/socials.js
+++ b/src/_lib/collections/socials.js
@@ -1,45 +1,42 @@
 /**
- * Socials collection
+ * Socials loader
  *
- * Loads external social-media posts (Instagram, etc.) from JSON files under
- * `src/instagram-posts/` and exposes them as a synthetic Eleventy collection.
- * Items don't render as standalone pages — the `external_url` field links
- * straight out to the source platform when rendered via the items block.
+ * Loads external social-media posts from JSON files in a directory under `src/`.
+ * Items don't render as standalone pages — the `url` field links straight out
+ * to the source platform when rendered via the socials block.
+ *
+ * The directory is supplied per-block by the `socials` block template, so one
+ * site can render posts from multiple sources (instagram, mastodon, etc.).
  *
  * @module #collections/socials
  */
 
 import fs from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { SRC_DIR } from "#lib/paths.js";
+import { memoize } from "#toolkit/fp/memoize.js";
 import { sortByDateDescending } from "#utils/sorting.js";
 
-const SOCIALS_DIR = join(SRC_DIR, "instagram-posts");
-
-const createSocialsCollection = () => {
-  if (!fs.existsSync(SOCIALS_DIR)) return [];
+const loadSocialsFromDirectory = memoize((directory) => {
+  const dir = isAbsolute(directory) ? directory : join(SRC_DIR, directory);
+  if (!fs.existsSync(dir)) return [];
   return fs
-    .readdirSync(SOCIALS_DIR)
+    .readdirSync(dir)
     .filter((f) => f.endsWith(".json"))
     .map((filename) => {
-      const raw = JSON.parse(
-        fs.readFileSync(join(SOCIALS_DIR, filename), "utf8"),
-      );
+      const raw = JSON.parse(fs.readFileSync(join(dir, filename), "utf8"));
       return {
         url: raw.url,
         date: new Date(raw.date),
         fileSlug: filename.replace(/\.json$/, ""),
-        data: {
-          ...raw,
-          tags: ["socials"],
-        },
+        data: { ...raw, tags: ["socials"] },
       };
     })
     .sort(sortByDateDescending);
-};
+});
 
 const configureSocials = (eleventyConfig) => {
-  eleventyConfig.addCollection("socials", createSocialsCollection);
+  eleventyConfig.addFilter("loadSocials", loadSocialsFromDirectory);
 };
 
-export { configureSocials, createSocialsCollection };
+export { configureSocials, loadSocialsFromDirectory };

--- a/src/_lib/collections/socials.js
+++ b/src/_lib/collections/socials.js
@@ -17,7 +17,7 @@ import { SRC_DIR } from "#lib/paths.js";
 import { memoize } from "#toolkit/fp/memoize.js";
 import { sortByDateDescending } from "#utils/sorting.js";
 
-const loadSocialsFromDirectory = memoize((directory) => {
+const loadSocialsFromDirectory = memoize((/** @type {string} */ directory) => {
   const dir = isAbsolute(directory) ? directory : join(SRC_DIR, directory);
   if (!fs.existsSync(dir)) return [];
   return fs

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -43,6 +43,7 @@ import * as reviews from "#utils/block-schema/reviews.js";
 import * as sectionHeader from "#utils/block-schema/section-header.js";
 import { CONTAINER_FIELDS } from "#utils/block-schema/shared.js";
 import * as snippet from "#utils/block-schema/snippet.js";
+import * as socials from "#utils/block-schema/socials.js";
 import * as splitBuyOptions from "#utils/block-schema/split-buy-options.js";
 import * as splitCallout from "#utils/block-schema/split-callout.js";
 import * as splitCode from "#utils/block-schema/split-code.js";
@@ -88,6 +89,7 @@ const BLOCK_MODULES = [
   imageBackground,
   items,
   itemsArray,
+  socials,
   linkColumns,
   contactForm,
   customContactForm,

--- a/src/_lib/utils/block-schema/socials.js
+++ b/src/_lib/utils/block-schema/socials.js
@@ -1,0 +1,21 @@
+import { ITEMS_COMMON_FIELDS, str } from "#utils/block-schema/shared.js";
+
+export const type = "socials";
+
+export const fields = {
+  directory: {
+    ...str("Directory", { required: true }),
+    description:
+      'Directory (relative to `src/`) containing social-post JSON files — e.g. `"instagram-posts"` or `"mastodon-posts"`. Each `*.json` file must have `url`, `date`, `title`, and `thumbnail` keys.',
+  },
+  ...ITEMS_COMMON_FIELDS,
+};
+
+export const docs = {
+  summary:
+    "Renders social-media posts loaded from a directory of JSON files as a card grid or horizontal slider.",
+  template: "src/_includes/design-system/socials-block.html",
+  scss: "src/css/design-system/_items.scss",
+  notes:
+    "Posts are loaded per-block from the given directory, so the same template works for Instagram, Mastodon, or any other source. External `url` values open in a new tab.",
+};

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -117,14 +117,14 @@ blocks:
 
       Display reviews in a masonry grid — cards flow naturally based on content height.
 
-  # Socials - externally-linked items collection
-  - type: items
-    collection: socials
+  # Socials - externally-linked posts loaded from a directory
+  - type: socials
+    directory: instagram-posts
     horizontal: true
     intro: |
       ## From our Socials
 
-      Any collection whose `url` is absolute opens in a new tab — perfect for linking out to Instagram, Mastodon, or wherever you post.
+      Point the block at any directory of JSON posts — `instagram-posts`, `mastodon-posts`, whatever you like. Absolute URLs open in a new tab.
 
   # Stats (via reusable snippet)
   - type: snippet


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `src/instagram-posts/` socials collection with a new `socials` block type that takes a `directory` field.
- Posts are loaded per-block from the given directory, so one site can surface multiple sources (Instagram, Mastodon, etc.) without the loader being tied to Instagram.
- `socials.js` now exposes a memoized `loadSocialsFromDirectory(dir)` loader plus a `loadSocials` Liquid filter. The old global `socials` collection registration is removed.

## Changes

- `src/_lib/collections/socials.js` — expose `loadSocialsFromDirectory` + register `loadSocials` filter (no more global collection).
- `src/_lib/utils/block-schema/socials.js` — new block schema with required `directory` field plus the standard items options (intro, horizontal, masonry, filter, header).
- `src/_includes/design-system/socials-block.html` — template loads posts from `block.directory` and hands off to `render-items-block.html`.
- `src/_lib/utils/block-schema.js` + `src/_includes/design-system/render-block.html` — register the new block type.
- `src/pages/chobble-template.md` — demo page uses `type: socials` with `directory: instagram-posts`.
- `.pages.yml` + `BLOCKS_LAYOUT.md` — regenerated to include the new block.

## Test plan

- [x] `bun run lint` passes
- [x] `bun run test:unit` passes (2490 tests)
- [x] `bun run build` succeeds
- [x] Rendered `_site/index.html` still contains Instagram post links from the demo page
- [ ] Manually verify a second directory (e.g. `mastodon-posts`) renders correctly in a consumer site

https://claude.ai/code/session_01HMn4NofhbQvEiHEZapgv4H