### PR TITLE
Add minimum_rating option to reviews block

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -610,6 +610,7 @@ components:
     fields:
       - { name: dark, type: boolean, label: Dark }
       - { name: current_item, type: boolean, label: Filter to Current Item }
+      - { name: minimum_rating, type: number, label: Minimum Rating }
   block_gallery:
     label: Gallery
     type: object

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -746,8 +746,9 @@ Renders reviews collection with optional filtering to the current item.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `current_item` | boolean | — | If true, filters reviews to the current item by slug and tags. |
+| `minimum_rating` | number | — | If set, only reviews with a rating >= this value are displayed (1–5). |
 
-Uses `getReviewsFor` filter to match reviews by slug and tags when `current_item` is true.
+Uses `getReviewsFor` filter to match reviews by slug and tags when `current_item` is true. Uses `filterByMinRating` filter when `minimum_rating` is set.
 
 ---
 

--- a/src/_includes/design-system/reviews-block.html
+++ b/src/_includes/design-system/reviews-block.html
@@ -2,13 +2,18 @@
 Reviews block: renders reviews collection with optional filtering to current item.
 
 Parameters (from block):
-  current_item  - If true, filters reviews to the current item by slug and tags
+  current_item   - If true, filters reviews to the current item by slug and tags
+  minimum_rating - If set, only shows reviews with rating >= this value
 {%- endcomment -%}
 
 {%- if block.current_item -%}
   {% assign reviews = collections.reviews | getReviewsFor: page.fileSlug, tags %}
 {%- else -%}
   {% assign reviews = collections.reviews %}
+{%- endif -%}
+
+{%- if block.minimum_rating -%}
+  {%- assign reviews = reviews | filterByMinRating: block.minimum_rating -%}
 {%- endif -%}
 
 {%- if reviews.size > 0 -%}

--- a/src/_lib/collections/reviews.js
+++ b/src/_lib/collections/reviews.js
@@ -103,6 +103,19 @@ const getReviewsFor = (reviews, slug, tags) => {
 };
 
 /**
+ * Filter reviews to those at or above a minimum rating.
+ * Reviews without a numeric rating are excluded.
+ *
+ * @param {ReviewCollectionItem[]} reviews - Array of review objects
+ * @param {number} minRating - Minimum rating threshold (inclusive)
+ * @returns {ReviewCollectionItem[]} Reviews with rating >= minRating
+ */
+const filterByMinRating = (reviews, minRating) =>
+  filter(
+    (r) => typeof r.data.rating === "number" && r.data.rating >= minRating,
+  )(reviews);
+
+/**
  * Calculate average rating for reviews matching a specific item.
  * Derives the review field from item tags.
  *
@@ -258,6 +271,7 @@ const reviewsRedirects = (reviewsField, limitOverride) =>
 const configureReviews = (eleventyConfig) => {
   eleventyConfig.addCollection("reviews", createReviewsCollection);
   addDataFilter(eleventyConfig, "getReviewsFor", getReviewsFor);
+  addDataFilter(eleventyConfig, "filterByMinRating", filterByMinRating);
   addDataFilter(eleventyConfig, "getRating", getRating);
   eleventyConfig.addFilter("ratingToStars", (rating) =>
     ratingToStars(rating, config().rating_stars_uses_svg),
@@ -267,6 +281,7 @@ const configureReviews = (eleventyConfig) => {
 
 export {
   configureReviews,
+  filterByMinRating,
   getReviewsFor,
   ratingToStars,
   reviewsRedirects,

--- a/src/_lib/utils/block-schema/reviews.js
+++ b/src/_lib/utils/block-schema/reviews.js
@@ -1,4 +1,4 @@
-import { bool } from "#utils/block-schema/shared.js";
+import { bool, num } from "#utils/block-schema/shared.js";
 
 export const type = "reviews";
 
@@ -8,6 +8,11 @@ export const fields = {
     description:
       "If true, filters reviews to the current item by slug and tags.",
   },
+  minimum_rating: {
+    ...num("Minimum Rating"),
+    description:
+      "If set, only reviews with a rating >= this value are displayed (1–5).",
+  },
 };
 
 export const docs = {
@@ -16,5 +21,5 @@ export const docs = {
   template: "src/_includes/design-system/reviews-block.html",
   scss: "src/css/design-system/_reviews.scss",
   notes:
-    "Uses `getReviewsFor` filter to match reviews by slug and tags when `current_item` is true.",
+    "Uses `getReviewsFor` filter to match reviews by slug and tags when `current_item` is true. Uses `filterByMinRating` filter when `minimum_rating` is set.",
 };

--- a/test/unit/collections/reviews.test.js
+++ b/test/unit/collections/reviews.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   configureReviews,
+  filterByMinRating,
   getReviewsFor,
   ratingToStars,
   reviewsRedirects,
@@ -269,6 +270,39 @@ describe("reviews", () => {
     const result1 = reviewerAvatar("John Smith");
     const result2 = reviewerAvatar("Jane Doe");
     expect(result1 !== result2).toBe(true);
+  });
+
+  test("filterByMinRating returns reviews at or above the minimum rating", () => {
+    const r = revs([
+      ["Review 1", "2024-01-01", { rating: 5 }],
+      ["Review 2", "2024-01-02", { rating: 3 }],
+      ["Review 3", "2024-01-03", { rating: 4 }],
+      ["Review 4", "2024-01-04", { rating: 2 }],
+    ]);
+    expectResultTitles(filterByMinRating(r, 4), ["Review 1", "Review 3"]);
+  });
+
+  test("filterByMinRating excludes reviews without a numeric rating", () => {
+    const r = revs([
+      ["Review 1", "2024-01-01", { rating: 5 }],
+      ["Review 2", "2024-01-02", {}],
+      ["Review 3", "2024-01-03", { rating: null }],
+    ]);
+    expectResultTitles(filterByMinRating(r, 1), ["Review 1"]);
+  });
+
+  test("filterByMinRating returns empty array when no reviews meet minimum", () => {
+    const r = revs([
+      ["Review 1", "2024-01-01", { rating: 3 }],
+      ["Review 2", "2024-01-02", { rating: 2 }],
+    ]);
+    expect(filterByMinRating(r, 5).length).toBe(0);
+  });
+
+  test("filterByMinRating is registered as a Liquid filter", () => {
+    const mockConfig = createMockEleventyConfig();
+    configureReviews(mockConfig);
+    expect(typeof mockConfig.filters.filterByMinRating).toBe("function");
   });
 
   test("Configures reviews collection and filters", () => {


### PR DESCRIPTION
## Summary

- Adds `filterByMinRating(reviews, minRating)` filter to `collections/reviews.js` — excludes reviews without a numeric rating or below the threshold
- Wires the filter into `reviews-block.html` so setting `minimum_rating` on a block hides lower-rated reviews
- Documents the new field in the block schema (`block-schema/reviews.js`)
- Adds 4 unit tests covering threshold filtering, missing ratings, empty results, and filter registration

## Test plan

- [ ] `bun test test/unit/collections/reviews.test.js` — all 28 tests pass
- [ ] Add a reviews block with `minimum_rating: 4` to a page and confirm only 4- and 5-star reviews render
- [ ] Confirm reviews without a rating field are excluded when `minimum_rating` is set
- [ ] Confirm blocks without `minimum_rating` still show all reviews (no regression)

https://claude.ai/code/session_01VEbmg9mTDGLAJBErzVFc2r