### PR TITLE
Sync reviews/features/items-array schemas with their templates

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -56,6 +56,7 @@ components:
             label: Description
             required: true
           - { name: style, type: string, label: Custom Style }
+      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: heading_level, type: number, label: Heading Level }
       - { name: center, type: boolean, label: Centered }
       - { name: header_intro, type: rich-text, label: Header Intro }
@@ -475,6 +476,16 @@ components:
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }
+      - name: filter
+        type: object
+        label: Filter
+        fields:
+          - name: property
+            type: string
+            label: Property (e.g. url, data.title)
+          - { name: includes, type: string, label: Contains }
+          - { name: equals, type: string, label: Equals }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_socials:
     label: Socials
     type: object
@@ -611,6 +622,8 @@ components:
       - { name: dark, type: boolean, label: Dark }
       - { name: current_item, type: boolean, label: Filter to Current Item }
       - { name: minimum_rating, type: number, label: Minimum Rating }
+      - { name: horizontal, type: boolean, label: Horizontal Slider }
+      - { name: masonry, type: boolean, label: Masonry Grid }
   block_gallery:
     label: Gallery
     type: object

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -75,6 +75,7 @@ Grid of feature cards with optional icons, titles, and descriptions.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `items` | array | **required** | Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji. |
+| `intro` | string | — | Markdown content rendered above the grid in `.prose`. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
 | `heading_level` | number | `3` | Heading level for item titles. |
 | `center` | boolean | `false` | If true, centers feature text. |
@@ -525,6 +526,10 @@ Renders items from an explicit list of paths. The collection is inferred dynamic
 | `intro` | string | — | Markdown content rendered above items in `.prose`. |
 | `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
 | `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
+| `filter` | object | — | Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value. |
+| `header_intro` | string | — | Section header content rendered as markdown above the block. |
+| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
+| `header_class` | string | — | Extra CSS classes on the section header. |
 
 ---
 
@@ -747,6 +752,8 @@ Renders reviews collection with optional filtering to the current item.
 |---|---|---|---|
 | `current_item` | boolean | — | If true, filters reviews to the current item by slug and tags. |
 | `minimum_rating` | number | — | If set, only reviews with a rating >= this value are displayed (1–5). |
+| `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
+| `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
 
 Uses `getReviewsFor` filter to match reviews by slug and tags when `current_item` is true. Uses `filterByMinRating` filter when `minimum_rating` is set.
 

--- a/src/_lib/utils/block-schema/features.js
+++ b/src/_lib/utils/block-schema/features.js
@@ -23,6 +23,10 @@ export const fields = {
     description:
       'Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji.',
   },
+  intro: {
+    ...md("Intro Content (Markdown)"),
+    description: "Markdown content rendered above the grid in `.prose`.",
+  },
   reveal: REVEAL_BOOLEAN_FIELD,
   heading_level: HEADING_LEVEL_FIELD,
   center: {

--- a/src/_lib/utils/block-schema/items-array.js
+++ b/src/_lib/utils/block-schema/items-array.js
@@ -13,9 +13,7 @@ export const fields = {
     description:
       "Array of path strings. Each entry may be a file path (e.g. `src/products/widget.md`) or a directory path (e.g. `locations/fulchester` or `locations/fulchester/`), in which case every item in that directory is included in place.",
   },
-  intro: ITEMS_COMMON_FIELDS.intro,
-  horizontal: ITEMS_COMMON_FIELDS.horizontal,
-  masonry: ITEMS_COMMON_FIELDS.masonry,
+  ...ITEMS_COMMON_FIELDS,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/reviews.js
+++ b/src/_lib/utils/block-schema/reviews.js
@@ -1,4 +1,9 @@
-import { bool, num } from "#utils/block-schema/shared.js";
+import {
+  bool,
+  HORIZONTAL_FIELD,
+  MASONRY_FIELD,
+  num,
+} from "#utils/block-schema/shared.js";
 
 export const type = "reviews";
 
@@ -13,6 +18,8 @@ export const fields = {
     description:
       "If set, only reviews with a rating >= this value are displayed (1–5).",
   },
+  horizontal: HORIZONTAL_FIELD,
+  masonry: MASONRY_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -81,24 +81,30 @@ export const HEADER_FIELDS = {
   },
 };
 
+/** Horizontal slider toggle shared between items-like blocks. */
+export const HORIZONTAL_FIELD = {
+  ...bool("Horizontal Slider"),
+  default: "false",
+  description:
+    "If true, renders as a horizontal slider instead of a wrapping grid.",
+};
+
+/** Masonry grid toggle shared between items-like blocks. */
+export const MASONRY_FIELD = {
+  ...bool("Masonry Grid"),
+  default: "false",
+  description:
+    "If true, renders as a masonry grid using uWrap for zero-reflow height prediction.",
+};
+
 /** Unified fields shared between items and items-array blocks. */
 export const ITEMS_COMMON_FIELDS = {
   intro: {
     ...md("Intro Content (Markdown)"),
     description: "Markdown content rendered above items in `.prose`.",
   },
-  horizontal: {
-    ...bool("Horizontal Slider"),
-    default: "false",
-    description:
-      "If true, renders as a horizontal slider instead of a wrapping grid.",
-  },
-  masonry: {
-    ...bool("Masonry Grid"),
-    default: "false",
-    description:
-      "If true, renders as a masonry grid using uWrap for zero-reflow height prediction.",
-  },
+  horizontal: HORIZONTAL_FIELD,
+  masonry: MASONRY_FIELD,
   filter: {
     ...FILTER_FIELD,
     description:

--- a/test/unit/utils/block-schema-template-sync.test.js
+++ b/test/unit/utils/block-schema-template-sync.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { rootDir } from "#test/test-utils.js";
+import { BLOCK_DOCS, BLOCK_SCHEMAS } from "#utils/block-schema.js";
+
+// Keys the outer wrapper in blocks.html injects onto every block, plus `type`
+// which is always present as the discriminant.
+const ALWAYS_ALLOWED_KEYS = ["dark", "type"];
+
+const INCLUDES_DIR = join(rootDir, "src/_includes");
+const INCLUDE_PATTERN = /\{%-?\s*include\s+"([^"]+)"([\s\S]*?)-?%\}/g;
+const BLOCK_REF_PATTERN = /\bblock\.([a-zA-Z_][a-zA-Z0-9_]*)/g;
+
+/** An include inherits the caller's `block` variable only when it either
+ *  passes no arguments or explicitly threads `block: block`. Includes that
+ *  rebind variables (e.g. `intro: block.header_intro`) hand the partial a
+ *  local-scoped context, so any `block.X` refs inside the partial belong to
+ *  the partial's own schema, not the caller's. */
+const includeInheritsBlock = (argsText) => {
+  const trimmed = argsText.trim();
+  if (trimmed === "") return true;
+  return /\bblock\s*:\s*block\b/.test(trimmed);
+};
+
+const COMMENT_BLOCK =
+  /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}/g;
+const INCLUDE_PATH = /(\{%-?\s*include\s+)"[^"]+"/g;
+
+/** Strip comments (usage examples reference fields unrelated to the block,
+ *  e.g. `block.figure_items` in an "embed me like this" snippet) and include
+ *  path strings (`"render-items-block.html"` would otherwise regex-match as
+ *  `block.html`). Args passed to an include, like `horizontal: block.horizontal`,
+ *  are preserved so we still see them as references. */
+const stripNonCode = (source) =>
+  source.replace(COMMENT_BLOCK, "").replace(INCLUDE_PATH, "$1");
+
+/** Recursively read a template and every static include that still shares the
+ *  caller's block scope. Returns the concatenated source (with comments and
+ *  string literals stripped) so callers can regex over the lot. */
+const readWithIncludes = (absPath, visited = new Set()) => {
+  if (visited.has(absPath) || !existsSync(absPath)) return "";
+  visited.add(absPath);
+  const rawContent = readFileSync(absPath, "utf-8");
+  const childSources = [...rawContent.matchAll(INCLUDE_PATTERN)]
+    .filter((m) => includeInheritsBlock(m[2]))
+    .map((m) => readWithIncludes(join(INCLUDES_DIR, m[1]), visited));
+  return [stripNonCode(rawContent), ...childSources].join("\n");
+};
+
+const collectBlockRefs = (templatePath) => {
+  const combined = readWithIncludes(join(rootDir, templatePath));
+  return new Set([...combined.matchAll(BLOCK_REF_PATTERN)].map((m) => m[1]));
+};
+
+/** Multiple block types (e.g. all split-* variants) can share one template.
+ *  Group them so the allowed-keys set is the union across the group. */
+const groupBlockTypesByTemplate = () =>
+  Object.entries(
+    Object.groupBy(
+      Object.entries(BLOCK_DOCS).filter(([, docs]) => docs.template),
+      ([, docs]) => docs.template,
+    ),
+  ).map(([template, entries]) => [template, entries.map(([type]) => type)]);
+
+const unionSchemaFields = (blockTypes) =>
+  new Set(blockTypes.flatMap((type) => BLOCK_SCHEMAS[type]));
+
+describe("template ↔ block schema sync", () => {
+  for (const [templatePath, blockTypes] of groupBlockTypesByTemplate()) {
+    const label = blockTypes.join(", ");
+    const refs = collectBlockRefs(templatePath);
+    const schemaFields = unionSchemaFields(blockTypes);
+
+    test(`${templatePath}: every block.<field> in the template is declared in the schema (${label})`, () => {
+      const undeclared = [...refs]
+        .filter((k) => !schemaFields.has(k) && !ALWAYS_ALLOWED_KEYS.includes(k))
+        .sort();
+      expect(undeclared).toEqual([]);
+    });
+
+    test(`${templatePath}: every schema field is used somewhere in the template (${label})`, () => {
+      const unused = [...schemaFields].filter((f) => !refs.has(f)).sort();
+      expect(unused).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes the `Block type "reviews" has unknown keys: "horizontal"` build error on client sites. PR #1326 wired `horizontal`/`masonry` into `reviews-block.html` but forgot the matching schema entries, so the block validator rejected valid pages.
- Adds a new test (`test/unit/utils/block-schema-template-sync.test.js`) that walks each block's template plus any scope-sharing includes and asserts every `block.<field>` reference is declared in the schema, and every schema field is referenced in the template.
- That test surfaced two pre-existing drifts between schema and template: `features` referenced `block.intro` (via `block-intro.html`) without declaring it, and `items-array` referenced `block.filter` / `block.header_*` (via `render-items-block.html` → `block-intro.html`) without declaring them. Both schemas have been updated and `.pages.yml` / `BLOCKS_LAYOUT.md` regenerated.

## Test plan

- [x] `bun test` — 2706 pass, 0 fail
- [x] `bun run lint`
- [x] `bun run precommit`
- [x] New sync test fails on `main` for the reviews gap (verified before the schema fix)

https://claude.ai/code/session_01Awh6454oPBEAwxGBZ6nzqL