### PR TITLE
Add page-path CSS class to body tag

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 {% include "head.html" %}
-<body class="{{ layout | getBodyClasses: config, body-classes, featured }}">
+<body class="{{ layout | getBodyClasses: config, body-classes, featured, page.url }}">
   {%- include "body-scripts.html" -%}
   {%- include "header.html" -%}
   <main>

--- a/src/_layouts/design-system-base.html
+++ b/src/_layouts/design-system-base.html
@@ -20,7 +20,7 @@
 
   {%- include "head-scripts.html" -%}
 </head>
-<body class="design-system {{ layout | getBodyClasses: config, body-classes, featured }}">
+<body class="design-system {{ layout | getBodyClasses: config, body-classes, featured, page.url }}">
   {%- include "body-scripts.html" -%}
   {%- unless no_navigation -%}
     {%- include "navigation.html" -%}

--- a/src/_lib/eleventy/style-bundle.js
+++ b/src/_lib/eleventy/style-bundle.js
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { slugify } from "#utils/slug-utils.js";
 
 const usesDesignSystem = (layout, designSystemLayouts) =>
   designSystemLayouts.includes(layout);
@@ -21,10 +22,27 @@ const detectRightContent = () =>
   fs.existsSync(path.join(process.cwd(), RIGHT_CONTENT_PATH));
 
 /**
+ * Build a page-path CSS class from a URL.
+ *
+ * "/"                          -> "page--home"
+ * "/about-us/"                 -> "page--about-us"
+ * "/products/example-product/" -> "page--products--example-product"
+ *
+ * @param {string} pageUrl
+ * @returns {string|null}
+ */
+const getPagePathClass = (pageUrl) => {
+  if (typeof pageUrl !== "string") return null;
+  const segments = pageUrl.split("/").filter(Boolean).map(slugify);
+  const suffix = segments.length === 0 ? "home" : segments.join("--");
+  return `page--${suffix}`;
+};
+
+/**
  * Generates body CSS classes based on layout and site config.
  *
  * Called from Liquid templates as:
- *   layout | getBodyClasses: config, extraClasses, featured
+ *   layout | getBodyClasses: config, extraClasses, featured, page.url
  *
  * hasRightContent is auto-detected from the filesystem.
  * design-system class is handled directly in the template.
@@ -33,15 +51,23 @@ const detectRightContent = () =>
  * @param {Object} siteConfig - The site config object (snake_case keys)
  * @param {string[]} [extraClasses] - Additional classes from theme body_classes
  * @param {boolean} [featured] - Whether the current page is featured
+ * @param {string} [pageUrl] - The current page URL (page.url)
  * @returns {string}
  */
-const getBodyClasses = (layout, siteConfig, extraClasses, featured) => {
+const getBodyClasses = (
+  layout,
+  siteConfig,
+  extraClasses,
+  featured,
+  pageUrl,
+) => {
   const classes = [
     layout.replace(".html", ""),
     siteConfig.sticky_mobile_nav ? "sticky-mobile-nav" : null,
     siteConfig.horizontal_nav !== false ? "horizontal-nav" : "left-nav",
     detectRightContent() ? "two-columns" : "one-column",
     featured ? "featured" : null,
+    getPagePathClass(pageUrl),
     ...(Array.isArray(extraClasses) ? extraClasses : []),
   ];
 

--- a/src/_lib/eleventy/style-bundle.js
+++ b/src/_lib/eleventy/style-bundle.js
@@ -33,7 +33,10 @@ const detectRightContent = () =>
  */
 const getPagePathClass = (pageUrl) => {
   if (typeof pageUrl !== "string") return null;
-  const segments = pageUrl.split("/").filter(Boolean).map(slugify);
+  const segments = pageUrl
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => slugify(segment));
   const suffix = segments.length === 0 ? "home" : segments.join("--");
   return `page--${suffix}`;
 };

--- a/test/unit/eleventy/style-bundle.test.js
+++ b/test/unit/eleventy/style-bundle.test.js
@@ -139,6 +139,49 @@ describe("style-bundle", () => {
       const result = getBodyClasses("item.html", baseConfig, [], false);
       expect(result).not.toContain("featured");
     });
+
+    test("adds page--home class for root URL", () => {
+      const result = getBodyClasses("base.html", baseConfig, [], false, "/");
+      expect(result).toContain("page--home");
+    });
+
+    test("adds single-segment page class", () => {
+      const result = getBodyClasses(
+        "base.html",
+        baseConfig,
+        [],
+        false,
+        "/about-us/",
+      );
+      expect(result).toContain("page--about-us");
+    });
+
+    test("joins multi-segment paths with double dashes", () => {
+      const result = getBodyClasses(
+        "item.html",
+        baseConfig,
+        [],
+        false,
+        "/products/example-product/",
+      );
+      expect(result).toContain("page--products--example-product");
+    });
+
+    test("slugifies unusual characters in path segments", () => {
+      const result = getBodyClasses(
+        "base.html",
+        baseConfig,
+        [],
+        false,
+        "/Foo Bar/Baz!/",
+      );
+      expect(result).toContain("page--foo-bar--baz");
+    });
+
+    test("does not add page class when pageUrl is missing", () => {
+      const result = getBodyClasses("base.html", baseConfig);
+      expect(result).not.toContain("page--");
+    });
   });
 
   describe("configureStyleBundle", () => {


### PR DESCRIPTION
## Summary

- `getBodyClasses` now accepts `page.url` and appends a slugified page-path class so per-page styling is possible.
- Examples: `/` → `page--home`, `/about-us/` → `page--about-us`, `/products/example-product/` → `page--products--example-product`.
- Both `base.html` and `design-system-base.html` now pass `page.url` to the filter.

## Test plan

- [x] `bun test test/unit/eleventy/style-bundle.test.js` — new cases cover home, single-segment, multi-segment, unusual characters, and missing URL.
- [x] `bun run test:unit` — full unit suite (2536 pass).
- [x] `bun run build` — verified output: `_site/index.html` has `page--home`, product pages have e.g. `page--products--pocket-doodah-mini`.
