### PR TITLE
Sort link-columns block items by title

### DIFF
--- a/src/_includes/design-system/link-columns.html
+++ b/src/_includes/design-system/link-columns.html
@@ -19,7 +19,7 @@ Parameters (from block):
 {%- if block.filter -%}
   {%- assign linkItems = linkItems | filterItems: block.filter -%}
 {%- endif -%}
-{%- assign linkItems = linkItems | sort: "data.title" -%}
+{%- assign linkItems = linkItems | sortItems -%}
 
 {%- if linkItems.size > 0 -%}
 <ul class="link-columns" role="list">

--- a/src/_includes/design-system/link-columns.html
+++ b/src/_includes/design-system/link-columns.html
@@ -19,6 +19,7 @@ Parameters (from block):
 {%- if block.filter -%}
   {%- assign linkItems = linkItems | filterItems: block.filter -%}
 {%- endif -%}
+{%- assign linkItems = linkItems | sort: "data.title" -%}
 
 {%- if linkItems.size > 0 -%}
 <ul class="link-columns" role="list">

--- a/src/_lib/eleventy/collection-filter.js
+++ b/src/_lib/eleventy/collection-filter.js
@@ -1,6 +1,8 @@
 import { filterItems } from "#utils/collection-filter.js";
+import { sortItems } from "#utils/sorting.js";
 
 /** @param {*} eleventyConfig */
 export const configureCollectionFilter = (eleventyConfig) => {
   eleventyConfig.addFilter("filterItems", filterItems);
+  eleventyConfig.addFilter("sortItems", (items) => [...items].sort(sortItems));
 };


### PR DESCRIPTION
## Summary
- Sort the items rendered by the `link-columns` block alphabetically by `data.title`, so the link list appears in a predictable order rather than collection order.

## Test plan
- [x] `bun run build` succeeds
- [x] `bun run lint` passes
- [x] `bun run test:unit` passes (2598 tests)
- [ ] Visually verify a page using a `link-columns` block renders links A→Z

https://claude.ai/code/session_019WAeVa7vKvgV7t2giah3tA