### PR TITLE
Strict types for src/_lib/utils/thumbnail-finder.js

### DIFF
--- a/scripts/strict-typecheck-ratchet.js
+++ b/scripts/strict-typecheck-ratchet.js
@@ -14,7 +14,7 @@ import { spawnSync } from "node:child_process";
 import { ROOT_DIR } from "#lib/paths.js";
 
 // Current baseline - lower this as you fix errors
-const CURRENT_ERROR_COUNT = 395;
+const CURRENT_ERROR_COUNT = 390;
 
 // Files that currently pass strict mode (must not regress)
 const STRICT_CLEAN_FILES = [
@@ -53,6 +53,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/build/theme-compiler.js",
   "src/_lib/collections/guides.js",
   "src/_lib/collections/tags.js",
+  "src/_lib/collections/thumbnail-resolvers.js",
   "src/_lib/config/helpers.js",
   "src/_lib/config/list-config.js",
   "src/_lib/config/site-config.js",
@@ -91,6 +92,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/utils/product-cart-data.js",
   "src/_lib/utils/slug-utils.js",
   "src/_lib/utils/sorting.js",
+  "src/_lib/utils/thumbnail-finder.js",
   "src/_lib/utils/video.js",
   "src/categories/categories.11tydata.js",
   "src/events/events.11tydata.js",

--- a/src/_lib/collections/thumbnail-resolvers.js
+++ b/src/_lib/collections/thumbnail-resolvers.js
@@ -9,7 +9,7 @@ import { findFirst, findFromChildren } from "#utils/thumbnail-finder.js";
 /**
  * Create a recursive thumbnail resolver that walks child items.
  *
- * @template {{fileSlug: string}} T
+ * @template {{fileSlug: string, data?: {order?: number}}} T
  * @param {object} options
  * @param {Map<string, T[]>} options.childrenByParent
  * @param {(item: T) => string | null | undefined} options.getOwnThumbnail
@@ -23,13 +23,14 @@ const createChildThumbnailResolver = ({
   getFallbackThumbnail,
   getKey = (item) => item.fileSlug,
 }) => {
+  /**
+   * @param {T} item
+   * @returns {string | undefined}
+   */
   const resolve = (item) =>
     findFirst(
       () => getOwnThumbnail(item),
-      () =>
-        findFromChildren(childrenByParent.get(getKey(item)), (child) =>
-          resolve(child),
-        ),
+      () => findFromChildren(childrenByParent.get(getKey(item)), resolve),
       () => (getFallbackThumbnail ? getFallbackThumbnail(item) : undefined),
     );
 

--- a/src/_lib/utils/thumbnail-finder.js
+++ b/src/_lib/utils/thumbnail-finder.js
@@ -11,23 +11,33 @@
 import { sortBy } from "#toolkit/fp/array.js";
 
 /**
- * Standard order extraction for items with data.order.
- * @param {{data?: {order?: number}}} item
- * @returns {number | undefined}
+ * @typedef {{ data?: { order?: number } }} OrderedItem
  */
-const getItemOrder = (item) => item?.data?.order;
+
+/**
+ * Default order extractor used when callers don't supply one.
+ * Assumes the item has the standard Eleventy `data.order` shape;
+ * missing orders sort as 0.
+ *
+ * @param {OrderedItem} item
+ * @returns {number}
+ */
+const defaultOrder = (item) => {
+  const order = item?.data?.order;
+  return typeof order === "number" ? order : 0;
+};
 
 /**
  * Generator that yields items sorted by order, lazily.
  * For small lists just sorts eagerly (overhead of lazy approach not worth it).
  * For larger lists, the consumer can stop iteration early.
  *
- * @template T
- * @param {T[]} items - Items to sort and yield
+ * @template {OrderedItem} T
+ * @param {T[] | null | undefined} items - Items to sort and yield
  * @param {(item: T) => number} [getOrder] - Order extraction function
- * @yields {T} Items in sorted order
+ * @returns {Generator<T>}
  */
-function* yieldSorted(items, getOrder = getItemOrder) {
+function* yieldSorted(items, getOrder = defaultOrder) {
   if (!items?.length) return;
   yield* sortBy(getOrder)(items);
 }
@@ -39,7 +49,7 @@ function* yieldSorted(items, getOrder = getItemOrder) {
  *
  * @template T
  * @param {Array<() => T | null | undefined>} sources - Thunks returning values
- * @yields {T} First non-null value (if any)
+ * @returns {Generator<T>}
  *
  * @example
  * // Lazy evaluation - only calls sources until one returns a value
@@ -92,13 +102,13 @@ const findFirst = (...sources) => first(yieldFromSources(sources));
  * Generator that yields thumbnails from sorted children.
  * Searches children in order, yielding the first valid thumbnail found.
  *
- * @template T
- * @param {T[]} children - Child items to search
+ * @template {OrderedItem} T
+ * @param {T[] | null | undefined} children - Child items to search
  * @param {(item: T) => string | null | undefined} getThumbnail - Extract thumbnail
  * @param {(item: T) => number} [getOrder] - Extract sort order
- * @yields {string} First valid thumbnail (if any)
+ * @returns {Generator<string>}
  */
-function* yieldFromChildren(children, getThumbnail, getOrder = getItemOrder) {
+function* yieldFromChildren(children, getThumbnail, getOrder = defaultOrder) {
   for (const child of yieldSorted(children, getOrder)) {
     const thumbnail = getThumbnail(child);
     if (thumbnail != null) {
@@ -112,8 +122,8 @@ function* yieldFromChildren(children, getThumbnail, getOrder = getItemOrder) {
  * Find the first thumbnail from sorted children.
  * Children are sorted by order, then searched lazily.
  *
- * @template T
- * @param {T[]} children - Child items to search
+ * @template {OrderedItem} T
+ * @param {T[] | null | undefined} children - Child items to search
  * @param {(item: T) => string | null | undefined} getThumbnail - Extract thumbnail
  * @param {(item: T) => number} [getOrder] - Extract sort order
  * @returns {string | undefined} First thumbnail found
@@ -125,7 +135,7 @@ function* yieldFromChildren(children, getThumbnail, getOrder = getItemOrder) {
  *   (child) => child.data.order ?? 0
  * );
  */
-const findFromChildren = (children, getThumbnail, getOrder = getItemOrder) =>
+const findFromChildren = (children, getThumbnail, getOrder = defaultOrder) =>
   first(yieldFromChildren(children, getThumbnail, getOrder));
 
 export { findFirst, findFromChildren };

--- a/test/unit/collections/thumbnail-resolvers.test.js
+++ b/test/unit/collections/thumbnail-resolvers.test.js
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { createChildThumbnailResolver } from "#collections/thumbnail-resolvers.js";
+
+/** Node factory: fileSlug is the default lookup key and thumbnail is optional. */
+const node = (fileSlug, thumbnail, order = 0) => ({
+  fileSlug,
+  thumbnail,
+  data: { order },
+});
+
+/** Build a childrenByParent Map from an adjacency record. */
+const childrenMap = (adjacency) => new Map(Object.entries(adjacency));
+
+const getOwnThumbnail = (n) => n.thumbnail;
+
+describe("createChildThumbnailResolver", () => {
+  test("returns the item's own thumbnail when present", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: new Map(),
+      getOwnThumbnail,
+    });
+    expect(resolve(node("root", "own"))).toBe("own");
+  });
+
+  test("falls back to a direct child's thumbnail when own is missing", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: childrenMap({ root: [node("child", "child-thumb")] }),
+      getOwnThumbnail,
+    });
+    expect(resolve(node("root"))).toBe("child-thumb");
+  });
+
+  test("recurses into grandchildren when intermediate nodes have no thumbnail", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: childrenMap({
+        root: [node("mid")],
+        mid: [node("leaf", "deep-thumb")],
+      }),
+      getOwnThumbnail,
+    });
+    expect(resolve(node("root"))).toBe("deep-thumb");
+  });
+
+  test("picks the lowest-order child when siblings have thumbnails", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: childrenMap({
+        root: [node("b", "thumb-b", 2), node("a", "thumb-a", 1)],
+      }),
+      getOwnThumbnail,
+    });
+    expect(resolve(node("root"))).toBe("thumb-a");
+  });
+
+  test("uses a descendant's fallback before bubbling back to the root's fallback", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: childrenMap({ root: [node("child")] }),
+      getOwnThumbnail,
+      getFallbackThumbnail: (n) => `fallback-${n.fileSlug}`,
+    });
+    expect(resolve(node("root"))).toBe("fallback-child");
+  });
+
+  test("uses the root's own fallback only when no descendants exist", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: new Map(),
+      getOwnThumbnail,
+      getFallbackThumbnail: (n) => `fallback-${n.fileSlug}`,
+    });
+    expect(resolve(node("root"))).toBe("fallback-root");
+  });
+
+  test("returns undefined when nothing in the tree provides a thumbnail", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: childrenMap({ root: [node("child")] }),
+      getOwnThumbnail,
+      getFallbackThumbnail: () => undefined,
+    });
+    expect(resolve(node("root"))).toBeUndefined();
+  });
+
+  test("returns undefined when there are no children and no fallback is supplied", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: new Map(),
+      getOwnThumbnail,
+    });
+    expect(resolve(node("root"))).toBeUndefined();
+  });
+
+  test("uses a caller-supplied getKey to look up children", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: childrenMap({
+        root: [{ slug: "child", thumbnail: "keyed-thumb" }],
+      }),
+      getOwnThumbnail,
+      getKey: (n) => n.slug,
+    });
+    expect(resolve({ slug: "root", thumbnail: undefined })).toBe("keyed-thumb");
+  });
+
+  test("searches sibling branches until a descendant yields a thumbnail", () => {
+    const resolve = createChildThumbnailResolver({
+      childrenByParent: childrenMap({
+        root: [node("left", undefined, 1), node("right", undefined, 2)],
+        left: [node("left-child")],
+        right: [node("right-child", "found-via-right")],
+      }),
+      getOwnThumbnail,
+    });
+    expect(resolve(node("root"))).toBe("found-via-right");
+  });
+});

--- a/test/unit/utils/thumbnail-finder.test.js
+++ b/test/unit/utils/thumbnail-finder.test.js
@@ -1,217 +1,105 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+import { item } from "#test/test-utils.js";
 import { findFirst, findFromChildren } from "#utils/thumbnail-finder.js";
 
-// ============================================
-// Test Data Factories
-// ============================================
+/** Shorthand for creating an orderable item with an optional thumbnail. */
+const orderedItem = (order, thumbnail) => item(null, { order, thumbnail });
 
-/**
- * Create a mock item with data.order and optional thumbnail
- */
-const mockItem = (order, thumbnail = undefined) => ({
-  data: { order, thumbnail },
-  fileSlug: `item-${order}`,
-});
-
-/**
- * Create a list of items with specified order and thumbnail
- */
-const mockItems = (...specs) =>
-  specs.map(([order, thumbnail]) => mockItem(order, thumbnail));
-
-// ============================================
-// findFirst Tests
-// ============================================
-
-describe("thumbnail-finder", () => {
-  describe("findFirst", () => {
-    test("returns first non-null value from sources", () => {
-      const result = findFirst(
-        () => null,
-        () => "found",
-        () => "ignored",
-      );
-
-      expect(result).toBe("found");
-    });
-
-    test("returns undefined when all sources are null", () => {
-      const result = findFirst(
-        () => null,
-        () => undefined,
-      );
-
-      expect(result).toBeUndefined();
-    });
-
-    test("works with single source", () => {
-      expect(findFirst(() => "only")).toBe("only");
-      expect(findFirst(() => null)).toBeUndefined();
-    });
-
-    test("evaluates lazily - skips later sources after finding value", () => {
-      const evaluated = { value: false };
-      findFirst(
-        () => "found",
-        () => {
-          evaluated.value = true;
-          return "never";
-        },
-      );
-
-      expect(evaluated.value).toBe(false);
-    });
-
-    test("handles falsy but non-null values (0, empty string)", () => {
-      expect(
-        findFirst(
-          () => 0,
-          () => "fallback",
-        ),
-      ).toBe(0);
-      expect(
-        findFirst(
-          () => "",
-          () => "fallback",
-        ),
-      ).toBe("");
-    });
+describe("findFirst", () => {
+  test("returns first non-null value from sources", () => {
+    const result = findFirst(
+      () => null,
+      () => "found",
+      () => "ignored",
+    );
+    expect(result).toBe("found");
   });
 
-  // ============================================
-  // findFromChildren Tests
-  // ============================================
+  test("returns undefined when every source yields null or undefined", () => {
+    expect(
+      findFirst(
+        () => null,
+        () => undefined,
+      ),
+    ).toBeUndefined();
+  });
 
-  describe("findFromChildren", () => {
-    test("finds thumbnail from first child in sort order", () => {
-      const children = mockItems([3, "thumb-3"], [1, "thumb-1"], [2]);
+  test("returns undefined when called with no sources", () => {
+    expect(findFirst()).toBeUndefined();
+  });
 
-      const result = findFromChildren(children, (c) => c.data.thumbnail);
+  test("stops evaluating sources once one resolves to a value", () => {
+    const laterSource = mock(() => "never");
+    findFirst(() => "found", laterSource);
+    expect(laterSource).not.toHaveBeenCalled();
+  });
 
-      expect(result).toBe("thumb-1"); // Order 1 comes first
-    });
+  test.each([
+    { label: "zero", value: 0 },
+    { label: "empty string", value: "" },
+    { label: "false", value: false },
+  ])("treats $label as a valid value (not a fallback trigger)", ({ value }) => {
+    expect(
+      findFirst(
+        () => value,
+        () => "fallback",
+      ),
+    ).toBe(value);
+  });
+});
 
-    test("skips children without thumbnails", () => {
-      const children = mockItems([1], [2, "thumb-2"], [3]);
+describe("findFromChildren", () => {
+  test("returns the thumbnail from the lowest-order child", () => {
+    const children = [
+      orderedItem(3, "thumb-3"),
+      orderedItem(1, "thumb-1"),
+      orderedItem(2, "thumb-2"),
+    ];
+    expect(findFromChildren(children, (c) => c.data.thumbnail)).toBe("thumb-1");
+  });
 
-      const result = findFromChildren(children, (c) => c.data.thumbnail);
+  test("skips children with no thumbnail and returns the next one in order", () => {
+    const children = [
+      orderedItem(1, undefined),
+      orderedItem(2, "thumb-2"),
+      orderedItem(3, "thumb-3"),
+    ];
+    expect(findFromChildren(children, (c) => c.data.thumbnail)).toBe("thumb-2");
+  });
 
-      expect(result).toBe("thumb-2");
-    });
+  test("returns undefined when no child has a thumbnail", () => {
+    const children = [orderedItem(1), orderedItem(2), orderedItem(3)];
+    expect(findFromChildren(children, (c) => c.data.thumbnail)).toBeUndefined();
+  });
 
-    test("returns undefined when no children have thumbnails", () => {
-      const children = mockItems([1], [2], [3]);
+  test.each([
+    { label: "null", value: null },
+    { label: "undefined", value: undefined },
+    { label: "empty array", value: [] },
+  ])("returns undefined for $label children", ({ value }) => {
+    expect(findFromChildren(value, (c) => c.data.thumbnail)).toBeUndefined();
+  });
 
-      const result = findFromChildren(children, (c) => c.data.thumbnail);
-
-      expect(result).toBeUndefined();
-    });
-
-    test("returns undefined for null/empty children", () => {
-      expect(findFromChildren(null, (c) => c.data.thumbnail)).toBeUndefined();
-      expect(findFromChildren([], (c) => c.data.thumbnail)).toBeUndefined();
-      expect(
-        findFromChildren(undefined, (c) => c.data.thumbnail),
-      ).toBeUndefined();
-    });
-
-    test("uses custom order function", () => {
-      const children = [
-        { priority: 10, thumb: "thumb-10" },
-        { priority: 5, thumb: "thumb-5" },
-      ];
-
-      const result = findFromChildren(
+  test("uses the caller-supplied order function when provided", () => {
+    const children = [
+      { priority: 10, thumb: "thumb-10" },
+      { priority: 5, thumb: "thumb-5" },
+    ];
+    expect(
+      findFromChildren(
         children,
         (c) => c.thumb,
         (c) => c.priority,
-      );
-
-      expect(result).toBe("thumb-5"); // Lower priority comes first
-    });
-
-    test("items with order 0 sort before items with higher order", () => {
-      const children = [
-        { data: { order: 5, thumbnail: "thumb-5" } },
-        { data: { order: 0, thumbnail: "thumb-0" } },
-        { data: { order: 2, thumbnail: "thumb-2" } },
-      ];
-
-      const result = findFromChildren(children, (c) => c.data.thumbnail);
-
-      expect(result).toBe("thumb-0"); // Order 0 comes first
-    });
+      ),
+    ).toBe("thumb-5");
   });
 
-  // ============================================
-  // Integration Tests
-  // ============================================
-
-  describe("integration patterns", () => {
-    test("own thumbnail first, then children fallback", () => {
-      const children = mockItems([1, "child-thumb"]);
-      const getThumbnail = () => "own-thumb";
-
-      const result = findFirst(getThumbnail, () =>
-        findFromChildren(children, (c) => c.data.thumbnail),
-      );
-
-      expect(result).toBe("own-thumb");
-    });
-
-    test("falls back to children when no own thumbnail", () => {
-      const children = mockItems([1, "child-thumb"]);
-
-      const result = findFirst(
-        () => undefined,
-        () => findFromChildren(children, (c) => c.data.thumbnail),
-      );
-
-      expect(result).toBe("child-thumb");
-    });
-
-    test("recursive pattern via nested findFirst calls", () => {
-      // Simulate: parent -> child -> grandchild
-      const grandchild = mockItem(1, "grandchild-thumb");
-      const child = { data: { order: 1 }, children: [grandchild] };
-      const parent = { data: { order: 1 }, children: [child] };
-
-      // Build a recursive resolver using findFirst composition
-      const resolveThumbnail = (item) =>
-        findFirst(
-          () => item.data?.thumbnail,
-          () => findFromChildren(item.children, resolveThumbnail),
-        );
-
-      expect(resolveThumbnail(parent)).toBe("grandchild-thumb");
-    });
-
-    test("prefers earlier children in sort order", () => {
-      const child1 = mockItem(2, "child-2-thumb");
-      const child2 = mockItem(1, "child-1-thumb");
-      const parent = { data: { order: 1 }, children: [child1, child2] };
-
-      const result = findFirst(
-        () => parent.data.thumbnail,
-        () => findFromChildren(parent.children, (c) => c.data.thumbnail),
-      );
-
-      expect(result).toBe("child-1-thumb");
-    });
-
-    test("lookup table pattern with child fallback", () => {
-      const lookup = { "cat-a": "thumb-a", "cat-b": "thumb-b" };
-      const children = [mockItem(2), mockItem(1)];
-      children[0].fileSlug = "cat-x";
-      children[1].fileSlug = "cat-b";
-
-      // Lookup direct, then fall back to children
-      const result = findFirst(
-        () => lookup["cat-missing"],
-        () => findFromChildren(children, (c) => lookup[c.fileSlug]),
-      );
-
-      expect(result).toBe("thumb-b");
-    });
+  test("treats order 0 as lower than any positive order", () => {
+    const children = [
+      orderedItem(5, "thumb-5"),
+      orderedItem(0, "thumb-0"),
+      orderedItem(2, "thumb-2"),
+    ];
+    expect(findFromChildren(children, (c) => c.data.thumbnail)).toBe("thumb-0");
   });
 });


### PR DESCRIPTION
## Summary

Makes `src/_lib/utils/thumbnail-finder.js` pass `tsc --strict` and adds it (plus its main consumer `src/_lib/collections/thumbnail-resolvers.js`) to `STRICT_CLEAN_FILES`. Takes `CURRENT_ERROR_COUNT` from 395 → 390.

Along the way, the tests for both files were rewritten to focus on observable behaviour.

## Type fixes

- Introduce an `OrderedItem` typedef (`{ data?: { order?: number } }`) in `thumbnail-finder.js` and use it as the generic constraint on `yieldSorted` / `yieldFromChildren` / `findFromChildren`. The default order extractor now has a concrete `(item: OrderedItem) => number` signature and coerces a missing order to `0` via `typeof … === "number"` — no `??`, no casts, no `any`.
- Tighten the generic constraint on `createChildThumbnailResolver` to `{ fileSlug: string, data?: { order?: number } }` so it lines up with the tighter `findFromChildren` signature. All existing production callers (categories, locations) already satisfy this.
- Add a `@param` / `@returns` JSDoc block on the recursive `resolve` function so its return type is inferred instead of leaking `any` into `findFirst`. Avoids inline `@type` casts (which the code-quality check bans).

## Test changes

- Rewrote `test/unit/utils/thumbnail-finder.test.js`:
  - Reuse the shared `item` factory from `test-utils` instead of a bespoke `mockItem`.
  - Replace the `let`-based "lazy evaluation" assertion with a `mock` spy that asserts the later source was never called (no mutable local state).
  - Parameterise the falsy-but-not-nullish cases (`0`, `""`, `false`) and the empty-children cases (`null`, `undefined`, `[]`) with `test.each`.
  - Remove the "integration patterns" block — its tests either duplicated simpler assertions or reimplemented the real resolver logic inline.
- New `test/unit/collections/thumbnail-resolvers.test.js` covers `createChildThumbnailResolver` directly (previously untested): own vs. child vs. fallback precedence, recursion across sibling branches, the custom `getKey` path, and the subtle detail that a descendant's fallback fires before the root's.

## Compromises

- The `OrderedItem` constraint is slightly narrower than the previous unconstrained `T` — callers that don't pass a custom `getOrder` must now have a `data.order` property. Every real call site already does; the test that used a `{ priority, thumb }` shape for custom `getOrder` still works because the caller provides its own extractor.

## Test plan

- [x] `bun run precommit` passes
- [x] `bun test test/unit/utils/thumbnail-finder.test.js test/unit/collections/thumbnail-resolvers.test.js` — 25 pass
- [x] `bun run scripts/strict-typecheck-ratchet.js` — 390 errors, 89 clean files

https://claude.ai/code/session_01Tyvb43TXWxX3mVgRwPHu4K