### PR TITLE
Collect all config validation errors before throwing

### DIFF
--- a/src/_lib/config/validated-config.js
+++ b/src/_lib/config/validated-config.js
@@ -17,6 +17,13 @@ import { PAGES_DIR } from "#lib/paths.js";
 const VALID_CART_MODES = ["stripe", "quote"];
 const VALID_PRODUCT_MODES = ["buy", "hire"];
 
+/**
+ * @param {string | null | undefined} value
+ * @param {readonly string[]} validValues
+ * @param {string} field
+ * @param {string} defaultNote
+ * @returns {string[]}
+ */
 const validateEnum = (value, validValues, field, defaultNote) => {
   if (!value || validValues.includes(value)) return [];
   return [

--- a/src/_lib/config/validated-config.js
+++ b/src/_lib/config/validated-config.js
@@ -1,9 +1,9 @@
 /**
  * Centralized configuration validation.
  *
- * All validation runs at module load time - errors indicate misconfiguration.
- * This file is excluded from coverage because validation branches only execute
- * when config files are invalid, which can't happen during normal test runs.
+ * All validation runs at module load time. Errors are collected from every
+ * validator before throwing so users see every problem at once rather than
+ * discovering them one build failure at a time.
  *
  * Exports validated values for use by other modules.
  */
@@ -14,49 +14,15 @@ import configData from "#data/config.json" with { type: "json" };
 import site from "#data/site.json" with { type: "json" };
 import { PAGES_DIR } from "#lib/paths.js";
 
-if (!site.url) {
-  throw new Error("site.json is missing the 'url' field");
-}
-
-if (site.url.endsWith("/")) {
-  throw new Error(`site.json 'url' must not end with a slash: ${site.url}`);
-}
-
-const parsedUrl = new URL(site.url);
-if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-  throw new Error(
-    `site.json 'url' must use http or https protocol, got: ${site.url}`,
-  );
-}
-
-export const siteUrl = site.url;
-
-if (
-  configData.currency &&
-  !Intl.supportedValuesOf("currency").includes(configData.currency)
-) {
-  throw new Error(
-    `Invalid currency: "${configData.currency}". Must be a valid ISO 4217 currency code (e.g. "GBP", "USD", "EUR").`,
-  );
-}
-
 const VALID_CART_MODES = ["stripe", "quote"];
 const VALID_PRODUCT_MODES = ["buy", "hire"];
 
-if (
-  configData.product_mode &&
-  !VALID_PRODUCT_MODES.includes(configData.product_mode)
-) {
-  throw new Error(
-    `Invalid product_mode: "${configData.product_mode}". Must be one of: ${VALID_PRODUCT_MODES.join(", ")}, or null/omitted for default (buy).`,
-  );
-}
-
-if (configData.cart_mode && !VALID_CART_MODES.includes(configData.cart_mode)) {
-  throw new Error(
-    `Invalid cart_mode: "${configData.cart_mode}". Must be one of: ${VALID_CART_MODES.join(", ")}, or null/omitted for no cart.`,
-  );
-}
+const validateEnum = (value, validValues, field, defaultNote) => {
+  if (!value || validValues.includes(value)) return [];
+  return [
+    `Invalid ${field}: "${value}". Must be one of: ${validValues.join(", ")}, or ${defaultNote}.`,
+  ];
+};
 
 const cartModeError = (cartMode, filename, issue) =>
   `cart_mode is "${cartMode}" but src/pages/${filename} ${issue}`;
@@ -67,66 +33,127 @@ const validatePageFrontmatter = (filename, layout, permalink, cartMode) => {
     : path.join(PAGES_DIR, filename);
 
   if (!fs.existsSync(pagePath)) {
-    throw new Error(cartModeError(cartMode, filename, "does not exist"));
+    return [cartModeError(cartMode, filename, "does not exist")];
   }
 
   const { data } = matter.read(pagePath);
   if (Object.keys(data).length === 0) {
-    throw new Error(cartModeError(cartMode, filename, "has no frontmatter"));
+    return [cartModeError(cartMode, filename, "has no frontmatter")];
   }
 
-  if (data.layout !== layout) {
-    throw new Error(
-      cartModeError(cartMode, filename, `does not have layout: ${layout}`),
-    );
-  }
-
-  if (data.permalink !== permalink) {
-    throw new Error(
-      cartModeError(
-        cartMode,
-        filename,
-        `does not have permalink: ${permalink}`,
-      ),
-    );
-  }
+  const layoutErrors =
+    data.layout !== layout
+      ? [cartModeError(cartMode, filename, `does not have layout: ${layout}`)]
+      : [];
+  const permalinkErrors =
+    data.permalink !== permalink
+      ? [
+          cartModeError(
+            cartMode,
+            filename,
+            `does not have permalink: ${permalink}`,
+          ),
+        ]
+      : [];
+  return [...layoutErrors, ...permalinkErrors];
 };
 
-if (configData.cart_mode === "stripe") {
-  if (!configData.ecommerce_api_host) {
-    throw new Error(
-      'cart_mode is "stripe" but ecommerce_api_host is not set in config.json',
-    );
-  }
-  validatePageFrontmatter(
-    "stripe-checkout.md",
-    "stripe-checkout.html",
-    "/stripe-checkout/",
-    "stripe",
-  );
-  validatePageFrontmatter(
-    "order-complete.md",
-    "checkout-complete.html",
-    "/order-complete/",
-    "stripe",
-  );
+const siteUrlProtocolErrors = !site.url
+  ? []
+  : !URL.canParse(site.url)
+    ? [`site.json 'url' is not a valid URL: ${site.url}`]
+    : ["http:", "https:"].includes(new URL(site.url).protocol)
+      ? []
+      : [`site.json 'url' must use http or https protocol, got: ${site.url}`];
+
+const siteUrlErrors = !site.url
+  ? ["site.json is missing the 'url' field"]
+  : [
+      ...(site.url.endsWith("/")
+        ? [`site.json 'url' must not end with a slash: ${site.url}`]
+        : []),
+      ...siteUrlProtocolErrors,
+    ];
+
+const currencyErrors =
+  !configData.currency ||
+  Intl.supportedValuesOf("currency").includes(configData.currency)
+    ? []
+    : [
+        `Invalid currency: "${configData.currency}". Must be a valid ISO 4217 currency code (e.g. "GBP", "USD", "EUR").`,
+      ];
+
+const stripeCartErrors =
+  configData.cart_mode !== "stripe"
+    ? []
+    : [
+        ...(configData.ecommerce_api_host
+          ? []
+          : [
+              'cart_mode is "stripe" but ecommerce_api_host is not set in config.json',
+            ]),
+        ...validatePageFrontmatter(
+          "stripe-checkout.md",
+          "stripe-checkout.html",
+          "/stripe-checkout/",
+          "stripe",
+        ),
+        ...validatePageFrontmatter(
+          "order-complete.md",
+          "checkout-complete.html",
+          "/order-complete/",
+          "stripe",
+        ),
+      ];
+
+const quoteFormTarget =
+  configData.contact_form_target ||
+  (configData.formspark_id &&
+    `https://submit-form.com/${configData.formspark_id}`);
+
+const quoteCartErrors =
+  configData.cart_mode !== "quote"
+    ? []
+    : [
+        ...(quoteFormTarget
+          ? []
+          : [
+              'cart_mode is "quote" but neither formspark_id nor contact_form_target is set in config.json',
+            ]),
+        ...validatePageFrontmatter(
+          "checkout.md",
+          "quote-checkout.html",
+          "/checkout/",
+          "quote",
+        ),
+      ];
+
+const errors = [
+  ...siteUrlErrors,
+  ...currencyErrors,
+  ...validateEnum(
+    configData.product_mode,
+    VALID_PRODUCT_MODES,
+    "product_mode",
+    "null/omitted for default (buy)",
+  ),
+  ...validateEnum(
+    configData.cart_mode,
+    VALID_CART_MODES,
+    "cart_mode",
+    "null/omitted for no cart",
+  ),
+  ...stripeCartErrors,
+  ...quoteCartErrors,
+];
+
+if (errors.length > 0) {
+  const heading =
+    errors.length === 1
+      ? "Configuration error:"
+      : `Configuration errors (${errors.length}):`;
+  const body = errors.map((msg, i) => `  ${i + 1}. ${msg}`).join("\n");
+  throw new Error(`${heading}\n${body}`);
 }
 
-if (configData.cart_mode === "quote") {
-  const formTarget =
-    configData.contact_form_target ||
-    (configData.formspark_id &&
-      `https://submit-form.com/${configData.formspark_id}`);
-
-  if (!formTarget) {
-    throw new Error(
-      'cart_mode is "quote" but neither formspark_id nor contact_form_target is set in config.json',
-    );
-  }
-  validatePageFrontmatter(
-    "checkout.md",
-    "quote-checkout.html",
-    "/checkout/",
-    "quote",
-  );
-}
+export const siteUrl = site.url;


### PR DESCRIPTION
## Summary
- `validated-config.js` used to throw on the first misconfiguration it found, so fixing a broken config meant rebuild → fix → rebuild → fix for every issue.
- Each validator now returns an array of error messages. All results are aggregated and a single `Error` listing every problem is thrown (numbered, with a `Configuration errors (N):` heading), so every issue is visible up front.
- The errors array is empty when config is valid, so a passing build is unchanged.

## Example output with a broken config

```
Configuration errors (5):
  1. site.json 'url' must not end with a slash: bad-url/
  2. site.json 'url' is not a valid URL: bad-url/
  3. Invalid currency: "XYZ". Must be a valid ISO 4217 currency code (e.g. "GBP", "USD", "EUR").
  4. Invalid product_mode: "nope". Must be one of: buy, hire, or null/omitted for default (buy).
  5. cart_mode is "quote" but neither formspark_id nor contact_form_target is set in config.json
```

## Test plan
- [x] `bun run lint` — passes
- [x] `bun run build` — passes with current valid config
- [x] `bun run test:unit` — 2609/2609 pass
- [x] Manually broke config in multiple ways → single error block lists all 5 problems at once
- [x] Single-error case still renders `Configuration error:` heading (singular)

https://claude.ai/code/session_01FqxUdFHHx25sKDa8Mm5HDU