### PR TITLE
Reduce review card max-height to 160px

### DIFF
--- a/src/css/design-system/_reviews.scss
+++ b/src/css/design-system/_reviews.scss
@@ -42,7 +42,7 @@
     }
 
     .review {
-      max-height: 300px;
+      max-height: 160px;
       overflow-y: auto;
 
       p {


### PR DESCRIPTION
## Summary
- Set `.design-system .reviews-grid .review` `max-height` from 300px to 160px in `src/css/design-system/_reviews.scss`.

## Test plan
- [ ] Visually confirm review cards in the design system reviews grid are capped at 160px and scroll overflow behaves as expected.
