### PR TITLE
Catch bad block field shapes before markdown-it does

### DIFF
--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -8,7 +8,9 @@
  *   - optionally `containerWidth` ("full" | "narrow"; defaults to "wide")
  *
  * This file aggregates them into:
- *   - `BLOCK_SCHEMAS`    — allowed keys per type (for validation)
+ *   - `BLOCK_SCHEMAS`    — field definitions per type, used for both
+ *     allowed-key checks and runtime value-shape validation. Indexed by
+ *     block type; each entry maps field name → `{ type, list?, ... }`.
  *   - `BLOCK_CMS_FIELDS` — CMS field definitions (for .pages.yml generation)
  *   - `BLOCK_DOCS`       — documentation (for BLOCKS_LAYOUT.md generation)
  */
@@ -54,12 +56,6 @@ import * as splitImage from "#utils/block-schema/split-image.js";
 import * as splitVideo from "#utils/block-schema/split-video.js";
 import * as stats from "#utils/block-schema/stats.js";
 import * as videoBackground from "#utils/block-schema/video-background.js";
-
-/**
- * Common wrapper keys allowed on all block types.
- * These are used by blocks.html to wrap blocks in sections/containers.
- */
-const COMMON_BLOCK_KEYS = ["dark"];
 
 /**
  * Iteration order determines the order that `scripts/generate-blocks-reference.js`
@@ -127,7 +123,7 @@ const DOC_TYPE_MAP = {
   reference: "string",
 };
 
-const BLOCK_SCHEMAS = indexByType((m) => Object.keys(m.fields));
+const BLOCK_SCHEMAS = indexByType((m) => m.fields);
 
 /** @type {Record<string, "full" | "wide" | "narrow">} */
 const BLOCK_CONTAINER_WIDTHS = indexByType((m) =>
@@ -181,34 +177,97 @@ const assert = (condition, message) => {
  * @typedef {Record<string, unknown>} Block
  */
 
+/** @param {string} t @returns {(v: unknown) => boolean} */
+const isTypeof = (t) => (v) => typeof v === t;
+
+/**
+ * Per-field-type runtime checks. `image` stores a path string;
+ * `reference` stores a collection item slug; `markdown` stores markdown
+ * source text passed to markdown-it — all plain strings at runtime.
+ * @type {Record<string, { label: string, check: (v: unknown) => boolean }>}
+ */
+const FIELD_TYPE_CHECKS = {
+  string: { label: "a string", check: isTypeof("string") },
+  markdown: { label: "a string", check: isTypeof("string") },
+  image: { label: "a string", check: isTypeof("string") },
+  reference: { label: "a string", check: isTypeof("string") },
+  number: { label: "a number", check: isTypeof("number") },
+  boolean: { label: "a boolean", check: isTypeof("boolean") },
+  object: {
+    label: "an object",
+    check: (v) => typeof v === "object" && v !== null && !Array.isArray(v),
+  },
+};
+
+const LIST_CHECK = { label: "an array", check: Array.isArray };
+
+/** Field types for wrapper keys (e.g. `dark`) accepted on every block. */
+const COMMON_FIELD_TYPES = {
+  dark: { type: "boolean" },
+};
+
+/**
+ * Converts a `{type, list?}` field definition to its runtime type-check
+ * spec, or `undefined` if the type has no known check.
+ */
+const specEntries = (defs) =>
+  Object.entries(defs).map(([k, d]) => [
+    k,
+    d.list ? LIST_CHECK : FIELD_TYPE_CHECKS[d.type],
+  ]);
+
+const COMMON_SPEC_ENTRIES = specEntries(COMMON_FIELD_TYPES);
+
+/**
+ * Pre-computed per-block lookup of `fieldName -> { label, check }`. Built
+ * once at module load so `validateBlock` can do a straight dictionary
+ * lookup per field instead of branching on `type` + `list` at runtime.
+ *
+ * @type {Record<string, Record<string, { label: string, check: (v: unknown) => boolean }>>}
+ */
+const BLOCK_FIELD_SPECS = Object.fromEntries(
+  Object.entries(BLOCK_SCHEMAS).map(([blockType, fieldDefs]) => [
+    blockType,
+    Object.fromEntries([...specEntries(fieldDefs), ...COMMON_SPEC_ENTRIES]),
+  ]),
+);
+
 /**
  * Validates a single block against its schema.
- * Throws an error if the block contains unknown keys or unknown type.
+ * Throws an error if the block contains unknown keys or unknown type, or
+ * if any field value does not match its declared shape.
  *
  * @param {Block} block - Block to validate
  * @param {string} ctx - Context suffix for error messages
- * @throws {Error} If the block contains unknown keys or invalid type
+ * @throws {Error} If the block fails any validation check
  */
 const validateBlock = (block, ctx) => {
   assert(
-    typeof block.type === "string" && block.type.length > 0,
+    typeof block.type === "string",
     `Block is missing required "type" field${ctx}`,
   );
-
-  const allowedKeys = BLOCK_SCHEMAS[block.type];
+  const specs = BLOCK_FIELD_SPECS[block.type];
   assert(
-    allowedKeys,
-    `Unknown block type "${block.type}"${ctx}. Valid types: ${Object.keys(BLOCK_SCHEMAS).join(", ")}`,
+    specs,
+    `Unknown block type "${block.type}"${ctx}. Valid types: ${Object.keys(BLOCK_FIELD_SPECS).join(", ")}`,
   );
-
-  const allAllowed = [...allowedKeys, ...COMMON_BLOCK_KEYS];
-  const unknown = Object.keys(block).filter(
-    (k) => k !== "type" && !allAllowed.includes(k),
-  );
+  const allowedKeys = [...Object.keys(specs), "type"];
+  const unknown = Object.keys(block).filter((k) => !allowedKeys.includes(k));
   assert(
     unknown.length === 0,
-    `Block type "${block.type}" has unknown keys: ${quoteJoin(unknown)}${ctx}. Allowed keys: ${quoteJoin(allAllowed)}`,
+    `Block type "${block.type}" has unknown keys: ${quoteJoin(unknown)}${ctx}. Allowed keys: ${quoteJoin(Object.keys(specs))}`,
   );
+
+  for (const [key, value] of Object.entries(block)) {
+    const spec = specs[key];
+    const skip =
+      !spec || value === undefined || value === null || spec.check(value);
+    if (skip) continue;
+    const actual = Array.isArray(value) ? "array" : typeof value;
+    throw new Error(
+      `Block "${block.type}" field "${key}" must be ${spec.label} but got ${actual}${ctx}`,
+    );
+  }
 };
 
 /**

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -207,8 +207,11 @@ const COMMON_FIELD_TYPES = {
 };
 
 /**
- * Converts a `{type, list?}` field definition to its runtime type-check
- * spec, or `undefined` if the type has no known check.
+ * Converts a `{type, list?}` field definition map to `[key, spec]` pairs
+ * for constructing a per-block lookup table. The returned spec is
+ * `undefined` when the declared type has no known runtime check.
+ *
+ * @param {object} defs
  */
 const specEntries = (defs) =>
   Object.entries(defs).map(([k, d]) => [

--- a/test/unit/utils/block-schema-template-sync.test.js
+++ b/test/unit/utils/block-schema-template-sync.test.js
@@ -64,7 +64,7 @@ const groupBlockTypesByTemplate = () =>
   ).map(([template, entries]) => [template, entries.map(([type]) => type)]);
 
 const unionSchemaFields = (blockTypes) =>
-  new Set(blockTypes.flatMap((type) => BLOCK_SCHEMAS[type]));
+  new Set(blockTypes.flatMap((type) => Object.keys(BLOCK_SCHEMAS[type])));
 
 describe("template ↔ block schema sync", () => {
   for (const [templatePath, blockTypes] of groupBlockTypesByTemplate()) {

--- a/test/unit/utils/block-schema.test.js
+++ b/test/unit/utils/block-schema.test.js
@@ -21,10 +21,20 @@ describe("validateBlocks accepts every schema-declared key", () => {
   // Data-driven replacement for the per-block "allows all valid keys for X"
   // tests. If a block schema drops a legitimate key, the corresponding
   // test case here will fail and name the block.
-  for (const [blockType, allowedKeys] of Object.entries(BLOCK_SCHEMAS)) {
+  const sampleValueFor = (fieldDef) => {
+    if (fieldDef.list) return [];
+    if (fieldDef.type === "number") return 1;
+    if (fieldDef.type === "boolean") return true;
+    if (fieldDef.type === "object") return {};
+    return "test-value";
+  };
+
+  for (const [blockType, fieldDefs] of Object.entries(BLOCK_SCHEMAS)) {
     test(`${blockType}: block with every schema key validates`, () => {
       const block = { type: blockType };
-      for (const key of allowedKeys) block[key] = "test-value";
+      for (const [key, fieldDef] of Object.entries(fieldDefs)) {
+        block[key] = sampleValueFor(fieldDef);
+      }
       expect(() => validateBlocks([block])).not.toThrow();
     });
   }
@@ -50,7 +60,7 @@ describe("validateBlocks error handling", () => {
     // Blocks like "content" and "properties" have an empty schema.
     // Pick one dynamically so the test doesn't break if the list changes.
     const emptySchemaType = Object.entries(BLOCK_SCHEMAS).find(
-      ([, keys]) => keys.length === 0,
+      ([, fields]) => Object.keys(fields).length === 0,
     )?.[0];
     expect(emptySchemaType).toBeDefined();
     expect(() => validateBlocks([{ type: emptySchemaType }])).not.toThrow();
@@ -126,6 +136,99 @@ describe("validateBlocks error handling", () => {
     expect(() => validateBlocks(blocks)).toThrow(
       'unknown keys: "section_class"',
     );
+  });
+});
+
+describe("validateBlocks field-type validation", () => {
+  // These tests lock in the fix for a cryptic "Input data should be a
+  // String" markdown-it failure that surfaced when a contact-form block's
+  // `content` was authored as a nested structure instead of a plain
+  // string. The validator now catches the bad shape up front and names
+  // the offending block, field, and file.
+
+  test("rejects a markdown field authored as an array", () => {
+    const blocks = [{ type: "contact-form", content: ["a", "b"] }];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'Block "contact-form" field "content" must be a string but got array',
+    );
+  });
+
+  test("rejects a markdown field authored as an object", () => {
+    const blocks = [{ type: "contact-form", content: { text: "hi" } }];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'Block "contact-form" field "content" must be a string but got object',
+    );
+  });
+
+  test("rejects a string field authored as a number", () => {
+    const blocks = [{ type: "link-button", text: 42, href: "/x" }];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'Block "link-button" field "text" must be a string but got number',
+    );
+  });
+
+  test("rejects a number field authored as a string", () => {
+    const blocks = [
+      {
+        type: "iframe-embed",
+        src: "https://example.com",
+        title: "Demo",
+        width: "560",
+      },
+    ];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'Block "iframe-embed" field "width" must be a number but got string',
+    );
+  });
+
+  test("rejects a boolean field authored as a string", () => {
+    const blocks = [{ type: "reviews", current_item: "yes" }];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'Block "reviews" field "current_item" must be a boolean but got string',
+    );
+  });
+
+  test("rejects a list field authored as a scalar", () => {
+    const blocks = [{ type: "downloads", items: "oops" }];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'Block "downloads" field "items" must be an array but got string',
+    );
+  });
+
+  test("rejects an object field authored as an array", () => {
+    const blocks = [
+      { type: "cta", title: "Hi", button: [{ text: "x", href: "/" }] },
+    ];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'Block "cta" field "button" must be an object but got array',
+    );
+  });
+
+  test("rejects dark field authored as a non-boolean", () => {
+    const blocks = [{ type: "section-header", intro: "x", dark: "true" }];
+    expect(() => validateBlocks(blocks)).toThrow(
+      'Block "section-header" field "dark" must be a boolean but got string',
+    );
+  });
+
+  test("allows null to mean 'omitted'", () => {
+    const blocks = [{ type: "contact-form", content: null }];
+    expect(() => validateBlocks(blocks)).not.toThrow();
+  });
+
+  test("field-type error includes the file context", () => {
+    const blocks = [{ type: "contact-form", content: ["a"] }];
+    expect(() => validateBlocks(blocks, " in src/products/widget.md")).toThrow(
+      "in src/products/widget.md",
+    );
+  });
+
+  test("field-type error reports the block index", () => {
+    const blocks = [
+      { type: "section-header", intro: "x" },
+      { type: "contact-form", content: { bad: true } },
+    ];
+    expect(() => validateBlocks(blocks)).toThrow("block 2");
   });
 });
 


### PR DESCRIPTION
## Summary

- A client build blew up with `Input data should be a String` from inside markdown-it, via `contact-form-block.html`. The actual cause was a `contact-form` block whose `content` field had been authored as a nested structure instead of a plain string, but the error named the template rather than the markdown file, so the authoring mistake was hard to find.
- `validateBlock` already rejected unknown keys and types; it now also checks each field's value against the declared `{type, list}` in its schema module. Bad shapes now throw up-front with the block type, field name, expected vs. got, and the input path passed in by `eleventyComputed.blocks`.
- To support the lookup cheaply, block schemas are pre-compiled once at module load into `BLOCK_FIELD_SPECS` (block → field → `{label, check}`), so the per-field check is a dictionary lookup rather than branching on `type`.

Example error now:
```
Block "contact-form" field "content" must be a string but got array (block 2 in ./src/products/audio-guestbook-hire.md)
```

## Test plan
- [x] `bun test test/unit/utils/block-schema.test.js` — 147 pass, including new `validateBlocks field-type validation` group covering string/markdown/number/boolean/list/object/dark violations, null-as-omitted, file path context, and block index reporting.
- [x] `bun run test:unit` — 2620 pass, 0 fail.
- [x] `bun run lint:fix` — clean.
- [x] `bun run build` — builds the template site.

https://claude.ai/code/session_015bBeyuSxaeU27aGGUPHrnq