### PR TITLE
Add product-only add-to-cart block type

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -727,6 +727,11 @@ components:
       - { name: title, type: string, label: Title, required: true }
       - { name: image, type: image, label: Image }
       - { name: body, type: rich-text, label: Body, required: true }
+  block_add_to_cart:
+    label: Add To Cart
+    type: object
+    fields:
+      - { name: dark, type: boolean, label: Dark }
   products_list:
     label: Products
     type: object
@@ -893,6 +898,54 @@ content:
               - { name: name, type: string, label: Name, required: true }
               - { name: price, type: number, label: Price, required: true }
       - { name: tabs, component: tabs }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: add-to-cart, component: block_add_to_cart }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: categories
     label: Categories
     path: src/categories
@@ -924,6 +977,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: news
     label: News
     path: src/news
@@ -949,6 +1049,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: events
     label: Events
     path: src/events
@@ -989,6 +1136,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: team
     label: Team
     path: src/team
@@ -1006,6 +1200,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: reviews
     label: Reviews
     path: src/reviews
@@ -1030,6 +1271,53 @@ content:
       - { name: permalink, type: string, label: Permalink }
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: locations
     label: Locations
     path: src/locations
@@ -1065,6 +1353,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: properties
     label: Properties
     path: src/properties
@@ -1111,6 +1446,53 @@ content:
       - { name: gallery, component: gallery }
       - { name: specs, component: specs }
       - { name: tabs, component: tabs }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: guide-categories
     label: Guide Categories
     path: src/guide-categories
@@ -1134,6 +1516,53 @@ content:
       - { name: permalink, type: string, label: Permalink }
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: guide-pages
     label: Guide Pages
     path: src/guide-pages
@@ -1157,6 +1586,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: menus
     label: Menus
     path: src/menus
@@ -1175,6 +1651,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: menu-categories
     label: Menu Categories
     path: src/menu-categories
@@ -1199,6 +1722,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: menu-items
     label: Menu Items
     path: src/menu-items
@@ -1226,6 +1796,53 @@ content:
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
       - { name: gallery, component: gallery }
+      - name: blocks
+        label: Content Blocks
+        type: block
+        list: true
+        blockKey: type
+        blocks:
+          - { name: section-header, component: block_section_header }
+          - { name: features, component: block_features }
+          - { name: image-cards, component: block_image_cards }
+          - { name: buy-options, component: block_buy_options }
+          - { name: stats, component: block_stats }
+          - { name: code-block, component: block_code_block }
+          - { name: hero, component: block_hero }
+          - { name: split-image, component: block_split_image }
+          - { name: split-video, component: block_split_video }
+          - { name: split-code, component: block_split_code }
+          - { name: split-icon-links, component: block_split_icon_links }
+          - { name: split-html, component: block_split_html }
+          - { name: split-callout, component: block_split_callout }
+          - { name: split-buy-options, component: block_split_buy_options }
+          - { name: split-full, component: block_split_full }
+          - { name: cta, component: block_cta }
+          - { name: callout, component: block_callout }
+          - { name: video-background, component: block_video_background }
+          - name: bunny-video-background
+            component: block_bunny_video_background
+          - { name: image-background, component: block_image_background }
+          - { name: items, component: block_items }
+          - { name: items-array, component: block_items_array }
+          - { name: socials, component: block_socials }
+          - { name: link-columns, component: block_link_columns }
+          - { name: contact-form, component: block_contact_form }
+          - { name: custom-contact-form, component: block_custom_contact_form }
+          - { name: markdown, component: block_markdown }
+          - { name: html, component: block_html }
+          - { name: iframe-embed, component: block_iframe_embed }
+          - { name: content, component: block_content }
+          - { name: include, component: block_include }
+          - { name: properties, component: block_properties }
+          - { name: guide-categories, component: block_guide_categories }
+          - { name: link-button, component: block_link_button }
+          - { name: reviews, component: block_reviews }
+          - { name: gallery, component: block_gallery }
+          - { name: marquee-images, component: block_marquee_images }
+          - { name: icon-links, component: block_icon_links }
+          - { name: downloads, component: block_downloads }
+          - { name: snippet, component: block_snippet }
   - name: snippets
     label: Snippets
     path: src/snippets

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -129,6 +129,17 @@ Each item renders as a `<li>` with `itemscope itemtype="https://schema.org/Produ
 
 ---
 
+### `add-to-cart`
+
+Renders the current product's add-to-cart button, reusing the same controls shown in the product options area.
+
+**Component:** `block_add_to_cart`
+**Template:** `src/_includes/design-system/add-to-cart-block.html`
+
+Product-only block. Reads `cart_attributes`, `options`, `product_mode`, `has_single_cart_option`, and `show_cart_quantity_selector` from the product's computed data and delegates rendering to `product-options.html`. Renders nothing when `config.cart_mode` is disabled or the page has no cart attributes.
+
+---
+
 ### `stats`
 
 Key metrics displayed as large numbers with labels.

--- a/scripts/customise-cms/collection-config.js
+++ b/scripts/customise-cms/collection-config.js
@@ -32,7 +32,7 @@ import {
   buildReviewsFields,
 } from "#scripts/customise-cms/item-builders.js";
 import { compact, filter, memberOf } from "#toolkit/fp/array.js";
-import { BLOCK_CMS_FIELDS } from "#utils/block-schema.js";
+import { BLOCK_CMS_FIELDS, isBlockAllowedIn } from "#utils/block-schema.js";
 
 /**
  * @typedef {import('./generator-helpers.js').CmsConfig} CmsConfig
@@ -107,6 +107,9 @@ const addOptionalFields = (
 
   const collection = getCollection(collectionName);
   const alreadyHasBlocks = collectionName === "pages";
+  const allowedBlockTypes = Object.keys(BLOCK_CMS_FIELDS).filter((type) =>
+    isBlockAllowedIn(type, collectionName),
+  );
   return compact([
     ...coreFields,
     config.features.permalinks && COMMON_FIELDS.permalink,
@@ -115,10 +118,7 @@ const addOptionalFields = (
     ...getCollectionSpecificFields(collection, config, fieldContext),
     config.features.use_blocks &&
       !alreadyHasBlocks &&
-      generateBlocksField(
-        Object.keys(BLOCK_CMS_FIELDS),
-        config.features.use_visual_editor,
-      ),
+      generateBlocksField(allowedBlockTypes, config.features.use_visual_editor),
   ]);
 };
 

--- a/scripts/customise-cms/field-builders.js
+++ b/scripts/customise-cms/field-builders.js
@@ -28,7 +28,7 @@ import {
   withHeaderFields,
 } from "#scripts/customise-cms/generator-helpers.js";
 import { compact, memberOf } from "#toolkit/fp/array.js";
-import { BLOCK_CMS_FIELDS } from "#utils/block-schema.js";
+import { BLOCK_CMS_FIELDS, isBlockAllowedIn } from "#utils/block-schema.js";
 
 /**
  * @typedef {import('./generator-helpers.js').CmsConfig} CmsConfig
@@ -81,7 +81,9 @@ export const getCollectionFieldBuilders = (config, fields) => ({
       config.features.no_index && COMMON_FIELDS.no_index,
       config.features.videos && VIDEOS_FIELD,
       generateBlocksField(
-        Object.keys(BLOCK_CMS_FIELDS),
+        Object.keys(BLOCK_CMS_FIELDS).filter((type) =>
+          isBlockAllowedIn(type, "pages"),
+        ),
         config.features.use_visual_editor,
       ),
     ]),

--- a/scripts/customise-cms/generate-full.js
+++ b/scripts/customise-cms/generate-full.js
@@ -28,6 +28,7 @@ const main = async () => {
   );
 
   const config = createDefaultConfig();
+  config.features.use_blocks = true;
 
   // Apply use_visual_editor from config.json if set
   if (siteConfig.use_visual_editor != null) {
@@ -39,7 +40,7 @@ const main = async () => {
   console.log(".pages.yml has been generated with:");
   console.log(`  - ${config.collections.length} collections`);
   console.log(
-    "  - All features enabled (permalinks, redirects, faqs, specs, features, galleries)",
+    "  - All features enabled (permalinks, redirects, faqs, specs, features, galleries, blocks)",
   );
   if (config.features.use_visual_editor) {
     console.log("  - Visual rich-text editor enabled");

--- a/scripts/customise-cms/generator.js
+++ b/scripts/customise-cms/generator.js
@@ -41,7 +41,7 @@ import {
   getSiteConfig,
 } from "#scripts/customise-cms/static-configs.js";
 import { compact, filterMap } from "#toolkit/fp/array.js";
-import { BLOCK_CMS_FIELDS } from "#utils/block-schema.js";
+import { BLOCK_CMS_FIELDS, isBlockAllowedIn } from "#utils/block-schema.js";
 
 /**
  * @typedef {import('./generator-helpers.js').CmsConfig} CmsConfig
@@ -103,7 +103,9 @@ const generateCustomBlocksCollectionConfig = (name, config, fieldContext) => {
       createEleventyNavigationField(config.features.external_navigation_urls),
       ...getCustomBlocksOptionalFields(config),
       generateBlocksField(
-        Object.keys(BLOCK_CMS_FIELDS),
+        Object.keys(BLOCK_CMS_FIELDS).filter((type) =>
+          isBlockAllowedIn(type, name),
+        ),
         config.features.use_visual_editor,
       ),
     ]),

--- a/src/_includes/design-system/add-to-cart-block.html
+++ b/src/_includes/design-system/add-to-cart-block.html
@@ -1,0 +1,10 @@
+{%- comment -%}
+Add-to-cart block - renders the current product's add-to-cart button.
+
+Product-only block. Reuses `product-options.html`, which reads the product's
+computed data (`cart_attributes`, `options`, `product_mode`,
+`has_single_cart_option`, `show_cart_quantity_selector`) and the site config
+(`config.cart_mode`). Renders nothing outside a product context.
+{%- endcomment -%}
+
+{%- include "product-options.html" -%}

--- a/src/_includes/design-system/render-block.html
+++ b/src/_includes/design-system/render-block.html
@@ -16,6 +16,9 @@ Renders a single block by type. Used by blocks.html.
   {%- when "buy-options" -%}
     {%- include "design-system/buy-options.html", block: block -%}
 
+  {%- when "add-to-cart" -%}
+    {%- include "design-system/add-to-cart-block.html" -%}
+
   {%- when "stats" -%}
     {%- include "design-system/stats.html", block: block -%}
 

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -13,6 +13,7 @@
  *   - `BLOCK_DOCS`       — documentation (for BLOCKS_LAYOUT.md generation)
  */
 
+import * as addToCart from "#utils/block-schema/add-to-cart.js";
 import * as bunnyVideoBackground from "#utils/block-schema/bunny-video-background.js";
 import * as buyOptions from "#utils/block-schema/buy-options.js";
 import * as callout from "#utils/block-schema/callout.js";
@@ -71,6 +72,7 @@ const BLOCK_MODULES = [
   features,
   imageCards,
   buyOptions,
+  addToCart,
   stats,
   codeBlock,
   hero,
@@ -137,6 +139,26 @@ const BLOCK_CONTAINER_WIDTHS = indexByType((m) =>
 /** @param {string} blockType */
 const getBlockContainerWidth = (blockType) =>
   BLOCK_CONTAINER_WIDTHS[blockType] || "wide";
+
+/**
+ * Collection allowlist per block type. `null` means the block is available on
+ * every collection; an array restricts it to the listed collections.
+ * @type {Record<string, string[] | null>}
+ */
+const BLOCK_ALLOWED_COLLECTIONS = indexByType((m) =>
+  "collections" in m ? m.collections : null,
+);
+
+/**
+ * Returns true when `blockType` is allowed on the given collection.
+ * Unrestricted blocks are allowed on every collection.
+ * @param {string} blockType
+ * @param {string} collectionName
+ */
+const isBlockAllowedIn = (blockType, collectionName) => {
+  const allowed = BLOCK_ALLOWED_COLLECTIONS[blockType];
+  return allowed === null || allowed.includes(collectionName);
+};
 
 const BLOCK_CMS_FIELDS = indexByType((m) => ({
   ...CONTAINER_FIELDS,
@@ -230,6 +252,7 @@ export {
   BLOCK_DOCS,
   BLOCK_SCHEMAS,
   getBlockContainerWidth,
+  isBlockAllowedIn,
   validateBlock,
   validateBlocks,
 };

--- a/src/_lib/utils/block-schema/add-to-cart.js
+++ b/src/_lib/utils/block-schema/add-to-cart.js
@@ -1,0 +1,15 @@
+export const type = "add-to-cart";
+
+export const containerWidth = "narrow";
+
+export const collections = ["products"];
+
+export const fields = {};
+
+export const docs = {
+  summary:
+    "Renders the current product's add-to-cart button, reusing the same controls shown in the product options area.",
+  template: "src/_includes/design-system/add-to-cart-block.html",
+  notes:
+    "Product-only block. Reads `cart_attributes`, `options`, `product_mode`, `has_single_cart_option`, and `show_cart_quantity_selector` from the product's computed data and delegates rendering to `product-options.html`. Renders nothing when `config.cart_mode` is disabled or the page has no cart attributes.",
+};


### PR DESCRIPTION
## Summary

- New `add-to-cart` block type that reuses the existing product-options button on product pages — single-option button, multi-option select + button, and the quantity selector all come through unchanged via a one-line `{% include "product-options.html" %}`.
- Block modules can now declare a `collections` allowlist; the CMS generator filters block types per collection so `add-to-cart` is only offered on products. Other blocks remain unaffected (no `collections` export = available everywhere, same as before).
- The full-features generator (`bun run generate-pages-yml`) now enables `use_blocks`, which the script's own description ("all features enabled") already implied. This is what adds a `blocks:` field to every item collection in the regenerated `.pages.yml` and keeps the product-only block CMS-reachable per the existing `pages-yml-block-sync` test.

## Files

- `src/_lib/utils/block-schema/add-to-cart.js` — schema module (`collections: ["products"]`, `containerWidth: "narrow"`, no user-editable fields).
- `src/_includes/design-system/add-to-cart-block.html` — thin wrapper around `product-options.html`.
- `src/_lib/utils/block-schema.js` — registers the module and exports `isBlockAllowedIn(blockType, collectionName)`.
- `src/_includes/design-system/render-block.html` — new `when "add-to-cart"` case.
- `scripts/customise-cms/{collection-config,field-builders,generator}.js` — filter block types through `isBlockAllowedIn` wherever they fed into `generateBlocksField`.
- `scripts/customise-cms/generate-full.js` — enables `use_blocks` so the committed `.pages.yml` includes the restricted block.
- `.pages.yml`, `BLOCKS_LAYOUT.md` — regenerated from source.

## Test plan

- [x] `bun test` — 2727 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run build` — built site renders `<button class="add-to-cart" data-item="…">` on a product page when the block is added to frontmatter
- [ ] CMS UI: confirm products expose the Add To Cart block and no other collection does
- [ ] Visual check on a product page with the block placed in its blocks list

https://claude.ai/code/session_019SrBWTBEpN8vJvLNmXc9qy