### PR TITLE
Add figure_autoplay option to split-video block

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -674,6 +674,7 @@ components:
       - { name: figure_thumbnail_url, type: string, label: Thumbnail URL }
       - { name: figure_alt, type: string, label: Video Alt Text }
       - { name: figure_caption, type: string, label: Video Caption }
+      - { name: figure_autoplay, type: boolean, label: Autoplay }
   block_stats:
     label: Stats
     type: object

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -242,6 +242,7 @@ Two-column layout with text content and an embedded video.
 | `figure_thumbnail_url` | string | — | Thumbnail image URL shown in the click-to-play facade. Required for non-YouTube URLs (Bunny Stream, Vimeo, etc.); YouTube thumbnails are fetched automatically when this is omitted. |
 | `figure_alt` | string | — | Accessible title for the video iframe. |
 | `figure_caption` | string | — | Visible caption below the video. |
+| `figure_autoplay` | boolean | `false` | If true, skips the click-to-play facade and renders the iframe directly with autoplay + mute (browsers block unmuted autoplay). Controls stay visible. |
 
 ---
 

--- a/src/_includes/design-system/split.html
+++ b/src/_includes/design-system/split.html
@@ -19,7 +19,7 @@ Parameters (via block object):
   Figure fields per block type:
     split-image:        figure_src, figure_alt, figure_caption
     split-video:        figure_video_id, figure_thumbnail_url, figure_alt,
-                        figure_caption
+                        figure_caption, figure_autoplay
     split-code:         figure_filename, figure_code, figure_language
     split-icon-links:   figure_items (array of {icon, text, url})
     split-html:         figure_html
@@ -46,14 +46,20 @@ Parameters (via block object):
           <figcaption>{{ block.figure_caption }}</figcaption>
         {%- endif -%}
       {%- when "split-video" -%}
-        {%- if block.figure_thumbnail_url -%}
-          {%- assign _thumbnail = block.figure_thumbnail_url -%}
-        {%- elsif block.figure_video_id | is_youtube_id -%}
-          {%- assign _thumbnail = block.figure_video_id | youtube_thumbnail -%}
+        {%- if block.figure_autoplay -%}
+          <div class="video-wrapper">
+            {%- include "design-system/video-iframe.html", video_id: block.figure_video_id, title: block.figure_alt, autoplay: true -%}
+          </div>
         {%- else -%}
-          {%- assign _thumbnail = null -%}
+          {%- if block.figure_thumbnail_url -%}
+            {%- assign _thumbnail = block.figure_thumbnail_url -%}
+          {%- elsif block.figure_video_id | is_youtube_id -%}
+            {%- assign _thumbnail = block.figure_video_id | youtube_thumbnail -%}
+          {%- else -%}
+            {%- assign _thumbnail = null -%}
+          {%- endif -%}
+          {%- include "design-system/video-facade.html", video_id: block.figure_video_id, title: block.figure_alt, thumbnail_url: _thumbnail -%}
         {%- endif -%}
-        {%- include "design-system/video-facade.html", video_id: block.figure_video_id, title: block.figure_alt, thumbnail_url: _thumbnail -%}
         {%- if block.figure_caption -%}
           <figcaption>{{ block.figure_caption }}</figcaption>
         {%- endif -%}

--- a/src/_includes/design-system/video-iframe.html
+++ b/src/_includes/design-system/video-iframe.html
@@ -8,19 +8,22 @@ to privacy-respecting youtube-nocookie.com embed URLs.
 Parameters:
   - video_id: YouTube video ID or custom iframe URL (required)
   - title: Accessible title for the iframe (required)
-  - background: If true, adds mute/loop/controls params for background video and
-                disables lazy loading to ensure autoplay works (default: false)
+  - background: If true, adds mute/loop/controls params for ambient background
+                video and disables lazy loading so autoplay works (default: false)
+  - autoplay: If true, adds mute/playsinline so the video starts on load with
+              controls still visible, and disables lazy loading (default: false)
 
 Both video-background and video-cards use this partial to ensure consistent
 iframe attributes and privacy settings.
 {%- endcomment -%}
 
+{%- assign _eager = background or autoplay -%}
 <iframe
-  src="{{ video_id | video_embed_url: background }}"
+  src="{{ video_id | video_embed_url: background, autoplay }}"
   title="{{ title }}"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
-  {% unless background %}loading="lazy"{% endunless %}
+  {% unless _eager %}loading="lazy"{% endunless %}
   referrerpolicy="origin"
 ></iframe>

--- a/src/_lib/eleventy/video.js
+++ b/src/_lib/eleventy/video.js
@@ -12,8 +12,10 @@ const configureVideo = (eleventyConfig) => {
     /**
      * @param {string} videoId
      * @param {boolean} background
+     * @param {boolean} autoplay
      */
-    (videoId, background = false) => getVideoEmbedUrl(videoId, { background }),
+    (videoId, background = false, autoplay = false) =>
+      getVideoEmbedUrl(videoId, { background, autoplay }),
   );
 
   /** Returns true if the video identifier is a YouTube ID (not a URL). */

--- a/src/_lib/utils/block-schema/split-video.js
+++ b/src/_lib/utils/block-schema/split-video.js
@@ -1,4 +1,5 @@
 /* jscpd:ignore-start */
+import { bool } from "#utils/block-schema/shared.js";
 import {
   SPLIT_BASE_DOCS,
   SPLIT_BASE_FIELDS,
@@ -28,6 +29,12 @@ export const fields = {
   figure_caption: {
     ...str("Video Caption"),
     description: "Visible caption below the video.",
+  },
+  figure_autoplay: {
+    ...bool("Autoplay"),
+    default: "false",
+    description:
+      "If true, skips the click-to-play facade and renders the iframe directly with autoplay + mute (browsers block unmuted autoplay). Controls stay visible.",
   },
 };
 

--- a/src/_lib/utils/video.js
+++ b/src/_lib/utils/video.js
@@ -78,16 +78,26 @@ const fetchVimeoThumbnail = memoize(async (vimeoId) => {
   return data.thumbnail_url;
 });
 
+const YOUTUBE_PARAMS_BY_MODE = {
+  background: (videoId) =>
+    `autoplay=1&mute=1&loop=1&controls=0&playsinline=1&enablejsapi=1&playlist=${videoId}`,
+  autoplay: () => "autoplay=1&mute=1&playsinline=1",
+  default: () => "autoplay=1",
+};
+
 /**
  * Get the embed URL for a video
  *
- * For Vimeo URLs, ensures autoplay=1 and loop=1 params are present.
+ * For Vimeo URLs, ensures autoplay=1 and loop=1 params are present; when
+ * `autoplay` is requested a `muted=1` param is also added so browsers allow
+ * playback without user gesture.
  * For other custom URLs (starting with "http"), returns the URL as-is.
  * For YouTube IDs, constructs a privacy-respecting youtube-nocookie.com URL.
  *
  * @param {string} videoId - YouTube video ID or custom URL
  * @param {Object} [options] - Options for YouTube embeds
- * @param {boolean} [options.background=false] - If true, adds mute/loop/controls params for background video
+ * @param {boolean} [options.background=false] - If true, adds mute/loop/controls=0 params for ambient background video
+ * @param {boolean} [options.autoplay=false] - If true, adds mute/playsinline params so the video starts on load with controls still visible
  * @returns {string} The embed URL for use in an iframe src
  *
  * @example
@@ -97,30 +107,37 @@ const fetchVimeoThumbnail = memoize(async (vimeoId) => {
  * getVideoEmbedUrl("dQw4w9WgXcQ", { background: true })
  * // "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&mute=1&loop=1&controls=0&playsinline=1&playlist=dQw4w9WgXcQ"
  *
+ * getVideoEmbedUrl("dQw4w9WgXcQ", { autoplay: true })
+ * // "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&mute=1&playsinline=1"
+ *
  * getVideoEmbedUrl("https://player.vimeo.com/video/123456")
  * // "https://player.vimeo.com/video/123456?autoplay=1&loop=1"
  */
 const getVideoEmbedUrl = (videoId, options = {}) => {
+  const autoplay = options.autoplay === true;
+  const background = options.background === true;
+  const pickMode = () => {
+    if (background) return "background";
+    if (autoplay) return "autoplay";
+    return "default";
+  };
+  const setMissing = (params, entries) => {
+    for (const [key, value] of entries) {
+      if (!params.has(key)) params.set(key, value);
+    }
+  };
   if (isVimeoUrl(videoId)) {
     const parsed = new URL(videoId);
-    if (!parsed.searchParams.has("autoplay")) {
-      parsed.searchParams.set("autoplay", "1");
-    }
-    if (!parsed.searchParams.has("loop")) {
-      parsed.searchParams.set("loop", "1");
-    }
+    const muted = autoplay || background;
+    setMissing(parsed.searchParams, [
+      ["autoplay", "1"],
+      ["loop", "1"],
+      ...(muted ? [["muted", "1"]] : []),
+    ]);
     return parsed.toString();
   }
-
-  if (isCustomVideoUrl(videoId)) {
-    return videoId;
-  }
-
-  const background = options.background === true;
-  const params = background
-    ? `autoplay=1&mute=1&loop=1&controls=0&playsinline=1&enablejsapi=1&playlist=${videoId}`
-    : "autoplay=1";
-
+  if (isCustomVideoUrl(videoId)) return videoId;
+  const params = YOUTUBE_PARAMS_BY_MODE[pickMode()](videoId);
   return `https://www.youtube-nocookie.com/embed/${videoId}?${params}`;
 };
 

--- a/src/_lib/utils/video.js
+++ b/src/_lib/utils/video.js
@@ -78,13 +78,6 @@ const fetchVimeoThumbnail = memoize(async (vimeoId) => {
   return data.thumbnail_url;
 });
 
-const YOUTUBE_PARAMS_BY_MODE = {
-  background: (videoId) =>
-    `autoplay=1&mute=1&loop=1&controls=0&playsinline=1&enablejsapi=1&playlist=${videoId}`,
-  autoplay: () => "autoplay=1&mute=1&playsinline=1",
-  default: () => "autoplay=1",
-};
-
 /**
  * Get the embed URL for a video
  *
@@ -116,29 +109,36 @@ const YOUTUBE_PARAMS_BY_MODE = {
 const getVideoEmbedUrl = (videoId, options = {}) => {
   const autoplay = options.autoplay === true;
   const background = options.background === true;
-  const pickMode = () => {
-    if (background) return "background";
-    if (autoplay) return "autoplay";
-    return "default";
-  };
-  const setMissing = (params, entries) => {
-    for (const [key, value] of entries) {
-      if (!params.has(key)) params.set(key, value);
+  /**
+   * @param {string} vimeoUrl
+   * @param {boolean} muted
+   * @returns {string}
+   */
+  const buildVimeo = (vimeoUrl, muted) => {
+    const parsed = new URL(vimeoUrl);
+    if (!parsed.searchParams.has("autoplay")) {
+      parsed.searchParams.set("autoplay", "1");
     }
-  };
-  if (isVimeoUrl(videoId)) {
-    const parsed = new URL(videoId);
-    const muted = autoplay || background;
-    setMissing(parsed.searchParams, [
-      ["autoplay", "1"],
-      ["loop", "1"],
-      ...(muted ? [["muted", "1"]] : []),
-    ]);
+    if (!parsed.searchParams.has("loop")) parsed.searchParams.set("loop", "1");
+    if (muted && !parsed.searchParams.has("muted")) {
+      parsed.searchParams.set("muted", "1");
+    }
     return parsed.toString();
-  }
+  };
+  /**
+   * @param {string} id
+   * @returns {string}
+   */
+  const youtubeParams = (id) => {
+    if (background) {
+      return `autoplay=1&mute=1&loop=1&controls=0&playsinline=1&enablejsapi=1&playlist=${id}`;
+    }
+    if (autoplay) return "autoplay=1&mute=1&playsinline=1";
+    return "autoplay=1";
+  };
+  if (isVimeoUrl(videoId)) return buildVimeo(videoId, autoplay || background);
   if (isCustomVideoUrl(videoId)) return videoId;
-  const params = YOUTUBE_PARAMS_BY_MODE[pickMode()](videoId);
-  return `https://www.youtube-nocookie.com/embed/${videoId}?${params}`;
+  return `https://www.youtube-nocookie.com/embed/${videoId}?${youtubeParams(videoId)}`;
 };
 
 /**

--- a/test/unit/utils/video.test.js
+++ b/test/unit/utils/video.test.js
@@ -32,6 +32,23 @@ describe("getVideoEmbedUrl", () => {
         "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1",
       );
     });
+
+    test("adds mute and playsinline when autoplay is true", () => {
+      const result = getVideoEmbedUrl("dQw4w9WgXcQ", { autoplay: true });
+      expect(result).toBe(
+        "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&mute=1&playsinline=1",
+      );
+    });
+
+    test("background option wins over autoplay when both are true", () => {
+      const result = getVideoEmbedUrl("dQw4w9WgXcQ", {
+        background: true,
+        autoplay: true,
+      });
+      expect(result).toBe(
+        "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&mute=1&loop=1&controls=0&playsinline=1&enablejsapi=1&playlist=dQw4w9WgXcQ",
+      );
+    });
   });
 
   describe("with Vimeo URL", () => {
@@ -73,6 +90,14 @@ describe("getVideoEmbedUrl", () => {
       ).toBe(
         "https://player.vimeo.com/video/123456?h=abc123&autoplay=1&loop=1",
       );
+    });
+
+    test("adds muted param when autoplay is true on Vimeo URL", () => {
+      expect(
+        getVideoEmbedUrl("https://player.vimeo.com/video/123456", {
+          autoplay: true,
+        }),
+      ).toBe("https://player.vimeo.com/video/123456?autoplay=1&loop=1&muted=1");
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a new `figure_autoplay` boolean to the `split-video` block schema (default `false`).
- When true, split.html skips the click-to-play facade and renders the iframe directly, with lazy loading disabled so the embed starts on page load.
- `getVideoEmbedUrl` / the `video_embed_url` Liquid filter gain an `autoplay` option that adds `mute=1&playsinline=1` (YouTube) or `muted=1` (Vimeo), since browsers block unmuted autoplay. Controls stay visible (unlike `background` mode which also loops and hides controls).
- Regenerated `.pages.yml` and `BLOCKS_LAYOUT.md` from the updated schema.

## Test plan

- [x] `bun test test/unit/utils/video.test.js` — covers new autoplay branches for YouTube and Vimeo, plus background-wins-over-autoplay precedence.
- [x] `bun test` — full suite (2760 passing).
- [x] `bun run lint` — clean.
- [ ] Manual: render a `split-video` block with `figure_autoplay: true` in the dev server and confirm the iframe autoplays muted with controls visible.

https://claude.ai/code/session_01W6stk8GouqzdYySf1yZsKe