### PR TITLE
Conditionally render contact form block content

### DIFF
--- a/src/_includes/design-system/contact-form-block.html
+++ b/src/_includes/design-system/contact-form-block.html
@@ -6,9 +6,11 @@
   -%}
 {%- endif -%}
 <div class="contact-form-block">
+  {%- if block.content -%}
   <div class="prose">
     {{ block.content | renderContent: "md" }}
   </div>
+  {%- endif -%}
   <div class="form">
     {%- include "contact-form.html" -%}
   </div>


### PR DESCRIPTION
## Summary
Added a conditional check to only render the prose content section of the contact form block when content is present, preventing empty markup from being generated.

## Changes
- Wrapped the prose content div with an `{%- if block.content -%}` conditional check
- This ensures the content section is only rendered when `block.content` has a value
- The form itself continues to render unconditionally

## Implementation Details
This prevents unnecessary empty `<div class="prose">` elements from appearing in the DOM when no content is provided to the block, resulting in cleaner HTML output and better semantic structure.

https://claude.ai/code/session_01PHTBdxYZqmRDPffz86BkqU