### PR TITLE
Default product options to empty array at data level

### DIFF
--- a/src/products/products.11tydata.js
+++ b/src/products/products.11tydata.js
@@ -27,48 +27,51 @@ const getDefaultMaxQuantity = (data) => {
   return config.default_max_quantity;
 };
 
-export default linkableContent("product", {
-  categories: (data) => (data.categories || []).map(normaliseSlug),
-  keywords: (data) => data.keywords || [],
-  gallery: computeGallery,
-  product_mode: (data) => getProductMode(data),
-  options: (data) =>
-    computeOptions(data, getProductMode(data), getDefaultMaxQuantity(data)),
-  specs: (data) => computeSpecs(data.specs || []),
-  highlighted_specs: (data) => {
-    const specs = computeSpecs(data.specs || []);
-    return getHighlightedSpecs(specs);
-  },
-  list_item_specs: (data) => {
-    const specs = computeSpecs(data.specs || []);
-    return getListItemSpecs(specs);
-  },
-  cart_attributes: (data) => {
-    const mode = getProductMode(data);
-    const defaultMaxQuantity = getDefaultMaxQuantity(data);
-    return buildCartAttributes({
-      title: data.title,
-      subtitle: data.subtitle,
-      options: computeOptions(data, mode, defaultMaxQuantity),
-      specs: computeSpecs(data.specs || []),
-      mode,
-    });
-  },
-  cart_btn_text: (data) => {
-    const mode = getProductMode(data);
-    return mode === "hire" ? "Add To Quote" : "Add to Cart";
-  },
-  has_single_cart_option: (data) => {
-    const mode = getProductMode(data);
-    return mode === "hire" || (data.options || []).length <= 1;
-  },
-  show_cart_quantity_selector: (data) => {
-    const config = getConfig();
-    if (config.cart_mode !== "quote") return false;
-    const mode = getProductMode(data);
-    const defaultMaxQuantity = getDefaultMaxQuantity(data);
-    const options = computeOptions(data, mode, defaultMaxQuantity);
-    const maxQuantity = options[0]?.max_quantity;
-    return maxQuantity != null && maxQuantity > 1;
-  },
-});
+export default {
+  options: [],
+  ...linkableContent("product", {
+    categories: (data) => (data.categories || []).map(normaliseSlug),
+    keywords: (data) => data.keywords || [],
+    gallery: computeGallery,
+    product_mode: (data) => getProductMode(data),
+    options: (data) =>
+      computeOptions(data, getProductMode(data), getDefaultMaxQuantity(data)),
+    specs: (data) => computeSpecs(data.specs || []),
+    highlighted_specs: (data) => {
+      const specs = computeSpecs(data.specs || []);
+      return getHighlightedSpecs(specs);
+    },
+    list_item_specs: (data) => {
+      const specs = computeSpecs(data.specs || []);
+      return getListItemSpecs(specs);
+    },
+    cart_attributes: (data) => {
+      const mode = getProductMode(data);
+      const defaultMaxQuantity = getDefaultMaxQuantity(data);
+      return buildCartAttributes({
+        title: data.title,
+        subtitle: data.subtitle,
+        options: computeOptions(data, mode, defaultMaxQuantity),
+        specs: computeSpecs(data.specs || []),
+        mode,
+      });
+    },
+    cart_btn_text: (data) => {
+      const mode = getProductMode(data);
+      return mode === "hire" ? "Add To Quote" : "Add to Cart";
+    },
+    has_single_cart_option: (data) => {
+      const mode = getProductMode(data);
+      return mode === "hire" || (data.options || []).length <= 1;
+    },
+    show_cart_quantity_selector: (data) => {
+      const config = getConfig();
+      if (config.cart_mode !== "quote") return false;
+      const mode = getProductMode(data);
+      const defaultMaxQuantity = getDefaultMaxQuantity(data);
+      const options = computeOptions(data, mode, defaultMaxQuantity);
+      const maxQuantity = options[0]?.max_quantity;
+      return maxQuantity != null && maxQuantity > 1;
+    },
+  }),
+};


### PR DESCRIPTION
## Summary

- Products without an `options` key in their front matter caused a `TypeError: undefined is not an object (evaluating 'data.options.length')` during Eleventy's computed data evaluation
- On the first computed-data pass, `data.options` was `undefined` (raw markdown value) before the computed `options` property had run — accessing `.length` on it threw
- Fix: add `options: []` as a static data default in `products.11tydata.js`, which is the earliest point in Eleventy's data cascade (directory data file, before any computed runs)

## Test plan

- [ ] Build the site with a product that has no `options` array — page should render without TypeError
- [ ] Build with a product that has an `options` array — options should display correctly
- [ ] Run `bun run lint` — no errors

https://claude.ai/code/session_01GvJwFZV58DSLXgW67QZz8X