### PR TITLE
Add masonry and intro support to the gallery block

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -196,6 +196,9 @@ components:
           - { name: image, type: image, label: Image, required: true }
           - { name: caption, type: string, label: Caption }
       - { name: aspect_ratio, type: string, label: Aspect Ratio }
+      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - { name: masonry, type: boolean, label: Masonry Grid }
+      - { name: header_intro, type: rich-text, label: Header Intro }
   block_guide_categories:
     label: Guide Categories
     type: object

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -782,6 +782,11 @@ Image grid with optional aspect ratio cropping and captions.
 |---|---|---|---|
 | `items` | array | **required** | Image objects. Each: `{image, caption}`. Images processed by `{% image %}` shortcode. |
 | `aspect_ratio` | string | — | Aspect ratio for images (e.g. `"16/9"`, `"1/1"`, `"4/3"`). Default: no cropping. |
+| `intro` | string | — | Markdown content rendered above items in `.prose`. |
+| `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
+| `header_intro` | string | — | Section header content rendered as markdown above the block. |
+| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
+| `header_class` | string | — | Extra CSS classes on the section header. |
 
 ---
 

--- a/src/_includes/design-system/gallery.html
+++ b/src/_includes/design-system/gallery.html
@@ -6,10 +6,13 @@ Parameters (via block object):
     - image: Image path (required)
     - caption: Caption text displayed below the image (optional)
   - block.aspect_ratio: Aspect ratio for images (e.g., "16/9", "1/1", "4/3"). Default: no cropping
+  - block.intro: Optional markdown content rendered above the grid in `.prose`
+  - block.masonry: If true, renders as a masonry grid using uWrap for zero-reflow height prediction
 {%- endcomment -%}
 
 {%- if block.items.size > 0 -%}
-  <ul class="items" role="list">
+  {%- include "design-system/block-intro.html" -%}
+  <ul class="items{% if block.masonry %} masonry{% endif %}" role="list">
     {%- for item in block.items -%}
       <li>
         {%- assign image = item.image -%}
@@ -23,4 +26,7 @@ Parameters (via block object):
       </li>
     {%- endfor -%}
   </ul>
+  {%- if block.masonry -%}
+  <script type="module" src="{{ '/assets/js/masonry.js' | cacheBust }}"></script>
+  {%- endif -%}
 {%- endif -%}

--- a/src/_lib/public/masonry.js
+++ b/src/_lib/public/masonry.js
@@ -153,8 +153,11 @@ const measureItemCard = (card, metrics, colWidth) => {
   const buttonHeight = buttonEl
     ? Number.parseFloat(getComputedStyle(buttonEl).height)
     : null;
+  const hasContent = childHeights.length > 0 || buttonHeight !== null;
   const extraPadding = imgHeight
-    ? metrics.padY / 2 + metrics.gap
+    ? hasContent
+      ? metrics.padY / 2 + metrics.gap
+      : 0
     : metrics.padY;
 
   return (

--- a/src/_lib/utils/block-schema/gallery.js
+++ b/src/_lib/utils/block-schema/gallery.js
@@ -1,6 +1,9 @@
 import {
+  HEADER_FIELDS,
+  ITEMS_COMMON_FIELDS,
   ITEMS_GRID_META,
   img,
+  MASONRY_FIELD,
   objectList,
   str,
 } from "#utils/block-schema/shared.js";
@@ -22,6 +25,9 @@ export const fields = {
     description:
       'Aspect ratio for images (e.g. `"16/9"`, `"1/1"`, `"4/3"`). Default: no cropping.',
   },
+  intro: ITEMS_COMMON_FIELDS.intro,
+  masonry: MASONRY_FIELD,
+  ...HEADER_FIELDS,
 };
 
 export const docs = {

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -115,6 +115,25 @@ blocks:
 
       Display reviews in a masonry grid — cards flow naturally based on content height.
 
+  # Gallery Masonry
+  - type: gallery
+    masonry: true
+    intro: |
+      ## Gallery
+
+      Mix images of any aspect ratio, with or without captions. The masonry layout packs them into columns with no ragged gaps.
+    items:
+      - image: /images/party.jpg
+        caption: Opening night — the room was packed from the first hour.
+      - image: /images/breakfast.jpg
+      - image: /images/dinner.jpg
+        caption: A three-course tasting menu featuring seasonal produce from local farms.
+      - image: /images/fireworks.jpg
+        caption: Summer festival finale.
+      - image: /images/lunch.jpg
+      - image: /images/menu.jpg
+        caption: This season's menu.
+
   # Socials - externally-linked posts loaded from a directory
   - type: socials
     directory: instagram-posts


### PR DESCRIPTION
## Summary

- Gallery items now flow into packed columns when `masonry: true`, matching items/items-array/reviews/socials. The `masonry` field has been added to the gallery schema and wired into `design-system/gallery.html` (applies the `masonry` class and loads `masonry.js`).
- Fixed a height over-estimation in `masonry.js` for image-only cards. The existing `measureItemCard()` unconditionally reserved `padY/2 + gap` below the image, but `_items.scss` removes `padding-bottom` when a card has only `.image-link` children. The `extraPadding` now drops to `0` when there is no text/button content — safe for existing consumers (items/items-array/reviews/socials) which always have text children.
- Added `intro` (shared `ITEMS_COMMON_FIELDS.intro` + `HEADER_FIELDS`) to the gallery schema and template via the existing `design-system/block-intro.html` include, so gallery blocks can render copy above the grid without a separate markdown block.
- Regenerated `.pages.yml` and `BLOCKS_LAYOUT.md` to reflect the new gallery fields.
- Added a masonry gallery demo with mixed captions/no-captions to `src/pages/chobble-template.md` using the existing demo images.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` clean
- [x] `bun test` — 2783 pass, 0 fail
- [x] Inspect generated `_site/index.html` — gallery renders as `<ul class="items masonry">` with correct image-wrappers and caption `<p>` siblings, masonry.js loaded, `.pages.yml` sync test passing
- [ ] Visual check in browser: masonry packs columns with no overlap, image-only items have no trailing padding, responsive down to 1 column below 768px

https://claude.ai/code/session_014tXq3Z4V3GTSJp4m2d6n6T