### PR TITLE
Normalize gallery image-link hrefs

### DIFF
--- a/src/_includes/design-system/gallery.html
+++ b/src/_includes/design-system/gallery.html
@@ -17,7 +17,7 @@ Parameters (via block object):
       <li>
         {%- assign image = item.image -%}
         {%- capture alt_text -%}{%- include "get-alt-text.html" -%}{%- endcapture -%}
-        <a class="image-link" href="{{ item.image }}">
+        <a class="image-link" href="{{ item.image | normalizeImageUrl }}">
           {%- image item.image, alt_text, "", "", "", block.aspect_ratio -%}
         </a>
         {%- if item.caption -%}

--- a/src/_includes/design-system/image-cards.html
+++ b/src/_includes/design-system/image-cards.html
@@ -39,7 +39,11 @@ Usage:
   {%- for item in block.items -%}
   <li{% if reveal %} data-reveal{% endif %}>
     {%- if item.image -%}
-      <a class="image-link" href="{{ item.link | default: item.image }}">
+      {%- if item.link -%}
+        <a class="image-link" href="{{ item.link }}">
+      {%- else -%}
+        <a class="image-link" href="{{ item.image | normalizeImageUrl }}">
+      {%- endif -%}
         {%- image item.image, "", "", "", "", block.image_aspect_ratio -%}
       </a>
     {%- endif -%}

--- a/src/_includes/gallery-thumbnail.html
+++ b/src/_includes/gallery-thumbnail.html
@@ -1,12 +1,6 @@
 <li>
   <a
-    href="
-      {%- if image[0] == "/" -%}
-        {{- image -}}
-      {%- else -%}
-        /images/{{ image -}}
-      {%- endif -%}
-    "
+    href="{{ image | normalizeImageUrl }}"
     data-index="{{ forloop.index }}"
     class="image-link"
   >

--- a/src/_lib/media/image-utils.js
+++ b/src/_lib/media/image-utils.js
@@ -5,8 +5,9 @@
  * Extracted to reduce complexity in image.js and provide reusable utilities.
  */
 import { compact } from "#toolkit/fp/array.js";
+import { isExternalUrl } from "#utils/url-utils.js";
 
-export { isExternalUrl } from "#utils/url-utils.js";
+export { isExternalUrl };
 
 const DEFAULT_WIDTHS = [240, 480, 900, 1300];
 const DEFAULT_SIZE = "auto";
@@ -27,6 +28,28 @@ export const normalizeImagePath = (imageName) => {
   if (imageName.startsWith("src/")) return `./${imageName}`;
   if (imageName.startsWith("images/")) return `./src/${imageName}`;
   return `./src/images/${imageName}`;
+};
+
+/**
+ * Normalize an image path to a browser URL rooted at the site.
+ * Mirrors normalizeImagePath's input shapes but returns URL-space output:
+ * - "/images/photo.jpg"    -> "/images/photo.jpg"
+ * - "src/images/photo.jpg" -> "/images/photo.jpg"
+ * - "images/photo.jpg"     -> "/images/photo.jpg"
+ * - "photo.jpg"            -> "/images/photo.jpg"
+ * External URLs (http:, https:, protocol-relative //, data:) pass through.
+ *
+ * @param {string} imageName - Image path as written in frontmatter
+ * @returns {string} Browser-safe URL
+ */
+export const normalizeImageUrl = (imageName) => {
+  if (isExternalUrl(imageName)) return imageName;
+  if (imageName.startsWith("//") || imageName.startsWith("data:"))
+    return imageName;
+  if (imageName.startsWith("/")) return imageName;
+  if (imageName.startsWith("src/")) return `/${imageName.slice(4)}`;
+  if (imageName.startsWith("images/")) return `/${imageName}`;
+  return `/images/${imageName}`;
 };
 
 /**

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -37,6 +37,7 @@ import {
   filenameFormat,
   isExternalUrl,
   normalizeImagePath,
+  normalizeImageUrl,
   parseWidths,
   prepareImageAttributes,
 } from "#media/image-utils.js";
@@ -229,6 +230,7 @@ const configureImages = async (eleventyConfig) => {
   eleventyConfig.addPlugin(eleventyImageOnRequestDuringServePlugin);
 
   eleventyConfig.addAsyncShortcode("image", imageShortcode);
+  eleventyConfig.addFilter("normalizeImageUrl", normalizeImageUrl);
   eleventyConfig.addCollection("images", () =>
     imageFiles.map((i) => i.split("/")[2]).reverse(),
   );

--- a/test/unit/media/image-utils.test.js
+++ b/test/unit/media/image-utils.test.js
@@ -6,6 +6,7 @@ import {
   getPathAwareBasename,
   isExternalUrl,
   normalizeImagePath,
+  normalizeImageUrl,
   parseWidths,
   prepareImageAttributes,
 } from "#media/image-utils.js";
@@ -32,6 +33,49 @@ describe("image-utils", () => {
 
     test("prepends ./src/images/ for bare filenames", () => {
       expect(normalizeImagePath("photo.jpg")).toBe("./src/images/photo.jpg");
+    });
+  });
+
+  describe("normalizeImageUrl", () => {
+    test("passes through paths already rooted at /", () => {
+      expect(normalizeImageUrl("/images/photo.jpg")).toBe("/images/photo.jpg");
+    });
+
+    test("strips src/ prefix", () => {
+      expect(normalizeImageUrl("src/images/photo.jpg")).toBe(
+        "/images/photo.jpg",
+      );
+    });
+
+    test("prepends / for paths starting with images/", () => {
+      expect(normalizeImageUrl("images/photo.jpg")).toBe("/images/photo.jpg");
+    });
+
+    test("prepends /images/ for bare filenames", () => {
+      expect(normalizeImageUrl("photo.jpg")).toBe("/images/photo.jpg");
+    });
+
+    test("passes through https:// URLs unchanged", () => {
+      expect(normalizeImageUrl("https://example.com/photo.jpg")).toBe(
+        "https://example.com/photo.jpg",
+      );
+    });
+
+    test("passes through http:// URLs unchanged", () => {
+      expect(normalizeImageUrl("http://example.com/photo.jpg")).toBe(
+        "http://example.com/photo.jpg",
+      );
+    });
+
+    test("passes through protocol-relative URLs unchanged", () => {
+      expect(normalizeImageUrl("//cdn.example.com/photo.jpg")).toBe(
+        "//cdn.example.com/photo.jpg",
+      );
+    });
+
+    test("passes through data: URIs unchanged", () => {
+      const dataUri = "data:image/png;base64,iVBORw0KGgo=";
+      expect(normalizeImageUrl(dataUri)).toBe(dataUri);
     });
   });
 


### PR DESCRIPTION
## Summary

- The `{% image %}` shortcode already normalizes `/images/foo.jpg`, `src/images/foo.jpg`, `images/foo.jpg`, and bare `foo.jpg` for the `<img>`. The surrounding `<a class="image-link" href="{{ item.image }}">` dropped the raw frontmatter path, so relative forms 404'd as `/products/<slug>/images/foo.jpg` and `gallery-thumbnail.html` had a workaround that still failed for `src/images/...`.
- Added `normalizeImageUrl` in `src/_lib/media/image-utils.js` — same input shapes as `normalizeImagePath`, URL-space output (`/images/foo.jpg`), pass-through for `http(s):`, `//`, and `data:`. Registered as a Liquid filter in `configureImages`.
- Applied the filter to `design-system/gallery.html`, `design-system/image-cards.html` (only on the image-fallback branch — `item.link`, when set, is an arbitrary URL and must not be treated as an image path), and `gallery-thumbnail.html` (replacing the hand-rolled prefix logic).

## Test plan

- [x] `bun test test/unit/media/image-utils.test.js` — 54 pass, including 8 new `normalizeImageUrl` cases
- [x] `bun test test/unit/media/` — 136 pass
- [x] `bun run lint` — clean
- [x] `bun run build` — homepage gallery now renders `<a class="image-link" href="/images/party.jpg">` etc.; external Instagram URLs pass through unchanged
- [ ] Manual: product page with multi-image `gallery` exercises `gallery-thumbnail.html` (current fixtures only have single-image products, so this path is covered by unit tests only)

https://claude.ai/code/session_01NBLEUpt6T9ei36JKRsFDG3