### PR TITLE
Strict types for src/_lib/collections/navigation.js

### DIFF
--- a/scripts/strict-typecheck-ratchet.js
+++ b/scripts/strict-typecheck-ratchet.js
@@ -14,7 +14,7 @@ import { spawnSync } from "node:child_process";
 import { ROOT_DIR } from "#lib/paths.js";
 
 // Current baseline - lower this as you fix errors
-const CURRENT_ERROR_COUNT = 380;
+const CURRENT_ERROR_COUNT = 367;
 
 // Files that currently pass strict mode (must not regress)
 const STRICT_CLEAN_FILES = [
@@ -52,6 +52,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/build/js-bundler.js",
   "src/_lib/build/theme-compiler.js",
   "src/_lib/collections/guides.js",
+  "src/_lib/collections/navigation.js",
   "src/_lib/collections/tags.js",
   "src/_lib/collections/thumbnail-resolvers.js",
   "src/_lib/config/form-helpers.js",

--- a/src/_lib/collections/navigation.js
+++ b/src/_lib/collections/navigation.js
@@ -9,12 +9,23 @@ import { filter, mapAsync, pipe, sort } from "#toolkit/fp/array.js";
 import { createHtml } from "#utils/dom-builder.js";
 import { sortNavigationItems } from "#utils/sorting.js";
 
+/** @typedef {import("#lib/types").EleventyCollectionItem} EleventyCollectionItem */
+/** @typedef {import("../types/navigation.d.ts").NavigationEntry} NavigationEntry */
+/** @typedef {(children: NavigationEntry[]) => Promise<string>} RenderChildren */
+
 const NAV_THUMBNAIL_WIDTHS = ["64", "128", "480", "600"];
 const NAV_THUMBNAIL_ASPECT = "1/1";
 const SEARCH_PAGE_PATH = join(PAGES_DIR, "search.md");
 const SEARCH_ICON_ID = "hugeicons:search-02";
 
-/** Renders a single navigation entry with optional thumbnail (not at root level) */
+/**
+ * @param {NavigationEntry} entry
+ * @param {string} activeKey
+ * @param {RenderChildren} renderChildren
+ * @param {boolean} isRootLevel
+ * @param {boolean} showThumbnails
+ * @returns {Promise<string>}
+ */
 const renderNavEntry = async (
   entry,
   activeKey,
@@ -38,16 +49,17 @@ const renderNavEntry = async (
       ? renderChildren(entry.children)
       : Promise.resolve(""),
   ]);
+  const href = entry.url ?? null;
   const anchorAttrs = {
     class: activeKey === entry.key ? "active" : null,
-    href: entry.url,
+    href,
   };
   const titleHtml = await createHtml("span", {}, entry.title);
   const anchor = await createHtml("a", anchorAttrs, thumbnailHtml + titleHtml);
   return createHtml("li", {}, anchor + childrenHtml);
 };
 
-/** Renders the search box list item for the navigation */
+/** @returns {Promise<string>} */
 const renderSearchItem = async () => {
   const iconSvg = await getIcon(SEARCH_ICON_ID);
   const searchButton = await createHtml("button", { type: "submit" }, iconSvg);
@@ -65,13 +77,19 @@ const renderSearchItem = async () => {
   return createHtml("li", { class: "nav-search" }, searchForm);
 };
 
-/** Filter: renders navigation HTML. Usage: {{ navItems | toNavigation: activeKey }} */
+/**
+ * Filter: renders navigation HTML. Usage: {{ navItems | toNavigation: activeKey }}
+ * @param {NavigationEntry[]} pages
+ * @param {string} [activeKey]
+ * @returns {Promise<string>}
+ */
 const toNavigation = async (pages, activeKey = "") => {
   if (!pages?.length) return "";
   if (pages[0]?.pluginType !== "eleventy-navigation") {
     throw new Error("toNavigation requires eleventyNavigation filter first");
   }
   const showThumbnails = config().nav_thumbnails;
+  /** @param {NavigationEntry[]} children */
   const renderChildren = async (children) => {
     const items = await mapAsync((child) =>
       renderNavEntry(child, activeKey, renderChildren, false, showThumbnails),
@@ -88,7 +106,13 @@ const toNavigation = async (pages, activeKey = "") => {
   return createHtml("ul", { class: "nav-thumbnails" }, items.join("\n"));
 };
 
-/** Find URL for a page matching tag and slug. Uses O(1) slug lookup. */
+/**
+ * Find URL for a page matching tag and slug. Uses O(1) slug lookup.
+ * @param {EleventyCollectionItem[]} collection
+ * @param {string} tag
+ * @param {string} slug
+ * @returns {string}
+ */
 const findPageUrl = (collection, tag, slug) => {
   const item = getBySlug(collection, slug);
   if (!item.data.tags?.includes(tag)) {
@@ -97,6 +121,10 @@ const findPageUrl = (collection, tag, slug) => {
   return item.url;
 };
 
+/**
+ * @param {import("11ty.ts").EleventyConfig} eleventyConfig
+ * @returns {Promise<void>}
+ */
 const configureNavigation = async (eleventyConfig) => {
   const nav = await import("@11ty/eleventy-navigation");
   eleventyConfig.addPlugin(nav.default);

--- a/src/_lib/types/eleventy-navigation.d.ts
+++ b/src/_lib/types/eleventy-navigation.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Ambient declaration for @11ty/eleventy-navigation.
+ *
+ * The upstream package ships no declarations. We only use the default
+ * export (the plugin function); the collection-item shape produced by
+ * its filter lives in `./navigation.d.ts` alongside the other
+ * Chobble-specific types.
+ */
+
+declare module "@11ty/eleventy-navigation" {
+  const plugin: (eleventyConfig: unknown, options?: unknown) => void;
+  export default plugin;
+}

--- a/src/_lib/types/navigation.d.ts
+++ b/src/_lib/types/navigation.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Navigation types produced by `@11ty/eleventy-navigation` and consumed
+ * by `#collections/navigation.js` for rendering menus.
+ */
+
+import type { EleventyCollectionItemData } from './eleventy.d.ts';
+
+/**
+ * A navigation entry produced by the `eleventyNavigation` filter,
+ * ready to be rendered as an `<li>` by `toNavigation`.
+ */
+export type NavigationEntry = {
+  key: string;
+  title: string;
+  url?: string;
+  pluginType: 'eleventy-navigation';
+  data: Partial<EleventyCollectionItemData>;
+  children?: NavigationEntry[];
+};

--- a/test/unit/collections/navigation.test.js
+++ b/test/unit/collections/navigation.test.js
@@ -25,53 +25,32 @@ const { configureNavigation, findPageUrl, toNavigation } = await import(
 
 const MOCK_SVG = '<svg xmlns="http://www.w3.org/2000/svg"><path/></svg>';
 
-/** Run an async callback with fetch mocked to return a valid SVG */
 const withIconMock = (callback) => withMockFetch(MOCK_SVG, {}, callback);
 
-// ============================================
-// Functional Test Fixture Builders
-// ============================================
-
-/** Create a page item for findPageUrl tests */
 const pageItem = (slug, url, tags = []) => ({
   data: { tags },
   fileSlug: slug,
   url,
 });
 
-/** Assert findPageUrl finds target page despite noisy items */
-const expectFindsTarget = (noisyItems) => {
-  const target = pageItem("hello-world", "/posts/hello-world/", ["post"]);
-  expect(findPageUrl([...noisyItems, target], "post", "hello-world")).toBe(
-    "/posts/hello-world/",
-  );
-};
-
-/** Create navigation item from [title, navOptions] tuple */
 const navItem = ([title, navOptions]) =>
   item(title, { eleventyNavigation: navOptions });
 
-/** Transform tuples to navigation items */
 const navItems = map(navItem);
 
-/** Create mock collection API from navigation tuples */
-const navCollectionApi = (tuples) => ({
-  getAll: () => navItems(tuples),
-});
-
-/** Setup configured navigation and return mockConfig */
-const withNavigation = async () => {
+const configureWithMock = async () => {
   const mockConfig = createMockEleventyConfig();
   await configureNavigation(mockConfig);
   return mockConfig;
 };
 
 const getNavLinks = async (entries) => {
-  const mockConfig = await withNavigation();
-  return mockConfig.collections.navigationLinks(navCollectionApi(entries));
+  const mockConfig = await configureWithMock();
+  return mockConfig.collections.navigationLinks({
+    getAll: () => navItems(entries),
+  });
 };
 
-/** Create a navigation entry as returned by eleventyNavigation filter */
 const navEntry = (key, options = {}) => ({
   key,
   title: options.title ?? key,
@@ -81,229 +60,211 @@ const navEntry = (key, options = {}) => ({
   children: options.children ?? [],
 });
 
-describe("navigation", () => {
-  test("Finds page URL by tag and slug", () => {
-    const collection = [
-      pageItem("hello-world", "/posts/hello-world/", ["post"]),
-      pageItem("about", "/about/", ["page"]),
-      pageItem("featured-post", "/posts/featured-post/", ["post", "featured"]),
-    ];
+describe("findPageUrl", () => {
+  const HELLO_WORLD = pageItem("hello-world", "/posts/hello-world/", ["post"]);
+  const ABOUT = pageItem("about", "/about/", ["page"]);
+  const FEATURED_POST = pageItem("featured-post", "/posts/featured-post/", [
+    "post",
+    "featured",
+  ]);
 
+  test("returns the URL of the matching tag + slug", () => {
+    const collection = [HELLO_WORLD, ABOUT, FEATURED_POST];
     expect(findPageUrl(collection, "post", "hello-world")).toBe(
       "/posts/hello-world/",
     );
   });
 
-  test("Finds page with multiple tags", () => {
-    const collection = [
-      pageItem("featured-post", "/posts/featured-post/", ["post", "featured"]),
-      pageItem("about", "/about/", ["page"]),
-    ];
-
-    expect(findPageUrl(collection, "featured", "featured-post")).toBe(
+  test("matches on any of the page's tags", () => {
+    expect(findPageUrl([FEATURED_POST], "featured", "featured-post")).toBe(
       "/posts/featured-post/",
     );
   });
 
-  test("Throws when page not found", () => {
+  test("matches exact slug even when similar slugs exist", () => {
+    const target = pageItem("hello-world", "/posts/hello-world/", ["post"]);
     const collection = [
-      pageItem("hello-world", "/posts/hello-world/", ["post"]),
+      pageItem("hello", "/posts/hello/", ["post"]),
+      pageItem("hello-world-2", "/posts/hello-world-2/", ["post"]),
+      target,
     ];
+    expect(findPageUrl(collection, "post", "hello-world")).toBe(target.url);
+  });
 
-    expect(() => findPageUrl(collection, "post", "nonexistent")).toThrow(
+  test("ignores items whose tags are missing or null", () => {
+    const target = pageItem("real", "/real/", ["post"]);
+    const noisy = [
+      { data: {}, fileSlug: "no-tags", url: "/no-tags/" },
+      pageItem("null-tags", "/null-tags/", null),
+    ];
+    expect(findPageUrl([...noisy, target], "post", "real")).toBe("/real/");
+  });
+
+  test("throws when the slug is not present", () => {
+    expect(() => findPageUrl([HELLO_WORLD], "post", "nonexistent")).toThrow(
       'Slug "nonexistent" not found',
     );
   });
 
-  test("Throws when slug exists but tag does not match", () => {
-    const collection = [
-      pageItem("hello-world", "/posts/hello-world/", ["post"]),
-    ];
-
-    expect(() => findPageUrl(collection, "page", "hello-world")).toThrow(
+  test("throws when the slug exists but the tag does not match", () => {
+    expect(() => findPageUrl([HELLO_WORLD], "page", "hello-world")).toThrow(
       'Page "hello-world" does not have tag "page"',
     );
   });
 
-  test("Handles items without tags", () => {
-    expectFindsTarget([{ data: {}, fileSlug: "no-tags", url: "/no-tags/" }]);
-  });
-
-  test("Handles items with null tags", () => {
-    expectFindsTarget([pageItem("null-tags", "/null-tags/", null)]);
-  });
-
-  test("Throws for empty collection", () => {
-    expect(() => findPageUrl([], "post", "test")).toThrow(
-      'Slug "test" not found',
-    );
-  });
-
-  test("Matches on exact slug even if there are similar items", () => {
-    expectFindsTarget([
-      pageItem("hello", "/posts/hello/", ["post"]),
-      pageItem("hello-world-2", "/posts/hello-world-2/", ["post"]),
-    ]);
-  });
-
-  test("Configures navigation filters in Eleventy", async () => {
-    const mockConfig = await withNavigation();
-
-    expect(typeof mockConfig.asyncFilters.toNavigation).toBe("function");
-    expect(typeof mockConfig.filters.pageUrl).toBe("function");
-    expect(mockConfig.filters.pageUrl).toBe(findPageUrl);
-  });
-
-  test("Creates navigationLinks collection that filters items", async () => {
-    const mockConfig = await withNavigation();
-    expect(typeof mockConfig.collections.navigationLinks).toBe("function");
-
-    const items = mockConfig.collections.navigationLinks(
-      navCollectionApi([
-        ["About", { key: "About", order: 2 }],
-        ["Home", { key: "Home", order: 1 }],
-      ]),
-    );
-
-    expectResultTitles(items, ["Home", "About"]);
-  });
-
-  test("navigationLinks collection excludes items without eleventyNavigation", async () => {
-    const mockConfig = await withNavigation();
-
-    const result = mockConfig.collections.navigationLinks({
-      getAll: () => [
-        item("Page 1", { eleventyNavigation: { key: "page-1" } }),
-        item("Page 2", {}),
-      ],
-    });
-
-    expect(result.length).toBe(1);
-    expectResultTitles(result, ["Page 1"]);
-  });
-
-  test("navigationLinks collection sorts by order, then by key", async () => {
-    const items = await getNavLinks([
-      ["Zebra", { key: "zebra", order: 2 }],
-      ["Apple", { key: "apple", order: 1 }],
-      ["Banana", { key: "banana", order: 1 }],
-    ]);
-
-    expectResultTitles(items, ["Apple", "Banana", "Zebra"]);
-  });
-
-  test("navigationLinks collection handles missing order", async () => {
-    const items = await getNavLinks([
-      ["Zebra", { key: "zebra" }],
-      ["Apple", { key: "apple" }],
-    ]);
-
-    expect(items.length).toBe(2);
-  });
-
-  test("Throws for empty collection with pageUrl", () => {
+  test("throws for an empty collection", () => {
     expect(() => findPageUrl([], "post", "test")).toThrow(
       'Slug "test" not found',
     );
   });
 });
 
-describe("toNavigation", () => {
-  test("Returns empty string for empty pages", async () => {
-    const result = await toNavigation([]);
-    expect(result).toBe("");
+describe("navigationLinks collection", () => {
+  test("excludes items without eleventyNavigation data", async () => {
+    const mockConfig = await configureWithMock();
+    const result = mockConfig.collections.navigationLinks({
+      getAll: () => [
+        item("Included", { eleventyNavigation: { key: "included" } }),
+        item("Excluded", {}),
+      ],
+    });
+    expectResultTitles(result, ["Included"]);
   });
 
-  test("Throws error for invalid input without pluginType", async () => {
-    const invalidPages = [{ key: "Home", title: "Home" }];
-    await expect(toNavigation(invalidPages)).rejects.toThrow(
+  test("sorts by eleventyNavigation.order", async () => {
+    const result = await getNavLinks([
+      ["Second", { key: "second", order: 2 }],
+      ["First", { key: "first", order: 1 }],
+    ]);
+    expectResultTitles(result, ["First", "Second"]);
+  });
+
+  test("breaks ties on order using key alphabetically", async () => {
+    const result = await getNavLinks([
+      ["Zebra", { key: "zebra", order: 1 }],
+      ["Apple", { key: "apple", order: 1 }],
+      ["Banana", { key: "banana", order: 1 }],
+    ]);
+    expectResultTitles(result, ["Apple", "Banana", "Zebra"]);
+  });
+
+  test("sorts items without an order alphabetically at the end", async () => {
+    const result = await getNavLinks([
+      ["No Order Z", { key: "z" }],
+      ["First", { key: "a", order: 1 }],
+      ["No Order A", { key: "a-no" }],
+    ]);
+    expectResultTitles(result, ["First", "No Order A", "No Order Z"]);
+  });
+});
+
+describe("configureNavigation wiring", () => {
+  test("registers pageUrl filter that finds URLs", async () => {
+    const mockConfig = await configureWithMock();
+    const collection = [pageItem("widget", "/products/widget/", ["product"])];
+    expect(mockConfig.filters.pageUrl(collection, "product", "widget")).toBe(
+      "/products/widget/",
+    );
+  });
+
+  test("registers async toNavigation filter", async () => {
+    const mockConfig = await configureWithMock();
+    expect(await mockConfig.asyncFilters.toNavigation([])).toBe("");
+  });
+});
+
+describe("toNavigation", () => {
+  test("returns empty string for empty pages", async () => {
+    expect(await toNavigation([])).toBe("");
+  });
+
+  test("throws when input is missing the eleventyNavigation pluginType", async () => {
+    const bare = [{ key: "Home", title: "Home" }];
+    await expect(toNavigation(bare)).rejects.toThrow(
       "toNavigation requires eleventyNavigation filter first",
     );
   });
 
-  test("Renders navigation with active class", () =>
+  test("marks the active entry with class='active'", () =>
     withIconMock(async () => {
-      const pages = [navEntry("Home", { url: "/" })];
-      const result = await toNavigation(pages, "Home");
-      expect(result).toContain('class="active"');
+      const html = await toNavigation([navEntry("Home", { url: "/" })], "Home");
+      expect(html).toContain('class="active"');
+      expect(html).toContain('href="/"');
     }));
 
-  test("Renders multiple nav items with hrefs", () =>
+  test("only marks the matching entry as active, not its siblings", () =>
     withIconMock(async () => {
-      const pages = [navEntry("Home", { url: "/" }), navEntry("About")];
-      const result = await toNavigation(pages, "");
-      expect(result).toContain("Home");
-      expect(result).toContain("About");
-      expect(result).toContain('href="/"');
-      expect(result).toContain('href="/about/"');
+      const html = await toNavigation(
+        [navEntry("Home", { url: "/" }), navEntry("About")],
+        "About",
+      );
+      const activeMatches = html.match(/class="active"/g);
+      expect(activeMatches).toHaveLength(1);
+      expect(html).toMatch(/class="active"[^>]*>.*About/);
     }));
 
-  test("Renders nested children", () =>
+  test("renders children inside a nested ul", () =>
     withIconMock(async () => {
-      const pages = [
-        navEntry("Products", {
-          children: [navEntry("Category A"), navEntry("Category B")],
-        }),
-      ];
-      const result = await toNavigation(pages, "");
-      expect(result).toContain("Products");
-      expect(result).toContain("Category A");
-      expect(result.match(/<ul/g).length).toBeGreaterThan(1);
+      const html = await toNavigation(
+        [
+          navEntry("Products", {
+            children: [navEntry("Category A"), navEntry("Category B")],
+          }),
+        ],
+        "",
+      );
+      expect(html).toContain("Category A");
+      expect(html).toContain("Category B");
+      expect(html.match(/<ul/g)).toHaveLength(2);
     }));
 
-  test("Does not render caret button for any items", () =>
+  test("renders entries without a href when url is missing", () =>
     withIconMock(async () => {
-      const pages = [
-        navEntry("Products", {
-          children: [navEntry("Category A")],
-        }),
-      ];
-      const result = await toNavigation(pages, "");
-      expect(result).not.toContain("nav-caret");
+      const html = await toNavigation(
+        [
+          {
+            key: "No Link",
+            title: "No Link",
+            pluginType: "eleventy-navigation",
+            data: {},
+            children: [],
+          },
+        ],
+        "",
+      );
+      expect(html).toContain("No Link");
+      expect(html).not.toContain("href=");
     }));
 
-  test("Renders entry without href when url is missing", () =>
+  test("does not render a thumbnail for root-level entries", () =>
     withIconMock(async () => {
-      const pages = [
-        {
-          key: "No Link",
-          title: "No Link",
-          pluginType: "eleventy-navigation",
-          data: {},
-          children: [],
-        },
-      ];
-      const result = await toNavigation(pages, "");
-      expect(result).toContain("No Link");
-      expect(result).not.toContain("href=");
+      const html = await toNavigation(
+        [
+          navEntry("Products", {
+            data: { thumbnail: "images/placeholders/blue.svg" },
+          }),
+        ],
+        "",
+      );
+      expect(html).not.toContain("<picture");
+      expect(html).not.toContain("<img");
     }));
 
-  const childWithThumbnail = () => [
-    navEntry("Products", {
-      children: [
-        navEntry("Category A", {
-          data: { thumbnail: "images/placeholders/blue.svg" },
-        }),
-      ],
-    }),
-  ];
-
-  test("Skips thumbnails for root-level navigation items", () =>
+  test("renders a thumbnail for a child entry when nav_thumbnails is on", () =>
     withIconMock(async () => {
-      const pages = [
-        navEntry("Products", {
-          data: { thumbnail: "images/placeholders/blue.svg" },
-        }),
-      ];
-      const result = await toNavigation(pages, "");
-      expect(result).not.toContain("<picture");
-      expect(result).not.toContain("<img");
-    }));
-
-  test("Renders thumbnail for child navigation items when nav_thumbnails is enabled", () =>
-    withIconMock(async () => {
-      const result = await toNavigation(childWithThumbnail(), "");
-      expect(result).toContain("<picture");
-      expect(result).toContain("<img");
+      const html = await toNavigation(
+        [
+          navEntry("Products", {
+            children: [
+              navEntry("Category A", {
+                data: { thumbnail: "images/placeholders/blue.svg" },
+              }),
+            ],
+          }),
+        ],
+        "",
+      );
+      expect(html).toContain("<picture");
+      expect(html).toContain("<img");
     }));
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.js", ".eleventy.js"],
+  "include": ["src/**/*.js", "src/_lib/types/**/*.d.ts", ".eleventy.js"],
   "exclude": ["node_modules", "_site", "coverage", "src/_lib/public/**/*.js"]
 }


### PR DESCRIPTION
## Summary

- Rewrite `test/unit/collections/navigation.test.js` to drop
  tautological and duplicate tests and cover real behaviour more
  tightly.
- Add JSDoc types throughout `src/_lib/collections/navigation.js` so
  the file is strict-clean, and lower
  `CURRENT_ERROR_COUNT` from 380 → 367.

## Test changes

Problems in the old file:
- Assertions paired `.toHaveLength(n)` with `.toEqual([...])` on the
  same value — the equality check already verifies length.
- `expect(mockConfig.filters.pageUrl).toBe(findPageUrl)` tested object
  identity (implementation wiring), not behaviour.
- Two tests with literally identical assertions (`"Throws for empty
  collection"` and `"Throws for empty collection with pageUrl"`).
- `"Does not render caret button"` asserted the absence of a deleted
  feature.
- The `navigationLinks` sort tests did not actually exercise the
  order-then-key fallback path in `sortNavigationItems`.

The rewrite:
- Splits the file into four `describe` blocks: `findPageUrl`,
  `navigationLinks collection`, `configureNavigation wiring`,
  `toNavigation`.
- Wiring tests now call the registered filter with a real input so
  they'd catch a miswire, not just a missing registration.
- Adds a test for the multi-item active-class case (only the matching
  entry is marked active), and a test for the order-then-key fallback.

21 tests, 37 expect calls, runs in ~0.5s.

## Type changes

`navigation.js` now has `@param`/`@returns` on every function. The
fiddly parts:
- `@11ty/eleventy-navigation` ships no declarations, so
  `types/eleventy-navigation.d.ts` adds an ambient module
  declaration for the default export (a plugin function).
- The shape the `eleventyNavigation` filter produces is captured as
  `NavigationEntry` in `types/navigation.d.ts`. It reuses
  `EleventyCollectionItemData` for the `data` slot instead of
  redefining fields.
- `entry.url` is `string | undefined`, but `ElementAttributes` is
  `Record<string, string | null>`. Coercing with `url ?? null`
  upfront lets the object literal be inferred as the expected type —
  no inline `@type` cast needed (which would also violate the
  inline-type-annotations code-quality rule).
- `RenderChildren` is hoisted to a module-level typedef so the
  recursive helper can reference itself without an inline cast.

## Compromises

- `tsconfig.json` `include` was widened from `src/**/*.js` to also
  pick up `src/_lib/types/**/*.d.ts`. This is needed for the ambient
  module declaration to be part of the program — previously .d.ts
  files were only pulled in via explicit imports, which doesn't work
  for ambient declarations. No other errors appeared from the
  widened include (count held at 380 before adding types).
- `configureNavigation` is typed as `(eleventyConfig: EleventyConfig)`
  from `11ty.ts`. This is consistent with other
  strict-clean collections (`tags.js`), though some files use `*`.

## Test plan

- [x] `bun test test/unit/collections/navigation.test.js` — 21 pass
- [x] `bun run precommit` — all checks pass (lint, typecheck, strict
      typecheck, dup detection, tests)
- [x] Ratchet passes at 367 with navigation.js in the clean list

https://claude.ai/code/session_01Ethmo6YfNgp4eaKehQS89W