### PR TITLE
Make description optional in feature block items

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -173,10 +173,7 @@ components:
             type: string
             label: Icon (Iconify ID or HTML entity)
           - { name: title, type: string, label: Title, required: true }
-          - name: description
-            type: rich-text
-            label: Description
-            required: true
+          - { name: description, type: rich-text, label: Description }
           - { name: style, type: string, label: Custom Style }
       - { name: intro, type: rich-text, label: Intro Content (Markdown) }
       - { name: heading_level, type: number, label: Heading Level }

--- a/src/_lib/utils/block-schema/features.js
+++ b/src/_lib/utils/block-schema/features.js
@@ -16,7 +16,7 @@ export const fields = {
     ...objectList("Features", {
       icon: str("Icon (Iconify ID or HTML entity)"),
       title: TITLE_REQUIRED,
-      description: md("Description", { required: true }),
+      description: md("Description"),
       style: str("Custom Style"),
     }),
     required: true,


### PR DESCRIPTION
## Summary

- Removes `required: true` from the `description` field in feature block items (`src/_lib/utils/block-schema/features.js`)

## Test plan

- [x] `bun test test/unit/utils/block-schema.test.js` — all 151 tests pass

https://claude.ai/code/session_01Ayi4JrYYrMbhydv8W4gREM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ayi4JrYYrMbhydv8W4gREM)_