### PR TITLE
Surface per-file uncovered lines and branches on coverage failure

### DIFF
--- a/test/test-runner-utils.js
+++ b/test/test-runner-utils.js
@@ -3,6 +3,8 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { ROOT_DIR } from "#lib/paths.js";
 
 const rootDir = ROOT_DIR;
@@ -55,6 +57,165 @@ export const printTruncatedList =
       );
     }
   };
+
+/**
+ * Extract uncovered line numbers from DA: entries in an lcov record.
+ * @param {string} record - A single lcov record (between SF: and end_of_record)
+ * @returns {number[]} Line numbers with zero hits
+ */
+export const extractUncoveredLines = (record) => {
+  const matches = record.matchAll(/^DA:(\d+),0$/gm);
+  const lines = [];
+  for (const m of matches) lines.push(Number.parseInt(m[1], 10));
+  return lines;
+};
+
+/**
+ * Extract uncovered branch line numbers from BRDA: entries, deduped by line.
+ * First-seen order is preserved.
+ * @param {string} record - A single lcov record
+ * @returns {number[]} Line numbers with at least one uncovered branch
+ */
+export const extractUncoveredBranchLines = (record) => {
+  const matches = record.matchAll(/^BRDA:(\d+),\d+,\d+,(-|0)$/gm);
+  const seen = new Set();
+  const lines = [];
+  for (const m of matches) {
+    const line = Number.parseInt(m[1], 10);
+    if (!seen.has(line)) {
+      seen.add(line);
+      lines.push(line);
+    }
+  }
+  return lines;
+};
+
+/**
+ * Format uncovered line numbers as an indented suffix, or "" if none.
+ * @param {string} label - Label for the list (e.g. "lines", "branches")
+ * @param {number[]} nums - Uncovered line numbers
+ * @returns {string}
+ */
+export const formatUncovered = (label, nums) => {
+  if (nums.length === 0) return "";
+  return `\n      uncovered ${label}: ${nums.join(", ")}`;
+};
+
+/**
+ * Check a coverage metric (lines or branches) in an lcov record.
+ * @param {string} record - A single lcov record
+ * @param {string} hitKey - Key for hit count (e.g. "LH", "BRH")
+ * @param {string} foundKey - Key for found count (e.g. "LF", "BRF")
+ * @param {string} file - Source file path
+ * @param {string} label - Human label for the metric
+ * @param {string} uncoveredSuffix - Precomputed suffix from formatUncovered
+ * @returns {string|undefined} Failure string or undefined when fully covered
+ */
+export const checkMetric = (
+  record,
+  hitKey,
+  foundKey,
+  file,
+  label,
+  uncoveredSuffix,
+) => {
+  const hitMatch = record.match(new RegExp(`^${hitKey}:(\\d+)$`, "m"));
+  const foundMatch = record.match(new RegExp(`^${foundKey}:(\\d+)$`, "m"));
+  if (!hitMatch || !foundMatch) return undefined;
+  const hit = Number.parseInt(hitMatch[1], 10);
+  const found = Number.parseInt(foundMatch[1], 10);
+  return hit < found
+    ? `${file}: ${hit}/${found} ${label} covered${uncoveredSuffix}`
+    : undefined;
+};
+
+/**
+ * Check line and branch metrics on an lcov record, pushing failures into the
+ * provided arrays.
+ * @param {string} record - A single lcov record
+ * @param {string} file - Source file path (from SF:)
+ * @param {string[]} lineFailures - Mutated with line-coverage failures
+ * @param {string[]} branchFailures - Mutated with branch-coverage failures
+ */
+export const checkRecord = (record, file, lineFailures, branchFailures) => {
+  const lineSuffix = formatUncovered("lines", extractUncoveredLines(record));
+  const branchSuffix = formatUncovered(
+    "branches",
+    extractUncoveredBranchLines(record),
+  );
+  const lineFail = checkMetric(record, "LH", "LF", file, "lines", lineSuffix);
+  if (lineFail) lineFailures.push(lineFail);
+  const branchFail = checkMetric(
+    record,
+    "BRH",
+    "BRF",
+    file,
+    "branches",
+    branchSuffix,
+  );
+  if (branchFail) branchFailures.push(branchFail);
+};
+
+/**
+ * Read coveragePathIgnorePatterns from bunfig.toml.
+ * Returns [] when the file does not exist.
+ * Throws when the file exists but the expected array block is missing.
+ * @param {string} bunfigPath - Absolute path to bunfig.toml
+ * @returns {string[]}
+ */
+export const readCoverageIgnorePatterns = (bunfigPath) => {
+  if (!existsSync(bunfigPath)) return [];
+  const text = readFileSync(bunfigPath, "utf8");
+  const block = text.match(/coveragePathIgnorePatterns\s*=\s*\[([\s\S]*?)\]/);
+  if (!block) {
+    throw new Error(
+      `coveragePathIgnorePatterns not found in ${bunfigPath}. ` +
+        "If the key was renamed, update readCoverageIgnorePatterns.",
+    );
+  }
+  const entries = [];
+  for (const m of block[1].matchAll(/"([^"]+)"/g)) entries.push(m[1]);
+  return entries;
+};
+
+/**
+ * Parse an lcov.info text into per-file failure strings.
+ * @param {string} lcovText - Contents of lcov.info
+ * @param {string[]} excludes - Paths to skip (from coveragePathIgnorePatterns)
+ * @returns {{ lineFailures: string[], branchFailures: string[] }}
+ */
+export const parseLcov = (lcovText, excludes) => {
+  const excludeSet = new Set(excludes);
+  const lineFailures = [];
+  const branchFailures = [];
+  const records = lcovText.split(/^end_of_record$/m);
+  for (const record of records) {
+    const sfMatch = record.match(/^SF:(.+)$/m);
+    if (!sfMatch) continue;
+    const file = sfMatch[1].trim();
+    if (excludeSet.has(file)) continue;
+    checkRecord(record, file, lineFailures, branchFailures);
+  }
+  return { lineFailures, branchFailures };
+};
+
+/**
+ * When a coverage failure occurs, read lcov.info and print per-file gaps.
+ * @param {string} lcovPath - Absolute path to coverage/lcov.info
+ * @param {string} bunfigPath - Absolute path to bunfig.toml
+ * @returns {boolean} True when a report was printed, false otherwise
+ */
+export const reportCoverageFailures = (lcovPath, bunfigPath) => {
+  if (!existsSync(lcovPath)) return false;
+  const lcovText = readFileSync(lcovPath, "utf8");
+  const excludes = readCoverageIgnorePatterns(bunfigPath);
+  const { lineFailures, branchFailures } = parseLcov(lcovText, excludes);
+  const all = [...lineFailures, ...branchFailures];
+  if (all.length === 0) return false;
+  console.log("\n  Per-file coverage gaps:");
+  printTruncatedList({ prefix: "    ", moreLabel: "files" })(all);
+  return true;
+};
 
 /**
  * Common step definitions used by test runners
@@ -276,6 +437,51 @@ export function runSteps({ steps, verbose, title }) {
 }
 
 /**
+ * Print the coverage-failure diagnostic block when the failed step output
+ * matches the "tests passed + coverage table present" heuristic.
+ */
+const printCoverageFailureBlock = () => {
+  const lcovPath = join(rootDir, "coverage/lcov.info");
+  const bunfigPath = join(rootDir, "bunfig.toml");
+  const reported = reportCoverageFailures(lcovPath, bunfigPath);
+  if (!reported) {
+    console.log("  Coverage threshold not met. Check coverage output above.");
+  }
+  console.log("  Thresholds are defined in bunfig.toml (coverageThreshold).");
+};
+
+/**
+ * Print the generic "last 15 lines" fallback for a failed step with no
+ * specific errors extracted.
+ */
+const printGenericFailureBlock = (result, allOutput) => {
+  console.log("  No specific errors extracted. Last 15 lines of output:");
+  const outputLines = allOutput.split("\n");
+  const lastLines = outputLines.slice(-15).filter((l) => l.trim());
+  for (const line of lastLines) {
+    console.log(`  ${line}`);
+  }
+  console.log("\n  Run with --verbose to see full output, or check exit code:");
+  console.log(`  Exit code: ${result.status}`);
+};
+
+/**
+ * Print diagnostics for a single failing step when no errors were extracted.
+ * Branches between the coverage-failure report and the generic fallback.
+ */
+const printStepFailureDiagnostics = (result) => {
+  const allOutput = result.stderr || result.stdout || "";
+  const hasPassingTests = /\d+ pass/.test(allOutput);
+  const hasZeroFail = /0 fail/.test(allOutput);
+  const hasCoverageTable = /% Funcs.*% Lines/.test(allOutput);
+  if (hasPassingTests && hasZeroFail && hasCoverageTable) {
+    printCoverageFailureBlock();
+  } else {
+    printGenericFailureBlock(result, allOutput);
+  }
+};
+
+/**
  * Print a summary of test results
  * @param {Object[]} steps - Array of step configurations
  * @param {Object} results - Map of step names to results
@@ -321,35 +527,7 @@ export function printSummary(steps, results, title = "SUMMARY") {
       if (errors.length > 0) {
         printTruncatedList({ moreLabel: "errors" })(errors);
       } else {
-        // Check if this looks like a coverage threshold failure
-        // (tests passed but exit code 1, with coverage table in output)
-        const allOutput = result.stderr || result.stdout || "";
-        const hasPassingTests = /\d+ pass/.test(allOutput);
-        const hasZeroFail = /0 fail/.test(allOutput);
-        const hasCoverageTable = /% Funcs.*% Lines/.test(allOutput);
-
-        if (hasPassingTests && hasZeroFail && hasCoverageTable) {
-          console.log(
-            "  Coverage threshold not met. Check coverage output above.",
-          );
-          console.log(
-            "  Thresholds are defined in bunfig.toml (coverageThreshold).",
-          );
-        } else {
-          // Show last 15 lines of output when no specific errors extracted
-          console.log(
-            "  No specific errors extracted. Last 15 lines of output:",
-          );
-          const outputLines = allOutput.split("\n");
-          const lastLines = outputLines.slice(-15).filter((l) => l.trim());
-          for (const line of lastLines) {
-            console.log(`  ${line}`);
-          }
-          console.log(
-            "\n  Run with --verbose to see full output, or check exit code:",
-          );
-          console.log(`  Exit code: ${result.status}`);
-        }
+        printStepFailureDiagnostics(result);
       }
     }
   }

--- a/test/unit/test-runner-utils.test.js
+++ b/test/unit/test-runner-utils.test.js
@@ -754,20 +754,27 @@ Failed to compile
     });
 
     describe("reportCoverageFailures", () => {
+      const writeCoverageFixture = (tempDir, { lcovLines, bunfigBody }) => {
+        const lcovPath = path.join(tempDir, "lcov.info");
+        const bunfigPath = path.join(tempDir, "bunfig.toml");
+        fs.writeFileSync(lcovPath, [...lcovLines, ""].join("\n"));
+        fs.writeFileSync(bunfigPath, bunfigBody);
+        return { lcovPath, bunfigPath };
+      };
+
       test("prints per-file gaps and returns true when lcov has failures", () =>
         withTempDir("coverage-gaps", (tempDir) => {
-          const lcovPath = path.join(tempDir, "lcov.info");
-          const bunfigPath = path.join(tempDir, "bunfig.toml");
-          fs.writeFileSync(
-            lcovPath,
-            ["SF:src/a.js", "DA:1,0", "LH:0", "LF:1", "end_of_record", ""].join(
-              "\n",
-            ),
-          );
-          fs.writeFileSync(
-            bunfigPath,
-            'coveragePathIgnorePatterns = [\n  "src/ignored.js",\n]\n',
-          );
+          const { lcovPath, bunfigPath } = writeCoverageFixture(tempDir, {
+            lcovLines: [
+              "SF:src/a.js",
+              "DA:1,0",
+              "LH:0",
+              "LF:1",
+              "end_of_record",
+            ],
+            bunfigBody:
+              'coveragePathIgnorePatterns = [\n  "src/ignored.js",\n]\n',
+          });
 
           const logs = captureConsole(() => {
             const returned = reportCoverageFailures(lcovPath, bunfigPath);
@@ -793,13 +800,10 @@ Failed to compile
 
       test("returns false when every record in lcov is fully covered", () =>
         withTempDir("coverage-clean", (tempDir) => {
-          const lcovPath = path.join(tempDir, "lcov.info");
-          const bunfigPath = path.join(tempDir, "bunfig.toml");
-          fs.writeFileSync(
-            lcovPath,
-            ["SF:src/a.js", "LH:1", "LF:1", "end_of_record", ""].join("\n"),
-          );
-          fs.writeFileSync(bunfigPath, "coveragePathIgnorePatterns = [\n]\n");
+          const { lcovPath, bunfigPath } = writeCoverageFixture(tempDir, {
+            lcovLines: ["SF:src/a.js", "LH:1", "LF:1", "end_of_record"],
+            bunfigBody: "coveragePathIgnorePatterns = [\n]\n",
+          });
 
           const returned = reportCoverageFailures(lcovPath, bunfigPath);
 

--- a/test/unit/test-runner-utils.test.js
+++ b/test/unit/test-runner-utils.test.js
@@ -1,11 +1,25 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
 import {
+  checkMetric,
+  checkRecord,
   extractErrorsFromOutput,
+  extractUncoveredBranchLines,
+  extractUncoveredLines,
+  formatUncovered,
+  parseLcov,
   printSummary,
   printTruncatedList,
+  readCoverageIgnorePatterns,
+  reportCoverageFailures,
   runStep,
 } from "#test/test-runner-utils.js";
-import { captureConsole, withMockedProcessExit } from "#test/test-utils.js";
+import {
+  captureConsole,
+  withMockedProcessExit,
+  withTempDir,
+} from "#test/test-utils.js";
 import { mapObject } from "#toolkit/fp/object.js";
 
 // ============================================
@@ -520,6 +534,277 @@ Failed to compile
 
       expect(logs.length).toBe(10); // No "more" message
       expect(logs[9]).toBe("  item 10");
+    });
+  });
+
+  // ============================================
+  // lcov parsing Tests
+  // ============================================
+  describe("lcov parsing", () => {
+    describe("extractUncoveredLines", () => {
+      test("collects line numbers from DA:N,0 entries", () => {
+        const record = ["DA:3,0", "DA:4,2", "DA:10,0", "DA:11,1"].join("\n");
+
+        expect(extractUncoveredLines(record)).toEqual([3, 10]);
+      });
+
+      test("ignores DA entries with non-zero hit counts", () => {
+        const record = ["DA:1,5", "DA:2,3", "DA:3,1"].join("\n");
+
+        expect(extractUncoveredLines(record)).toEqual([]);
+      });
+
+      test("returns empty array when record has no DA lines", () => {
+        const record = "SF:src/foo.js\nLH:0\nLF:0";
+
+        expect(extractUncoveredLines(record)).toEqual([]);
+      });
+    });
+
+    describe("extractUncoveredBranchLines", () => {
+      test("collects lines from BRDA entries with zero and dash hits", () => {
+        const record = ["BRDA:5,0,0,0", "BRDA:7,0,0,-", "BRDA:9,0,0,2"].join(
+          "\n",
+        );
+
+        expect(extractUncoveredBranchLines(record)).toEqual([5, 7]);
+      });
+
+      test("dedupes multiple uncovered branches on the same line", () => {
+        const record = ["BRDA:12,0,0,0", "BRDA:12,0,1,0", "BRDA:12,0,2,-"].join(
+          "\n",
+        );
+
+        expect(extractUncoveredBranchLines(record)).toEqual([12]);
+      });
+
+      test("ignores BRDA entries with positive hit counts", () => {
+        const record = ["BRDA:3,0,0,4", "BRDA:3,0,1,1"].join("\n");
+
+        expect(extractUncoveredBranchLines(record)).toEqual([]);
+      });
+    });
+
+    describe("formatUncovered", () => {
+      test("returns empty string for empty list", () => {
+        expect(formatUncovered("lines", [])).toBe("");
+      });
+
+      test("formats non-empty list as indented suffix", () => {
+        expect(formatUncovered("lines", [3, 7, 12])).toBe(
+          "\n      uncovered lines: 3, 7, 12",
+        );
+      });
+    });
+
+    describe("checkMetric", () => {
+      test("returns undefined when hit equals found", () => {
+        const record = "LH:10\nLF:10";
+
+        expect(
+          checkMetric(record, "LH", "LF", "src/foo.js", "lines", ""),
+        ).toBeUndefined();
+      });
+
+      test("returns formatted failure string when hit is less than found", () => {
+        const record = "LH:8\nLF:10";
+        const suffix = "\n      uncovered lines: 3, 7";
+
+        expect(
+          checkMetric(record, "LH", "LF", "src/foo.js", "lines", suffix),
+        ).toBe(`src/foo.js: 8/10 lines covered${suffix}`);
+      });
+
+      test("returns undefined when metric keys are absent from record", () => {
+        const record = "SF:src/foo.js";
+
+        expect(
+          checkMetric(record, "LH", "LF", "src/foo.js", "lines", ""),
+        ).toBeUndefined();
+      });
+    });
+
+    describe("checkRecord", () => {
+      test("pushes line and branch failures for partially covered record", () => {
+        const record = [
+          "SF:src/foo.js",
+          "DA:3,0",
+          "DA:4,1",
+          "BRDA:5,0,0,0",
+          "BRDA:5,0,1,2",
+          "LH:1",
+          "LF:2",
+          "BRH:1",
+          "BRF:2",
+        ].join("\n");
+        const lineFailures = [];
+        const branchFailures = [];
+
+        checkRecord(record, "src/foo.js", lineFailures, branchFailures);
+
+        expect(lineFailures).toEqual([
+          "src/foo.js: 1/2 lines covered\n      uncovered lines: 3",
+        ]);
+        expect(branchFailures).toEqual([
+          "src/foo.js: 1/2 branches covered\n      uncovered branches: 5",
+        ]);
+      });
+
+      test("pushes nothing when record is fully covered", () => {
+        const record = [
+          "SF:src/bar.js",
+          "DA:1,3",
+          "DA:2,1",
+          "LH:2",
+          "LF:2",
+          "BRH:2",
+          "BRF:2",
+        ].join("\n");
+        const lineFailures = [];
+        const branchFailures = [];
+
+        checkRecord(record, "src/bar.js", lineFailures, branchFailures);
+
+        expect(lineFailures).toEqual([]);
+        expect(branchFailures).toEqual([]);
+      });
+    });
+
+    describe("parseLcov", () => {
+      const makeRecord = (file, lh, lf) =>
+        [`SF:${file}`, `LH:${lh}`, `LF:${lf}`, "end_of_record"].join("\n");
+
+      test("parses multiple records and collects per-file failures", () => {
+        const lcov = [
+          makeRecord("src/a.js", 1, 2),
+          makeRecord("src/b.js", 3, 3),
+          makeRecord("src/c.js", 0, 5),
+        ].join("\n");
+
+        const { lineFailures, branchFailures } = parseLcov(lcov, []);
+
+        expect(lineFailures).toEqual([
+          "src/a.js: 1/2 lines covered",
+          "src/c.js: 0/5 lines covered",
+        ]);
+        expect(branchFailures).toEqual([]);
+      });
+
+      test("skips records whose path matches the exclude list", () => {
+        const lcov = [
+          makeRecord("src/keep.js", 1, 2),
+          makeRecord("src/skip.js", 0, 4),
+        ].join("\n");
+
+        const { lineFailures } = parseLcov(lcov, ["src/skip.js"]);
+
+        expect(lineFailures).toEqual(["src/keep.js: 1/2 lines covered"]);
+      });
+
+      test("returns empty arrays when every record is fully covered", () => {
+        const lcov = [
+          makeRecord("src/a.js", 5, 5),
+          makeRecord("src/b.js", 2, 2),
+        ].join("\n");
+
+        const result = parseLcov(lcov, []);
+
+        expect(result.lineFailures).toEqual([]);
+        expect(result.branchFailures).toEqual([]);
+      });
+    });
+
+    describe("readCoverageIgnorePatterns", () => {
+      test("extracts quoted entries from the coveragePathIgnorePatterns array", () =>
+        withTempDir("ignore-patterns", (tempDir) => {
+          const bunfigPath = path.join(tempDir, "bunfig.toml");
+          fs.writeFileSync(
+            bunfigPath,
+            [
+              "[test]",
+              "coveragePathIgnorePatterns = [",
+              '  "src/skip-a.js",',
+              '  "src/skip-b.js",',
+              "]",
+              "",
+            ].join("\n"),
+          );
+
+          expect(readCoverageIgnorePatterns(bunfigPath)).toEqual([
+            "src/skip-a.js",
+            "src/skip-b.js",
+          ]);
+        }));
+
+      test("returns empty array when the file does not exist", () => {
+        expect(
+          readCoverageIgnorePatterns("/nonexistent/missing-bunfig.toml"),
+        ).toEqual([]);
+      });
+
+      test("throws when the array block is missing from an existing file", () =>
+        withTempDir("ignore-patterns-missing", (tempDir) => {
+          const bunfigPath = path.join(tempDir, "bunfig.toml");
+          fs.writeFileSync(bunfigPath, "[test]\ntimeout = 30000\n");
+
+          expect(() => readCoverageIgnorePatterns(bunfigPath)).toThrow(
+            /coveragePathIgnorePatterns/,
+          );
+        }));
+    });
+
+    describe("reportCoverageFailures", () => {
+      test("prints per-file gaps and returns true when lcov has failures", () =>
+        withTempDir("coverage-gaps", (tempDir) => {
+          const lcovPath = path.join(tempDir, "lcov.info");
+          const bunfigPath = path.join(tempDir, "bunfig.toml");
+          fs.writeFileSync(
+            lcovPath,
+            ["SF:src/a.js", "DA:1,0", "LH:0", "LF:1", "end_of_record", ""].join(
+              "\n",
+            ),
+          );
+          fs.writeFileSync(
+            bunfigPath,
+            'coveragePathIgnorePatterns = [\n  "src/ignored.js",\n]\n',
+          );
+
+          const logs = captureConsole(() => {
+            const returned = reportCoverageFailures(lcovPath, bunfigPath);
+            expect(returned).toBe(true);
+          });
+
+          expect(logs.some((l) => l.includes("Per-file coverage gaps"))).toBe(
+            true,
+          );
+          expect(
+            logs.some((l) => l.includes("src/a.js: 0/1 lines covered")),
+          ).toBe(true);
+        }));
+
+      test("returns false when lcov file does not exist", () => {
+        expect(
+          reportCoverageFailures(
+            "/nonexistent/lcov.info",
+            "/nonexistent/bunfig.toml",
+          ),
+        ).toBe(false);
+      });
+
+      test("returns false when every record in lcov is fully covered", () =>
+        withTempDir("coverage-clean", (tempDir) => {
+          const lcovPath = path.join(tempDir, "lcov.info");
+          const bunfigPath = path.join(tempDir, "bunfig.toml");
+          fs.writeFileSync(
+            lcovPath,
+            ["SF:src/a.js", "LH:1", "LF:1", "end_of_record", ""].join("\n"),
+          );
+          fs.writeFileSync(bunfigPath, "coveragePathIgnorePatterns = [\n]\n");
+
+          const returned = reportCoverageFailures(lcovPath, bunfigPath);
+
+          expect(returned).toBe(false);
+        }));
     });
   });
 });


### PR DESCRIPTION
## Summary

Applies the "extract uncovered lines and branches" pattern from the upstream run-tests diff to this project's test harness. When a coverage step fails, we now read `coverage/lcov.info` and surface exactly which lines and branches are uncovered per file, instead of only printing the generic `"Coverage threshold not met"` message.

Enforcement stays with Bun's `coverageThreshold` — this is a diagnostics-only change.

### Implementation

- New helpers in `test/test-runner-utils.js` mirroring the diff's API:
  - `extractUncoveredLines(record)` — `DA:N,0` entries
  - `extractUncoveredBranchLines(record)` — `BRDA:N,_,_,(0|-)` entries, deduped by line
  - `formatUncovered(label, nums)` — indented suffix
  - `checkMetric(record, hitKey, foundKey, file, label, uncoveredSuffix)` — per-metric failure string
  - `checkRecord(record, file, lineFailures, branchFailures)` — orchestrator
- New wrappers for integration:
  - `readCoverageIgnorePatterns(bunfigPath)` — regex-parses `coveragePathIgnorePatterns` from `bunfig.toml` (zero new deps; fails fast if the key disappears)
  - `parseLcov(lcovText, excludes)` — splits on `end_of_record`, applies excludes, walks each record
  - `reportCoverageFailures(lcovPath, bunfigPath)` — reads both files, prints `"  Per-file coverage gaps:"` followed by up to 10 entries via the existing `printTruncatedList({ moreLabel: "files" })`, returns `true` when anything was printed
- `printSummary` coverage-failure branch now calls `reportCoverageFailures` and falls back to the old generic message when lcov is absent or every record is clean. The branch was extracted into `printStepFailureDiagnostics` / `printCoverageFailureBlock` / `printGenericFailureBlock` to stay under the 30 cognitive-complexity cap for this file.
- 19 new unit tests in `test/unit/test-runner-utils.test.js` covering each helper, plus two file-I/O tests via `withTempDir` for `readCoverageIgnorePatterns` and `reportCoverageFailures`.

### Example output

```
  Per-file coverage gaps:
    src/foo.js: 2/4 lines covered
      uncovered lines: 3, 5
    src/foo.js: 1/3 branches covered
      uncovered branches: 3
  Thresholds are defined in bunfig.toml (coverageThreshold).
```

## Test plan

- [x] `bun test test/unit/test-runner-utils.test.js` — 54 pass
- [x] `bun test test/unit/precommit.test.js` — 19 pass (it snapshots parts of `test-runner-utils.js`; still passes)
- [x] `bun run lint` — clean
- [x] End-to-end simulation with a hand-crafted lcov: line/branch gaps are reported per file, `coveragePathIgnorePatterns` entries are excluded, fully covered files produce no output
- [ ] Manual verification on a real coverage failure (left for reviewer; see verification in the plan file)

https://claude.ai/code/session_019ZTKJzCorUKwGimt837Pzq

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZTKJzCorUKwGimt837Pzq)_