### PR TITLE
Fix mobile navigation scroll direction

### DIFF
--- a/src/css/_nav-mixins.scss
+++ b/src/css/_nav-mixins.scss
@@ -198,7 +198,7 @@
   background: var(--color-bg);
   top: 3rem;
   right: -100%;
-  bottom: 0;
+  height: calc(100vh - 3rem);
   width: 70%;
   max-width: 300px;
   overflow-y: scroll;

--- a/src/css/_nav-mixins.scss
+++ b/src/css/_nav-mixins.scss
@@ -201,7 +201,7 @@
   bottom: 0;
   width: 70%;
   max-width: 300px;
-  overflow-x: scroll;
+  overflow-y: scroll;
   display: flex;
   flex-direction: column;
   gap: $gap;


### PR DESCRIPTION
## Summary
Fixed the sticky mobile navigation menu to use vertical scrolling (`overflow-y`) instead of horizontal scrolling (`overflow-x`), and set an explicit height to properly constrain the menu below the sticky nav bar.

## Changes
- Updated `nav-mobile-menu` mixin in `src/css/_nav-mixins.scss`:
  - Changed `overflow-x: scroll` to `overflow-y: scroll` for vertical scrolling
  - Replaced `bottom: 0` with `height: calc(100vh - 3rem)` for proper height calculation

## Testing
- Build verified: `bun run build` completes successfully
- Linting verified: `bun run lint` passes