### PR TITLE
Set image-wrapper height to 100%

### DIFF
--- a/src/css/design-system/_image-background.scss
+++ b/src/css/design-system/_image-background.scss
@@ -41,6 +41,7 @@
       .image-wrapper {
         position: absolute;
         inset: 0;
+        height: 100%;
         background-size: cover;
       }
     }


### PR DESCRIPTION
## Summary
Added explicit `height: 100%` property to `.design-system .image-background > div .image-wrapper` selector to ensure the image wrapper fills the full height of its container.

## Changes
- Modified `src/css/design-system/_image-background.scss` to include `height: 100%` on the `.image-wrapper` rule

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThoNYszqjxLUrrwQmiG6Vf)_