### PR TITLE
Refactor image shortcode argument handling and reuse default image options

### DIFF
--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -33,7 +33,6 @@ import {
 } from "#media/image-pipeline.js";
 import { generatePlaceholderHtml } from "#media/image-placeholder.js";
 import {
-  DEFAULT_IMAGE_OPTIONS,
   buildWrapperStyles,
   filenameFormat,
   isExternalUrl,

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -33,6 +33,7 @@ import {
 } from "#media/image-pipeline.js";
 import { generatePlaceholderHtml } from "#media/image-placeholder.js";
 import {
+  DEFAULT_IMAGE_OPTIONS,
   buildWrapperStyles,
   filenameFormat,
   isExternalUrl,
@@ -45,8 +46,7 @@ import { memoize } from "#toolkit/fp/memoize.js";
 import { frozenObject } from "#toolkit/fp/object.js";
 
 const DEFAULT_OPTIONS = frozenObject({
-  outputDir: ".image-cache",
-  urlPath: "/img/",
+  ...DEFAULT_IMAGE_OPTIONS,
   svgShortCircuit: true,
   filenameFormat,
 });
@@ -191,26 +191,38 @@ const processAndWrapImage = async ({
   document = null,
   ...imageProps
 }) => {
-  if (isExternalUrl(imageProps.imageName)) {
+  const {
+    imageName,
+    alt,
+    classes,
+    sizes,
+    widths,
+    aspectRatio,
+    loading,
+    noLqip,
+    skipMaxWidth,
+  } = imageProps;
+
+  if (isExternalUrl(imageName)) {
     if (PLACEHOLDER_MODE) {
       const html = await generatePlaceholderHtml({
-        alt: imageProps.alt,
-        classes: imageProps.classes,
-        sizes: imageProps.sizes,
-        loading: imageProps.loading,
-        aspectRatio: imageProps.aspectRatio,
+        alt,
+        classes,
+        sizes,
+        loading,
+        aspectRatio,
       });
       return resolveOutput(html, returnElement, document);
     }
     return await processExternalImage({
-      src: imageProps.imageName,
-      alt: imageProps.alt,
-      loading: imageProps.loading,
-      classes: imageProps.classes,
-      sizes: imageProps.sizes,
-      widths: imageProps.widths,
-      aspectRatio: imageProps.aspectRatio,
-      skipMaxWidth: imageProps.skipMaxWidth,
+      src: imageName,
+      alt,
+      loading,
+      classes,
+      sizes,
+      widths,
+      aspectRatio,
+      skipMaxWidth,
       returnElement,
       document,
     });
@@ -291,20 +303,31 @@ const imageShortcode = async (
   noLqip = false,
   skipMaxWidth = false,
 ) => {
-  assertStringOrFalsy(loading, "loading", imageName);
-  assertStringOrFalsy(classes, "classes", imageName);
-  assertStringOrFalsy(sizes, "sizes", imageName);
-  assertStringOrFalsy(aspectRatio, "aspectRatio", imageName);
+  for (const [name, value] of [
+    ["loading", loading],
+    ["classes", classes],
+    ["sizes", sizes],
+    ["aspectRatio", aspectRatio],
+  ]) {
+    assertStringOrFalsy(value, name, imageName);
+  }
+
+  const normalized = {
+    classes: toStringOrNull(classes),
+    sizes: toStringOrNull(sizes),
+    aspectRatio: toStringOrNull(aspectRatio),
+    loading: toStringOrNull(loading),
+  };
 
   return processAndWrapImage({
     logName: `imageShortcode: ${imageName}`,
     imageName,
     alt,
-    classes: toStringOrNull(classes),
-    sizes: toStringOrNull(sizes),
+    classes: normalized.classes,
+    sizes: normalized.sizes,
     widths,
-    aspectRatio: toStringOrNull(aspectRatio),
-    loading: toStringOrNull(loading),
+    aspectRatio: normalized.aspectRatio,
+    loading: normalized.loading,
     noLqip,
     skipMaxWidth,
     returnElement: false,


### PR DESCRIPTION
### Motivation
- Reduce duplicated configuration and make image entrypoints easier to reason about while preserving existing `{% image %}` behavior.
- Simplify the hot path for image processing (shortcode + transform) to make the control flow and parameter handling clearer.
- Improve maintainability by centralizing defaults and removing repetitive argument coercion/validation code.

### Description
- Reuse shared defaults by basing `DEFAULT_OPTIONS` on `DEFAULT_IMAGE_OPTIONS` from `#media/image-utils.js` and layer only local overrides such as `svgShortCircuit` and `filenameFormat`.
- Destructure `imageProps` once in `processAndWrapImage` and reuse the extracted variables for placeholder and external-image branches to eliminate repeated `imageProps.xxx` access.
- Consolidate shortcode validation into a compact loop that calls `assertStringOrFalsy` for each optional string argument and normalize those values once into a `normalized` object before calling `processAndWrapImage`.
- Keep existing public API (`configureImages`, `imageShortcode`, `processAndWrapImage`) and `{% image %}` semantics unchanged while reducing boilerplate and duplication.

### Testing
- Ran unit tests `bun test test/unit/media/image-shortcode.test.js` and `bun test test/unit/media/image-utils.test.js`, both passed.
- Ran integration suite `bun test test/integration/build/image.test.js` where most tests passed but one integration case timed out in this environment (build subprocess timeout), the remainder of the file passed.
- Attempted `bunx @biomejs/biome check src/_lib/media/image.js` which could not complete in this environment due to external registry access returning HTTP 403.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0f8512f0832db2c15df3638a9a37)