### PR TITLE
Refactor image handling: centralize defaults, simplify external flow, and normalize shortcode args

### DIFF
--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -33,7 +33,6 @@ import {
 } from "#media/image-pipeline.js";
 import { generatePlaceholderHtml } from "#media/image-placeholder.js";
 import {
-  DEFAULT_IMAGE_OPTIONS,
   buildWrapperStyles,
   filenameFormat,
   isExternalUrl,

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -33,6 +33,7 @@ import {
 } from "#media/image-pipeline.js";
 import { generatePlaceholderHtml } from "#media/image-placeholder.js";
 import {
+  DEFAULT_IMAGE_OPTIONS,
   buildWrapperStyles,
   filenameFormat,
   isExternalUrl,
@@ -45,8 +46,7 @@ import { memoize } from "#toolkit/fp/memoize.js";
 import { frozenObject } from "#toolkit/fp/object.js";
 
 const DEFAULT_OPTIONS = frozenObject({
-  outputDir: ".image-cache",
-  urlPath: "/img/",
+  ...DEFAULT_IMAGE_OPTIONS,
   svgShortCircuit: true,
   filenameFormat,
 });
@@ -191,26 +191,37 @@ const processAndWrapImage = async ({
   document = null,
   ...imageProps
 }) => {
-  if (isExternalUrl(imageProps.imageName)) {
+  const {
+    imageName,
+    alt,
+    classes,
+    sizes,
+    widths,
+    aspectRatio,
+    loading,
+    skipMaxWidth,
+  } = imageProps;
+
+  if (isExternalUrl(imageName)) {
     if (PLACEHOLDER_MODE) {
       const html = await generatePlaceholderHtml({
-        alt: imageProps.alt,
-        classes: imageProps.classes,
-        sizes: imageProps.sizes,
-        loading: imageProps.loading,
-        aspectRatio: imageProps.aspectRatio,
+        alt,
+        classes,
+        sizes,
+        loading,
+        aspectRatio,
       });
       return resolveOutput(html, returnElement, document);
     }
     return await processExternalImage({
-      src: imageProps.imageName,
-      alt: imageProps.alt,
-      loading: imageProps.loading,
-      classes: imageProps.classes,
-      sizes: imageProps.sizes,
-      widths: imageProps.widths,
-      aspectRatio: imageProps.aspectRatio,
-      skipMaxWidth: imageProps.skipMaxWidth,
+      src: imageName,
+      alt,
+      loading,
+      classes,
+      sizes,
+      widths,
+      aspectRatio,
+      skipMaxWidth,
       returnElement,
       document,
     });
@@ -291,20 +302,31 @@ const imageShortcode = async (
   noLqip = false,
   skipMaxWidth = false,
 ) => {
-  assertStringOrFalsy(loading, "loading", imageName);
-  assertStringOrFalsy(classes, "classes", imageName);
-  assertStringOrFalsy(sizes, "sizes", imageName);
-  assertStringOrFalsy(aspectRatio, "aspectRatio", imageName);
+  for (const [name, value] of [
+    ["loading", loading],
+    ["classes", classes],
+    ["sizes", sizes],
+    ["aspectRatio", aspectRatio],
+  ]) {
+    assertStringOrFalsy(value, name, imageName);
+  }
+
+  const normalized = {
+    classes: toStringOrNull(classes),
+    sizes: toStringOrNull(sizes),
+    aspectRatio: toStringOrNull(aspectRatio),
+    loading: toStringOrNull(loading),
+  };
 
   return processAndWrapImage({
     logName: `imageShortcode: ${imageName}`,
     imageName,
     alt,
-    classes: toStringOrNull(classes),
-    sizes: toStringOrNull(sizes),
+    classes: normalized.classes,
+    sizes: normalized.sizes,
     widths,
-    aspectRatio: toStringOrNull(aspectRatio),
-    loading: toStringOrNull(loading),
+    aspectRatio: normalized.aspectRatio,
+    loading: normalized.loading,
     noLqip,
     skipMaxWidth,
     returnElement: false,


### PR DESCRIPTION
### Motivation

- Centralize default image configuration and reduce duplicated option values across the image pipeline.  
- Simplify the external-image handling path to avoid repeated property access and make placeholder generation clearer.  
- Normalize and validate shortcode arguments in one place to make input handling consistent and reduce repetitive assertions.

### Description

- Import and spread `DEFAULT_IMAGE_OPTIONS` into `DEFAULT_OPTIONS` so default `outputDir`/`urlPath` are maintained from a single source.  
- Destructure `imageProps` in `processAndWrapImage` and use the local variables when dispatching to `generatePlaceholderHtml` and `processExternalImage` to reduce repeated `imageProps.*` access.  
- Consolidate multiple `assertStringOrFalsy` calls into a loop and build a `normalized` object using `toStringOrNull` for `classes`, `sizes`, `aspectRatio`, and `loading` before calling `processAndWrapImage`.  
- Small cleanup and reordering of arguments for clarity in the external-image and shortcode paths.

### Testing

- Ran the project unit test suite with `npm test` and it completed successfully.  
- Ran the linter with `npm run lint` and no linting errors were reported.  
- Performed a local Eleventy build smoke test which produced the expected image cache outputs and image shortcodes rendered without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0f8512f0832db2c15df3638a9a37)