### PR TITLE
Make bunny-video-background thumbnail_url optional

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -36,10 +36,7 @@ components:
         type: string
         label: Bunny Stream Embed URL
         required: true
-      - name: thumbnail_url
-        type: string
-        label: Thumbnail URL
-        required: true
+      - { name: thumbnail_url, type: string, label: Thumbnail URL }
       - { name: video_title, type: string, label: Video Title }
       - { name: class, type: string, label: CSS Class }
       - name: content

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -471,7 +471,7 @@ Bunny CDN video background with player.js-powered thumbnail that fades when play
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `video_url` | string | **required** | Bunny Stream embed URL. |
-| `thumbnail_url` | string | **required** | Thumbnail image URL. Displayed as a placeholder until video playback begins. |
+| `thumbnail_url` | string | — | Thumbnail image URL. Displayed as a placeholder until video playback begins. |
 | `video_title` | string | `"Background video"` | Accessible `title` on the iframe. |
 | `class` | string | — | Extra CSS classes. |
 | `content` | string | **required** | Overlay content. Rendered as markdown in `<figcaption class="prose">`. |

--- a/src/_includes/design-system/bunny-video-background.html
+++ b/src/_includes/design-system/bunny-video-background.html
@@ -8,7 +8,7 @@ that use this block.
 
 Parameters (via block object):
   - block.video_url: Bunny Stream embed URL (required)
-  - block.thumbnail_url: Thumbnail image shown while video loads (required)
+  - block.thumbnail_url: Thumbnail image shown while video loads (optional)
   - block.video_title: Accessible title for the iframe (default: "Background video")
   - block.content: HTML/markdown content to overlay on the video (required)
   - block.class: Additional classes for the container (optional)
@@ -20,9 +20,11 @@ Usage:
 {%- assign _video_title = block.video_title | default: "Background video" -%}
 
 <div class="video-background{% if block.class %} {{ block.class }}{% endif %}" data-bunny-video>
+  {%- if block.thumbnail_url -%}
   <div class="video-background__thumbnail">
     {% image block.thumbnail_url, _video_title, "2560,1920,1280,960,640", "", "100vw", "16/9", "", false, true %}
   </div>
+  {%- endif -%}
   <iframe
     src="{{ block.video_url }}"
     title="{{ _video_title }}"
@@ -38,4 +40,6 @@ Usage:
   </figure>
 </div>
 
+{%- if block.thumbnail_url -%}
 <script type="module" src="{{ '/assets/js/bunny-video.js' | cacheBust }}"></script>
+{%- endif -%}

--- a/src/_lib/utils/block-schema/bunny-video-background.js
+++ b/src/_lib/utils/block-schema/bunny-video-background.js
@@ -12,7 +12,6 @@ export const fields = {
   },
   thumbnail_url: {
     ...str("Thumbnail URL"),
-    required: true,
     description:
       "Thumbnail image URL. Displayed as a placeholder until video playback begins.",
   },


### PR DESCRIPTION
## Summary
- Drops `required: true` from `thumbnail_url` on the `bunny-video-background` block schema, matching the regular `video-background` block where it is optional.
- Skips the `<div class="video-background__thumbnail">` and the `bunny-video.js` script tag when no thumbnail is provided (the script's only job is to fade the thumbnail out when playback starts).

## Test plan
- [x] `bun test test/unit/utils/block-schema.test.js`
- [x] `bun test test/unit/utils/block-columns.test.js test/unit/code-quality/html-in-js.test.js`
- [x] `bun run build`
- [x] `bun run lint`
- [ ] Visually confirm a `bunny-video-background` block with no `thumbnail_url` autoplays in-browser (autoplay/muted come from the embed URL, so no JS is required for that)

https://claude.ai/code/session_01LEsgj7AE5RseqERtesCi4b

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEsgj7AE5RseqERtesCi4b)_