### PR TITLE
Make links inside .design-system .cta visible

### DIFF
--- a/src/css/design-system/_cta.scss
+++ b/src/css/design-system/_cta.scss
@@ -20,6 +20,11 @@
       max-width: $width-narrow;
     }
 
+    a:not(.btn) {
+      color: var(--color-contrast-text);
+      text-decoration: underline;
+    }
+
     .btn--secondary {
       border-color: var(--color-contrast-text);
       color: var(--color-contrast-text);


### PR DESCRIPTION
## Summary
- Plain anchors inside the `.design-system .cta` block were using the default `--color-link`, which is invisible against the brand-gradient background.
- Apply `var(--color-contrast-text)` and an underline to `a:not(.btn)` so links inherit the same color as the surrounding text while staying distinguishable.
- `.btn` / `.btn--secondary` styling is unchanged.

## Test plan
- [ ] Visually verify a CTA containing an inline link shows the link in the contrast color with an underline across themes.
- [ ] Confirm `.btn--secondary` inside a CTA still renders with its existing styling.

https://claude.ai/code/session_01HGHCC7Q3KVidANjNoUAoza

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGHCC7Q3KVidANjNoUAoza)_