### PR TITLE
Set meta_title max to 60 and meta_description max to 160

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -14,12 +14,12 @@ components:
     type: string
     label: Meta Title
     options:
-      maxlength: 55
+      maxlength: 60
   meta_description:
     type: string
     label: Meta Description
     options:
-      maxlength: 155
+      maxlength: 160
   videos:
     label: Videos
     type: object

--- a/scripts/customise-cms/fields.js
+++ b/scripts/customise-cms/fields.js
@@ -49,14 +49,14 @@ export const COMMON_FIELDS = {
     type: "string",
     label: "Meta Title",
     _componentName: "meta_title",
-    options: { maxlength: 55 },
+    options: { maxlength: 60 },
   },
   meta_description: {
     name: "meta_description",
     type: "string",
     label: "Meta Description",
     _componentName: "meta_description",
-    options: { maxlength: 155 },
+    options: { maxlength: 160 },
   },
   permalink: { name: "permalink", type: "string", label: "Permalink" },
   redirect_from: {


### PR DESCRIPTION
## Summary
- Bump CMS `meta_title` maxlength from 55 to 60
- Bump CMS `meta_description` maxlength from 155 to 160

## Test plan
- [x] `bun test test/unit/scripts/customise-cms/generator.test.js` passes
- [x] `bun run lint` clean

https://claude.ai/code/session_01CoBGjgYXNgfpebXFYStbNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoBGjgYXNgfpebXFYStbNm)_