### PR TITLE
Add image_aspect_ratio field to items and items-array blocks

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -316,6 +316,7 @@ components:
           - { name: includes, type: string, label: Contains }
           - { name: equals, type: string, label: Equals }
       - { name: header_intro, type: rich-text, label: Header Intro }
+      - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
   block_items_array:
     label: Items Array
     type: object
@@ -335,6 +336,7 @@ components:
           - { name: includes, type: string, label: Contains }
           - { name: equals, type: string, label: Equals }
       - { name: header_intro, type: rich-text, label: Header Intro }
+      - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
   block_link_button:
     label: Link Button
     type: object

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -519,6 +519,7 @@ Displays an Eleventy collection as a card grid or horizontal slider.
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
 | `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
 | `header_class` | string | — | Extra CSS classes on the section header. |
+| `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
 
 ---
 
@@ -540,6 +541,7 @@ Renders items from an explicit list of paths. The collection is inferred dynamic
 | `header_intro` | string | — | Section header content rendered as markdown above the block. |
 | `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
 | `header_class` | string | — | Extra CSS classes on the section header. |
+| `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
 
 ---
 

--- a/src/_includes/design-system/items-array-block.html
+++ b/src/_includes/design-system/items-array-block.html
@@ -17,4 +17,4 @@ Parameters (from block):
 
 {%- assign resolvedPaths = block.items -%}
 {%- assign blockItems = collections.all | getItemsByPath: resolvedPaths -%}
-{%- include "design-system/render-items-block.html" -%}
+{%- include "design-system/render-items-block.html", block: block, image_aspect_ratio: block.image_aspect_ratio -%}

--- a/src/_includes/design-system/items-block.html
+++ b/src/_includes/design-system/items-block.html
@@ -13,4 +13,4 @@ Parameters (from block):
 {%- endcomment -%}
 
 {%- assign blockItems = collections[block.collection] -%}
-{%- include "design-system/render-items-block.html" -%}
+{%- include "design-system/render-items-block.html", block: block, image_aspect_ratio: block.image_aspect_ratio -%}

--- a/src/_includes/design-system/render-items-block.html
+++ b/src/_includes/design-system/render-items-block.html
@@ -7,4 +7,4 @@ Expects blockItems and block variables to be set by the caller.
 {%- if block.filter -%}
   {%- assign blockItems = blockItems | filterItems: block.filter -%}
 {%- endif -%}
-{%- include "items.html", items: blockItems, horizontal: block.horizontal, masonry: block.masonry -%}
+{%- include "items.html", items: blockItems, horizontal: block.horizontal, masonry: block.masonry, image_aspect_ratio: image_aspect_ratio -%}

--- a/src/_includes/items.html
+++ b/src/_includes/items.html
@@ -20,7 +20,7 @@
   {%- endfor -%}
 {%- else -%}
   {%- for item in items -%}
-    {%- include "list-item.html" -%}
+    {%- include "list-item.html", image_aspect_ratio: image_aspect_ratio -%}
   {%- endfor -%}
 {%- endif -%}
 </ul>

--- a/src/_includes/list-item-thumbnail.html
+++ b/src/_includes/list-item-thumbnail.html
@@ -1,9 +1,10 @@
 {%- if item.data.thumbnail -%}
+  {%- assign aspect_ratio = image_aspect_ratio | default: config.products.item_list_aspect_ratio -%}
   {%- if item.url contains "://" -%}
     <a class="image-link" href="{{ item.url }}" target="_blank" rel="noopener" aria-hidden="true" tabindex="-1">
   {%- else -%}
     <a class="image-link" href="{{ item.url }}{{ config.internal_link_suffix }}" aria-hidden="true" tabindex="-1">
   {%- endif -%}
-    {%- image item.data.thumbnail, "", "", "", "", config.products.item_list_aspect_ratio -%}
+    {%- image item.data.thumbnail, "", "", "", "", aspect_ratio -%}
   </a>
 {%- endif -%}

--- a/src/_includes/list-item.html
+++ b/src/_includes/list-item.html
@@ -6,7 +6,7 @@
   {%- for field in listItemFields -%}
     {%- case field -%}
       {%- when "thumbnail" -%}
-        {%- include "list-item-thumbnail.html" -%}
+        {%- include "list-item-thumbnail.html", image_aspect_ratio: image_aspect_ratio -%}
       {%- when "link" -%}
         {%- include "list-item-link.html" -%}
       {%- when "price" -%}

--- a/src/_lib/utils/block-schema/items-array.js
+++ b/src/_lib/utils/block-schema/items-array.js
@@ -1,4 +1,5 @@
 import {
+  IMAGE_ASPECT_RATIO_FIELD,
   ITEMS_COMMON_FIELDS,
   ITEMS_GRID_META,
   str,
@@ -14,6 +15,7 @@ export const fields = {
       "Array of path strings. Each entry may be a file path (e.g. `src/products/widget.md`) or a directory path (e.g. `locations/fulchester` or `locations/fulchester/`), in which case every item in that directory is included in place.",
   },
   ...ITEMS_COMMON_FIELDS,
+  image_aspect_ratio: IMAGE_ASPECT_RATIO_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/items.js
+++ b/src/_lib/utils/block-schema/items.js
@@ -1,5 +1,6 @@
 import {
   collectionField,
+  IMAGE_ASPECT_RATIO_FIELD,
   ITEMS_COMMON_FIELDS,
 } from "#utils/block-schema/shared.js";
 
@@ -10,6 +11,7 @@ export const fields = {
     'Name of an Eleventy collection (e.g. `"featuredProducts"`, `"events"`, `"news"`).',
   ),
   ...ITEMS_COMMON_FIELDS,
+  image_aspect_ratio: IMAGE_ASPECT_RATIO_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -97,6 +97,12 @@ export const MASONRY_FIELD = {
     "If true, renders as a masonry grid using uWrap for zero-reflow height prediction.",
 };
 
+/** Per-block aspect-ratio override for thumbnails / card images. */
+export const IMAGE_ASPECT_RATIO_FIELD = {
+  ...str("Image Aspect Ratio"),
+  description: 'Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`.',
+};
+
 /** Unified fields shared between items and items-array blocks. */
 export const ITEMS_COMMON_FIELDS = {
   intro: {
@@ -146,10 +152,7 @@ export const imageCardGridFields = (itemsField) => ({
   items: itemsField,
   reveal: REVEAL_BOOLEAN_FIELD,
   heading_level: HEADING_LEVEL_FIELD,
-  image_aspect_ratio: {
-    ...str("Image Aspect Ratio"),
-    description: 'Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`.',
-  },
+  image_aspect_ratio: IMAGE_ASPECT_RATIO_FIELD,
   ...HEADER_FIELDS,
 });
 


### PR DESCRIPTION
## Summary

- Adds an optional `image_aspect_ratio` field to the `items` and `items-array` block schemas, matching the field already used by `image-cards`, `buy-options`, and `gallery`.
- Threads the per-block override through `render-items-block.html` → `items.html` → `list-item.html` → `list-item-thumbnail.html`.
- Falls back to the existing global `config.products.item_list_aspect_ratio` when the per-block value is not set, so all current consumers of `items.html` (home, layouts, category pages, etc.) keep their existing behavior.
- Extracts a shared `IMAGE_ASPECT_RATIO_FIELD` constant in `block-schema/shared.js` so the same definition powers `imageCardGridFields`, `items`, and `items-array`.
- Regenerates the auto-generated `.pages.yml` and `BLOCKS_LAYOUT.md` artifacts.

## Test plan

- [x] `bun test test/unit/utils/block-schema.test.js` — schema validates the new field on every block.
- [x] `bun test test/unit/utils/block-schema-template-sync.test.js` — every `block.<field>` referenced in templates is declared in the schema, and every schema field is referenced in its template (including `socials-block.html`, which still uses `render-items-block.html` but does not declare the new field).
- [x] `bun test test/unit/` — full unit suite, 2701 pass / 0 fail.
- [x] `bun run lint` — clean.
- [ ] Manual: in the CMS, set `image_aspect_ratio` on an `items` block (e.g. `"16/9"`) and confirm thumbnails render with that ratio while a sibling `items` block without the field continues to use the global default.

https://claude.ai/code/session_011gBhaR3XVdfbBnXsprkRor

---
_Generated by [Claude Code](https://claude.ai/code/session_011gBhaR3XVdfbBnXsprkRor)_