### PR TITLE
Fix .icon contrast in dark sections

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -284,6 +284,7 @@
   --color-text: #{$color-dark-text};
   --color-text-muted: #{$color-dark-text-muted};
   --color-card-bg: #{$color-dark-card-bg};
+  --color-tint: #{$color-dark-card-bg};
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- In dark sections, `--color-text` was overridden to light but `--color-tint` kept its light-theme value, so SVG icons (which inherit `currentColor`) rendered as near-white on a pale blue tint background.
- Override `--color-tint` in `dark-section-vars` to `$color-dark-card-bg` (`#374151`) so tinted surfaces — icon badges, hero badges, info callouts, search focus rings — have proper contrast against the light text/icon foreground.

## Test plan
- [x] `bun run build` succeeds
- [x] `bun run lint` clean
- [x] Verified compiled CSS contains `--color-tint:#374151` inside `section.dark` and `footer` rules


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hf6L294oyY1a6mYiN3ghbn)_