### PR TITLE
Replace header_intro and heading_level with intro_content

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -65,9 +65,10 @@ components:
             label: Currency (ISO code, e.g. GBP)
           - { name: link, type: string, label: Buy Link, required: true }
           - { name: button_text, type: string, label: Button Text }
-      - { name: heading_level, type: number, label: Heading Level }
       - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
-      - { name: header_intro, type: rich-text, label: Header Intro }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
   block_callout:
     label: Callout
     type: object
@@ -95,6 +96,9 @@ components:
     fields:
       - { name: dark, type: boolean, label: Dark }
       - { name: content, type: rich-text, label: Content }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
   block_content:
     label: Content
     type: object
@@ -137,13 +141,17 @@ components:
           - { name: rows, type: number, label: Rows (for textarea) }
           - { name: note, type: string, label: Help Note }
           - { name: fieldClass, type: string, label: CSS Class }
-      - { name: header_intro, type: rich-text, label: Header Intro }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
   block_downloads:
     label: Downloads
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
       - name: items
         type: object
         label: Downloads
@@ -172,10 +180,10 @@ components:
           - { name: title, type: string, label: Title, required: true }
           - { name: description, type: rich-text, label: Description }
           - { name: style, type: string, label: Custom Style }
-      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
-      - { name: heading_level, type: number, label: Heading Level }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
       - { name: center, type: boolean, label: Centered }
-      - { name: header_intro, type: rich-text, label: Header Intro }
   block_gallery:
     label: Gallery
     type: object
@@ -190,9 +198,10 @@ components:
           - { name: image, type: image, label: Image, required: true }
           - { name: caption, type: string, label: Caption }
       - { name: aspect_ratio, type: string, label: Aspect Ratio }
-      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
       - { name: masonry, type: boolean, label: Masonry Grid }
-      - { name: header_intro, type: rich-text, label: Header Intro }
   block_guide_categories:
     label: Guide Categories
     type: object
@@ -227,7 +236,9 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
-      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
       - name: items
         type: object
         label: Links
@@ -256,7 +267,9 @@ components:
       - { name: sandbox, type: string, label: Sandbox }
       - { name: allow, type: string, label: Allow (permissions policy) }
       - { name: scrolling, type: string, label: Scrolling }
-      - { name: header_intro, type: rich-text, label: Header Intro }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
   block_image_background:
     label: Image Background
     type: object
@@ -285,9 +298,10 @@ components:
           - { name: title, type: string, label: Title, required: true }
           - { name: description, type: string, label: Description }
           - { name: link, type: string, label: Link URL }
-      - { name: heading_level, type: number, label: Heading Level }
       - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
-      - { name: header_intro, type: rich-text, label: Header Intro }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
   block_include:
     label: Include
     type: object
@@ -303,7 +317,9 @@ components:
         type: string
         label: Collection Name
         required: true
-      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }
       - name: filter
@@ -315,7 +331,6 @@ components:
             label: Property (e.g. url, data.title)
           - { name: includes, type: string, label: Contains }
           - { name: equals, type: string, label: Equals }
-      - { name: header_intro, type: rich-text, label: Header Intro }
       - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
   block_items_array:
     label: Items Array
@@ -323,7 +338,9 @@ components:
     fields:
       - { name: dark, type: boolean, label: Dark }
       - { name: items, type: string, label: Items, list: true }
-      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }
       - name: filter
@@ -335,7 +352,6 @@ components:
             label: Property (e.g. url, data.title)
           - { name: includes, type: string, label: Contains }
           - { name: equals, type: string, label: Equals }
-      - { name: header_intro, type: rich-text, label: Header Intro }
       - { name: image_aspect_ratio, type: string, label: Image Aspect Ratio }
   block_link_button:
     label: Link Button
@@ -356,7 +372,9 @@ components:
         type: string
         label: Collection Name
         required: true
-      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
       - name: filter
         type: object
         label: Filter
@@ -367,7 +385,6 @@ components:
           - { name: includes, type: string, label: Contains }
           - { name: equals, type: string, label: Equals }
       - { name: remove_text, type: string, label: Remove Text (Regex) }
-      - { name: header_intro, type: rich-text, label: Header Intro }
   block_markdown:
     label: Markdown
     type: object
@@ -390,6 +407,9 @@ components:
           - { name: link_url, type: string, label: Link URL }
       - { name: speed, type: string, label: Scroll Speed (e.g. 30s) }
       - { name: height, type: string, label: Image Height (e.g. 50px) }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
   block_properties:
     label: Properties
     type: object
@@ -432,7 +452,9 @@ components:
     fields:
       - { name: dark, type: boolean, label: Dark }
       - { name: directory, type: string, label: Directory, required: true }
-      - { name: intro, type: rich-text, label: Intro Content (Markdown) }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
       - { name: horizontal, type: boolean, label: Horizontal Slider }
       - { name: masonry, type: boolean, label: Masonry Grid }
       - name: filter
@@ -444,7 +466,6 @@ components:
             label: Property (e.g. url, data.title)
           - { name: includes, type: string, label: Contains }
           - { name: equals, type: string, label: Equals }
-      - { name: header_intro, type: rich-text, label: Header Intro }
   block_split_buy_options:
     label: Split Buy Options
     type: object

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -75,13 +75,9 @@ Grid of feature cards with optional icons, titles, and descriptions.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `items` | array | **required** | Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji. |
-| `intro` | string | — | Markdown content rendered above the grid in `.prose`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
-| `heading_level` | number | `3` | Heading level for item titles. |
 | `center` | boolean | `false` | If true, centers feature text. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
 
 ---
 
@@ -98,11 +94,8 @@ Grid of cards featuring images with titles and optional descriptions.
 |---|---|---|---|
 | `items` | array | **required** | Card objects. Each: `{image, title, description, link}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
-| `heading_level` | number | `3` | Heading level for item titles. |
 | `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 
 ---
 
@@ -119,11 +112,8 @@ Grid of buyable products — image, title, optional subtitle, price, and a buy b
 |---|---|---|---|
 | `items` | array | **required** | Product objects. Each: `{image, title, subtitle, price, currency, link, button_text}`. Images processed by `{% image %}` shortcode for responsive srcset + LQIP. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each item. |
-| `heading_level` | number | `3` | Heading level for item titles. |
 | `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 
 Each item renders as a `<li>` with `itemscope itemtype="https://schema.org/Product"`. The price is emitted as a nested `Offer` with `priceCurrency` (defaults to `GBP`). Use this block when the buy action is external (Stripe, itch.io, Gumroad); for sitewide shop listings, use the `items` block with a `products` collection.
 
@@ -512,13 +502,10 @@ Displays an Eleventy collection as a card grid or horizontal slider.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `collection` | string | **required** | Name of an Eleventy collection (e.g. `"featuredProducts"`, `"events"`, `"news"`). |
-| `intro` | string | — | Markdown content rendered above items in `.prose`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
 | `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
 | `filter` | object | — | Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
 | `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
 
 ---
@@ -534,13 +521,10 @@ Renders items from an explicit list of paths. The collection is inferred dynamic
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `items` | array | — | Array of path strings. Each entry may be a file path (e.g. `src/products/widget.md`) or a directory path (e.g. `locations/fulchester` or `locations/fulchester/`), in which case every item in that directory is included in place. |
-| `intro` | string | — | Markdown content rendered above items in `.prose`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
 | `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
 | `filter` | object | — | Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
 | `image_aspect_ratio` | string | — | Aspect ratio for images, e.g. `"16/9"`, `"1/1"`, `"4/3"`. |
 
 ---
@@ -556,13 +540,10 @@ Renders social-media posts loaded from a directory of JSON files as a card grid 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `directory` | string | **required** | Directory (relative to `src/`) containing social-post JSON files — e.g. `"instagram-posts"` or `"mastodon-posts"`. Each `*.json` file must have `url`, `date`, `title`, and `thumbnail` keys. |
-| `intro` | string | — | Markdown content rendered above items in `.prose`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `horizontal` | boolean | `false` | If true, renders as a horizontal slider instead of a wrapping grid. |
 | `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
 | `filter` | object | — | Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
 
 Posts are loaded per-block from the given directory, so the same template works for Instagram, Mastodon, or any other source. External `url` values open in a new tab.
 
@@ -579,12 +560,9 @@ Renders a collection as a plain-text unordered list of links arranged in respons
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `collection` | string | **required** | Name of an Eleventy collection (e.g. `"locations"`, `"services"`). |
-| `intro` | string | — | Markdown content rendered above items in `.prose`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `filter` | object | — | Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value. |
 | `remove_text` | string | — | Regex pattern (JavaScript syntax, global flag implied). Each match is removed from every link's display text and the result is trimmed. Useful for stripping repetitive prefixes like `"Service in "` so links render tidier. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
 
 ---
 
@@ -600,9 +578,7 @@ Two-column layout with prose content and a contact form.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `content` | string | — | Left-side content. Rendered as markdown in `.prose`. Centered text. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 
 ---
 
@@ -619,9 +595,7 @@ Contact form block with a custom, block-level field list instead of the site-wid
 |---|---|---|---|
 | `content` | string | — | Left-side content. Rendered as markdown in `.prose`. Centered text. |
 | `fields` | array | **required** | Array of field definitions for this form. Replaces `contactForm.fields` for this block only. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 
 Identical layout and styling to `contact-form`, but accepts its own `fields` array. Each field object follows the same shape as entries in `src/_data/contact-form.json` — e.g. `{name, label, type, placeholder, required, rows, options, note, fieldClass, showOn, defaultFromPageTitle}`. Supported `type` values: `"text"` (default), `"email"`, `"tel"`, `"textarea"`, `"select"`, `"radio"`, `"heading"`.
 
@@ -677,9 +651,7 @@ Third-party iframe embed (itch.io widgets, Buttondown, Bandcamp, Stripe buttons,
 | `sandbox` | string | — | Space-separated sandbox tokens, e.g. `"allow-scripts allow-same-origin allow-forms"`. |
 | `allow` | string | — | `allow` attribute for iframe permissions policy. |
 | `scrolling` | string | — | Legacy `scrolling` attribute, e.g. `"no"`. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 
 Provide either `height` for a fixed-height embed or `aspect_ratio` (e.g. `16/9`) for a responsive one. Use `max_width` to cap the embed width within the container.
 
@@ -784,11 +756,8 @@ Image grid with optional aspect ratio cropping and captions.
 |---|---|---|---|
 | `items` | array | **required** | Image objects. Each: `{image, caption}`. Images processed by `{% image %}` shortcode. |
 | `aspect_ratio` | string | — | Aspect ratio for images (e.g. `"16/9"`, `"1/1"`, `"4/3"`). Default: no cropping. |
-| `intro` | string | — | Markdown content rendered above items in `.prose`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `masonry` | boolean | `false` | If true, renders as a masonry grid using uWrap for zero-reflow height prediction. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
 
 ---
 
@@ -806,9 +775,7 @@ Continuously scrolling marquee of images (e.g. brand logos, partner badges).
 | `items` | array | **required** | Image objects. Each: `{image, alt, link_url}`. `image` is a path; `alt` is optional alt text; `link_url` is an optional URL to wrap the image in a link. Images are processed via the `{% image %}` shortcode for responsive formats and proper URL normalization. |
 | `speed` | string | `"30s"` | CSS animation duration for one full scroll cycle (e.g. `"20s"`, `"45s"`). Slower = longer duration. |
 | `height` | string | `"50px"` | CSS height for the images (e.g. `"60px"`, `"80px"`). Width scales proportionally. |
-| `header_intro` | string | — | Section header content rendered as markdown above the block. |
-| `header_align` | string | — | Header text alignment. `"center"` adds `.text-center`. |
-| `header_class` | string | — | Extra CSS classes on the section header. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 
 ---
 
@@ -823,7 +790,7 @@ Vertical list of links with icons, rendered as a flex column stack.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `intro` | string | — | Markdown content rendered above the links list in `.prose`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `items` | array | **required** | Link objects. Each: `{icon, text, url}`. `url` is optional — items without it render as plain text. Icon can be an Iconify ID (`"prefix:name"`), image path, or raw HTML/emoji. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each link item. |
 
@@ -840,7 +807,7 @@ List of downloadable files. Each item auto-detects its icon from the file extens
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `intro` | string | — | Markdown content rendered above the downloads list in `.prose`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `items` | array | **required** | Download objects. Each: `{file, label}`. `file` is a site-relative URL path; `label` is the visible text. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each download item. |
 

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -28,7 +28,7 @@ const hasTag = (data, tag) => (data.tags || []).includes(tag);
  * @type {Record<string, Record<string, unknown>>}
  */
 const BLOCK_DEFAULTS = {
-  features: { reveal: true, heading_level: 3, center: false },
+  features: { reveal: true, center: false },
   stats: { reveal: true },
   "split-image": { title_level: 2, reveal_figure: "scale" },
   "split-video": { title_level: 2, reveal_figure: "scale" },
@@ -37,7 +37,7 @@ const BLOCK_DEFAULTS = {
   "split-html": { title_level: 2, reveal_figure: "scale" },
   "split-callout": { title_level: 2, reveal_figure: "scale" },
   "section-header": { align: "center" },
-  "image-cards": { reveal: true, heading_level: 3 },
+  "image-cards": { reveal: true },
   "code-block": { reveal: true },
   "icon-links": { reveal: true },
   downloads: { reveal: true },

--- a/src/_includes/design-system/block-intro.html
+++ b/src/_includes/design-system/block-intro.html
@@ -1,18 +1,9 @@
 {%- comment -%}
-Renders the optional section header and markdown intro for a block.
-Shared by any block that accepts header_intro / header_align / header_class
-and an `intro` markdown field.
+Renders the optional markdown intro for a block.
 
 Expects:
   block - the block frontmatter object
 {%- endcomment -%}
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-     intro: block.header_intro,
-     align: block.header_align,
-     header_class: block.header_class
-  -%}
-{%- endif -%}
-{%- if block.intro -%}
-  <div class="prose">{{ block.intro | renderContent: "md" }}</div>
+{%- if block.intro_content -%}
+  <div class="prose">{{ block.intro_content | renderContent: "md" }}</div>
 {%- endif -%}

--- a/src/_includes/design-system/buy-options.html
+++ b/src/_includes/design-system/buy-options.html
@@ -15,20 +15,12 @@ Parameters (via block object):
     - link: Buy URL (required)
     - button_text: Button label, defaults to "Buy now" (optional)
   - block.reveal: If true, adds data-reveal animation (default: true)
-  - block.heading_level: Heading level for titles, defaults to 3 (h3)
   - block.image_aspect_ratio: Aspect ratio for images (e.g. "1/1", "4/3")
-  - block.header_intro, header_align, header_class: Optional section header
+  - block.intro_content: Optional markdown intro rendered above the grid
 {%- endcomment -%}
 
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-     intro: block.header_intro,
-     align: block.header_align,
-     header_class: block.header_class
-  -%}
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 
-{%- assign heading_level = block.heading_level | default: 3 -%}
 {%- assign reveal = block.reveal | default: true -%}
 
 <ul class="items buy-options" role="list">
@@ -42,7 +34,6 @@ Parameters (via block object):
          currency: item.currency,
          link: item.link,
          button_text: item.button_text,
-         heading_level: heading_level,
          image_aspect_ratio: block.image_aspect_ratio -%}
     </li>
   {%- endfor -%}

--- a/src/_includes/design-system/contact-form-block.html
+++ b/src/_includes/design-system/contact-form-block.html
@@ -1,10 +1,4 @@
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-     intro: block.header_intro,
-     align: block.header_align,
-     header_class: block.header_class
-  -%}
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 <div class="contact-form-block">
   {%- if block.content -%}
   <div class="prose">

--- a/src/_includes/design-system/custom-contact-form-block.html
+++ b/src/_includes/design-system/custom-contact-form-block.html
@@ -1,10 +1,4 @@
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-     intro: block.header_intro,
-     align: block.header_align,
-     header_class: block.header_class
-  -%}
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 {%- assign _customFields = block.fields | addFieldTemplates -%}
 <div class="contact-form-block">
   <div class="prose">

--- a/src/_includes/design-system/downloads.html
+++ b/src/_includes/design-system/downloads.html
@@ -6,7 +6,7 @@ size is read from the filesystem at build time (see
 src/_lib/eleventy/file-info.js).
 
 Parameters:
-  - block.intro: Optional markdown intro rendered above the list.
+  - block.intro_content: Optional markdown intro rendered above the list.
   - block.items: Array of {file, label} objects.
     - file: Site-relative URL path (e.g. "/files/guide.pdf"). Resolved against src/.
     - label: Visible link text.
@@ -15,9 +15,7 @@ Parameters:
 
 {%- assign reveal = block.reveal | default: true -%}
 
-{%- if block.intro -%}
-  <div class="prose">{{ block.intro | renderContent: "md" }}</div>
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 
 <ul class="downloads" role="list">
   {%- for item in block.items -%}

--- a/src/_includes/design-system/features.html
+++ b/src/_includes/design-system/features.html
@@ -12,11 +12,8 @@ Parameters (via block object):
     - description: Feature description (supports markdown)
     - style: Optional inline styles (e.g., for custom colors)
   - block.reveal: If true, adds data-reveal animation (default: true)
-  - block.heading_level: Heading level for titles, defaults to 3 (h3)
   - block.center: If true, centers feature text (default: false)
-  - block.header_intro: Optional section header intro (rich text, renders section-header before grid)
-  - block.header_align: Text alignment for section header (default: "center")
-  - block.header_class: Additional CSS classes for section header
+  - block.intro_content: Optional markdown intro rendered above the grid
 
 Usage:
   {% include "design-system/features.html", block: { items: page.features } %}
@@ -30,7 +27,6 @@ Usage:
 {%- endcomment -%}
 
 {%- assign reveal = block.reveal | default: true -%}
-{%- assign heading_level = block.heading_level | default: 3 -%}
 
 {%- include "design-system/block-intro.html" -%}
 
@@ -41,7 +37,7 @@ Usage:
       {%- if item.icon -%}
         {%- include "design-system/icon-badge.html", icon: item.icon, label: item.icon_label -%}
       {%- endif -%}
-      <h{{ heading_level }}>{{ item.title }}</h{{ heading_level }}>
+      <h3>{{ item.title }}</h3>
       {%- if item.description -%}
         <div class="prose">{{ item.description | renderContent: "md" }}</div>
       {%- endif -%}

--- a/src/_includes/design-system/gallery.html
+++ b/src/_includes/design-system/gallery.html
@@ -6,7 +6,7 @@ Parameters (via block object):
     - image: Image path (required)
     - caption: Caption text displayed below the image (optional)
   - block.aspect_ratio: Aspect ratio for images (e.g., "16/9", "1/1", "4/3"). Default: no cropping
-  - block.intro: Optional markdown content rendered above the grid in `.prose`
+  - block.intro_content: Optional markdown content rendered above the grid in `.prose`
   - block.masonry: If true, renders as a masonry grid using uWrap for zero-reflow height prediction
 {%- endcomment -%}
 

--- a/src/_includes/design-system/icon-links.html
+++ b/src/_includes/design-system/icon-links.html
@@ -3,7 +3,7 @@ Icon links block - a list of links with icons, rendered as a flex column.
 
 Parameters:
   Standalone (via block object):
-    - block.intro: Optional markdown intro rendered above the list.
+    - block.intro_content: Optional markdown intro rendered above the list.
     - block.items: Array of link objects (see below)
     - block.reveal: If true, adds data-reveal animation (default: true)
 
@@ -24,9 +24,7 @@ Usage:
 {%- assign reveal = block.reveal | default: true -%}
 
 {%- unless items -%}
-  {%- if block.intro -%}
-    <div class="prose">{{ block.intro | renderContent: "md" }}</div>
-  {%- endif -%}
+  {%- include "design-system/block-intro.html" -%}
 {%- endunless -%}
 
 <ul class="icon-links" role="list">

--- a/src/_includes/design-system/iframe-embed.html
+++ b/src/_includes/design-system/iframe-embed.html
@@ -17,16 +17,10 @@ Parameters (via block object):
   - block.sandbox: Sandbox tokens
   - block.allow: Permissions policy
   - block.scrolling: Legacy scrolling attribute
-  - block.header_intro, header_align, header_class: Optional section header
+  - block.intro_content: Optional markdown intro rendered above the embed
 {%- endcomment -%}
 
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-     intro: block.header_intro,
-     align: block.header_align,
-     header_class: block.header_class
-  -%}
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 
 {%- capture _wrap_style -%}
   {%- if block.aspect_ratio %}aspect-ratio: {{ block.aspect_ratio }};{%- endif -%}

--- a/src/_includes/design-system/image-cards.html
+++ b/src/_includes/design-system/image-cards.html
@@ -8,10 +8,8 @@ Parameters (via block object):
     - description: Card description (optional)
     - link: URL to link to (optional)
   - block.reveal: If true, adds data-reveal animation (default: true)
-  - block.heading_level: Heading level for titles, defaults to 3 (h3)
   - block.image_aspect_ratio: Aspect ratio for images (e.g., "16/9", "1/1", "4/3"). Default: uses CSS default
-  - block.header_intro, header_align, header_class:
-    Optional section header params (same as features.html, renders section-header before grid)
+  - block.intro_content: Optional markdown intro rendered above the grid
 
 Usage:
   {% include "design-system/image-cards.html",
@@ -25,15 +23,8 @@ Usage:
 {%- endcomment -%}
 
 {%- assign reveal = block.reveal | default: true -%}
-{%- assign heading_level = block.heading_level | default: 3 -%}
 
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-     intro: block.header_intro,
-     align: block.header_align,
-     header_class: block.header_class
-  -%}
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 
 <ul class="items" role="list">
   {%- for item in block.items -%}
@@ -47,13 +38,13 @@ Usage:
         {%- image item.image, "", "", "", "", block.image_aspect_ratio -%}
       </a>
     {%- endif -%}
-    <h{{ heading_level }}>
+    <h3>
       {%- if item.link -%}
         <a href="{{ item.link }}">{{ item.title }}</a>
       {%- else -%}
         {{ item.title }}
       {%- endif -%}
-    </h{{ heading_level }}>
+    </h3>
     {%- if item.description -%}
       <p>{{ item.description }}</p>
     {%- endif -%}

--- a/src/_includes/design-system/link-columns.html
+++ b/src/_includes/design-system/link-columns.html
@@ -4,13 +4,12 @@ arranged in CSS columns. Unlike items-block, there is no card, image or
 metadata — just a tidy list of links.
 
 Parameters (from block):
-  collection  - Name of an Eleventy collection (e.g. "locations")
-  intro       - Optional markdown content rendered above the list
-  filter      - Optional filter object ({property, includes, equals})
-  remove_text - Optional regex pattern; each match is stripped from every
-                link's display text and the result is trimmed. Useful for
-                killing repetitive prefixes like "Service in ".
-  header_intro / header_align / header_class - Optional section header.
+  collection   - Name of an Eleventy collection (e.g. "locations")
+  intro_content - Optional markdown content rendered above the list
+  filter       - Optional filter object ({property, includes, equals})
+  remove_text  - Optional regex pattern; each match is stripped from every
+                 link's display text and the result is trimmed. Useful for
+                 killing repetitive prefixes like "Service in ".
 {%- endcomment -%}
 
 {%- include "design-system/block-intro.html" -%}

--- a/src/_includes/design-system/marquee-images.html
+++ b/src/_includes/design-system/marquee-images.html
@@ -12,23 +12,15 @@ Parameters (via block object):
     - link_url: Optional URL to link the image to
   - block.speed: Animation duration for one cycle (default: "30s")
   - block.height: CSS height for images (default: "50px")
-  - block.header_intro: Optional markdown section header above the marquee
-  - block.header_align: Header text alignment
-  - block.header_class: Extra header CSS classes
+  - block.intro_content: Optional markdown intro rendered above the marquee
 {%- endcomment -%}
 
-{%- if block.header_intro -%}
-  {%- include "design-system/section-header.html",
-    intro: block.header_intro,
-    align: block.header_align,
-    header_class: block.header_class
-  -%}
-{%- endif -%}
+{%- include "design-system/block-intro.html" -%}
 
 {%- if block.items.size > 0 -%}
   {%- assign speed = block.speed | default: "30s" -%}
   {%- assign height = block.height | default: "50px" -%}
-  <div class="marquee-images{% if block.header_intro %} marquee-images--has-header{% endif %}" style="--marquee-speed: {{ speed }}; --marquee-height: {{ height }}">
+  <div class="marquee-images{% if block.intro_content %} marquee-images--has-header{% endif %}" style="--marquee-speed: {{ speed }}; --marquee-height: {{ height }}">
     <div class="marquee-images__track">
       {%- for item in block.items -%}
         {%- assign image = item.image -%}

--- a/src/_lib/utils/block-schema/contact-form.js
+++ b/src/_lib/utils/block-schema/contact-form.js
@@ -1,7 +1,4 @@
-import {
-  HEADER_FIELDS_DOC_ONLY_INTRO,
-  md,
-} from "#utils/block-schema/shared.js";
+import { INTRO_CONTENT_FIELD, md } from "#utils/block-schema/shared.js";
 
 export const type = "contact-form";
 
@@ -11,7 +8,7 @@ export const fields = {
     description:
       "Left-side content. Rendered as markdown in `.prose`. Centered text.",
   },
-  ...HEADER_FIELDS_DOC_ONLY_INTRO,
+  intro_content: INTRO_CONTENT_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/custom-contact-form.js
+++ b/src/_lib/utils/block-schema/custom-contact-form.js
@@ -1,6 +1,6 @@
 import {
   bool,
-  HEADER_FIELDS,
+  INTRO_CONTENT_FIELD,
   md,
   num,
   objectList,
@@ -32,7 +32,7 @@ export const fields = {
     description:
       "Array of field definitions for this form. Replaces `contactForm.fields` for this block only.",
   },
-  ...HEADER_FIELDS,
+  intro_content: INTRO_CONTENT_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/downloads.js
+++ b/src/_lib/utils/block-schema/downloads.js
@@ -1,5 +1,9 @@
 /* jscpd:ignore-start */
-import { md, objectList, str } from "#utils/block-schema/shared.js";
+import {
+  INTRO_CONTENT_FIELD,
+  objectList,
+  str,
+} from "#utils/block-schema/shared.js";
 /* jscpd:ignore-end */
 
 export const type = "downloads";
@@ -12,11 +16,7 @@ const FILE_RESOLUTION_NOTE =
   "The `file` path is resolved against `src/` (e.g. `/files/guide.pdf` reads from `src/files/guide.pdf`). Missing files cause a build error. Ensure the containing directory is configured as a passthrough-copy target so the file is also served to the browser.";
 
 export const fields = {
-  intro: {
-    ...md("Intro Content (Markdown)"),
-    description:
-      "Markdown content rendered above the downloads list in `.prose`.",
-  },
+  intro_content: INTRO_CONTENT_FIELD,
   items: {
     ...objectList("Downloads", {
       file: str("File Path (e.g. /files/guide.pdf)", { required: true }),

--- a/src/_lib/utils/block-schema/features.js
+++ b/src/_lib/utils/block-schema/features.js
@@ -1,7 +1,6 @@
 import {
   bool,
-  HEADER_FIELDS,
-  HEADING_LEVEL_FIELD,
+  INTRO_CONTENT_FIELD,
   md,
   objectList,
   REVEAL_BOOLEAN_FIELD,
@@ -23,18 +22,13 @@ export const fields = {
     description:
       'Feature objects. Each: `{icon, icon_label, title, description, style}`. Icon can be an Iconify ID (`"prefix:name"`), image path (`"/images/foo.svg"`), or raw HTML/emoji.',
   },
-  intro: {
-    ...md("Intro Content (Markdown)"),
-    description: "Markdown content rendered above the grid in `.prose`.",
-  },
+  intro_content: INTRO_CONTENT_FIELD,
   reveal: REVEAL_BOOLEAN_FIELD,
-  heading_level: HEADING_LEVEL_FIELD,
   center: {
     ...bool("Centered"),
     default: "false",
     description: "If true, centers feature text.",
   },
-  ...HEADER_FIELDS,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/gallery.js
+++ b/src/_lib/utils/block-schema/gallery.js
@@ -1,6 +1,5 @@
 import {
-  HEADER_FIELDS,
-  ITEMS_COMMON_FIELDS,
+  INTRO_CONTENT_FIELD,
   ITEMS_GRID_META,
   img,
   MASONRY_FIELD,
@@ -25,9 +24,8 @@ export const fields = {
     description:
       'Aspect ratio for images (e.g. `"16/9"`, `"1/1"`, `"4/3"`). Default: no cropping.',
   },
-  intro: ITEMS_COMMON_FIELDS.intro,
+  intro_content: INTRO_CONTENT_FIELD,
   masonry: MASONRY_FIELD,
-  ...HEADER_FIELDS,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/icon-links.js
+++ b/src/_lib/utils/block-schema/icon-links.js
@@ -1,4 +1,8 @@
-import { md, objectList, str } from "#utils/block-schema/shared.js";
+import {
+  INTRO_CONTENT_FIELD,
+  objectList,
+  str,
+} from "#utils/block-schema/shared.js";
 
 export const type = "icon-links";
 
@@ -12,10 +16,7 @@ export const ICON_LINKS_ITEMS_FIELD = objectList("Links", {
 });
 
 export const fields = {
-  intro: {
-    ...md("Intro Content (Markdown)"),
-    description: "Markdown content rendered above the links list in `.prose`.",
-  },
+  intro_content: INTRO_CONTENT_FIELD,
   items: {
     ...ICON_LINKS_ITEMS_FIELD,
     required: true,

--- a/src/_lib/utils/block-schema/iframe-embed.js
+++ b/src/_lib/utils/block-schema/iframe-embed.js
@@ -1,4 +1,4 @@
-import { HEADER_FIELDS, num, str } from "#utils/block-schema/shared.js";
+import { INTRO_CONTENT_FIELD, num, str } from "#utils/block-schema/shared.js";
 
 export const type = "iframe-embed";
 
@@ -44,7 +44,7 @@ export const fields = {
     ...str("Scrolling"),
     description: 'Legacy `scrolling` attribute, e.g. `"no"`.',
   },
-  ...HEADER_FIELDS,
+  intro_content: INTRO_CONTENT_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/link-columns.js
+++ b/src/_lib/utils/block-schema/link-columns.js
@@ -1,7 +1,7 @@
 import {
   collectionField,
   FILTER_FIELD,
-  HEADER_FIELDS,
+  INTRO_CONTENT_FIELD,
   ITEMS_COMMON_FIELDS,
   str,
 } from "#utils/block-schema/shared.js";
@@ -12,7 +12,7 @@ export const fields = {
   collection: collectionField(
     'Name of an Eleventy collection (e.g. `"locations"`, `"services"`).',
   ),
-  intro: ITEMS_COMMON_FIELDS.intro,
+  intro_content: INTRO_CONTENT_FIELD,
   filter: {
     ...FILTER_FIELD,
     description: ITEMS_COMMON_FIELDS.filter.description,
@@ -22,7 +22,6 @@ export const fields = {
     description:
       'Regex pattern (JavaScript syntax, global flag implied). Each match is removed from every link\'s display text and the result is trimmed. Useful for stripping repetitive prefixes like `"Service in "` so links render tidier.',
   },
-  ...HEADER_FIELDS,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/marquee-images.js
+++ b/src/_lib/utils/block-schema/marquee-images.js
@@ -1,5 +1,5 @@
 import {
-  HEADER_FIELDS_DOC_ONLY_INTRO,
+  INTRO_CONTENT_FIELD,
   objectList,
   str,
 } from "#utils/block-schema/shared.js";
@@ -31,7 +31,7 @@ export const fields = {
     description:
       'CSS height for the images (e.g. `"60px"`, `"80px"`). Width scales proportionally.',
   },
-  ...HEADER_FIELDS_DOC_ONLY_INTRO,
+  intro_content: INTRO_CONTENT_FIELD,
 };
 
 export const docs = {

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -30,9 +30,6 @@ export const objectField = (label, fields) => ({
   fields,
 });
 
-/** Strip the CMS `label` so a field becomes doc-only (schema + docs, not CMS). */
-export const docOnly = ({ label, ...rest }) => rest;
-
 /** Container wrapper fields common to every CMS block. */
 export const CONTAINER_FIELDS = { dark: bool("Dark") };
 
@@ -65,20 +62,10 @@ export const ITEMS_GRID_META = {
   htmlRoot: '<ul class="items" role="list">',
 };
 
-/** Unified header fields. `header_intro` is CMS-exposed; align/class are doc-only. */
-export const HEADER_FIELDS = {
-  header_intro: {
-    ...md("Header Intro"),
-    description: "Section header content rendered as markdown above the block.",
-  },
-  header_align: {
-    type: "string",
-    description: 'Header text alignment. `"center"` adds `.text-center`.',
-  },
-  header_class: {
-    type: "string",
-    description: "Extra CSS classes on the section header.",
-  },
+/** Unified markdown intro field rendered above a block in `.prose`. */
+export const INTRO_CONTENT_FIELD = {
+  ...md("Intro Content (Markdown)"),
+  description: "Markdown content rendered above the block in `.prose`.",
 };
 
 /** Horizontal slider toggle shared between items-like blocks. */
@@ -105,10 +92,7 @@ export const IMAGE_ASPECT_RATIO_FIELD = {
 
 /** Unified fields shared between items and items-array blocks. */
 export const ITEMS_COMMON_FIELDS = {
-  intro: {
-    ...md("Intro Content (Markdown)"),
-    description: "Markdown content rendered above items in `.prose`.",
-  },
+  intro_content: INTRO_CONTENT_FIELD,
   horizontal: HORIZONTAL_FIELD,
   masonry: MASONRY_FIELD,
   filter: {
@@ -116,19 +100,12 @@ export const ITEMS_COMMON_FIELDS = {
     description:
       'Filter object: `{property, includes, equals}`. `property` is a dot-notation path (e.g. `"url"`, `"data.title"`). `includes` matches substring, `equals` matches exact value.',
   },
-  ...HEADER_FIELDS,
 };
 
 export const REVEAL_BOOLEAN_FIELD = {
   type: "boolean",
   default: "true",
   description: "Adds `data-reveal` to each item.",
-};
-
-export const HEADING_LEVEL_FIELD = {
-  ...num("Heading Level"),
-  default: "3",
-  description: "Heading level for item titles.",
 };
 
 export const REVEAL_STRING_FIELD = {
@@ -142,18 +119,12 @@ export const collectionField = (description) => ({
   description,
 });
 
-export const HEADER_FIELDS_DOC_ONLY_INTRO = {
-  ...HEADER_FIELDS,
-  header_intro: docOnly(HEADER_FIELDS.header_intro),
-};
-
 /** @param {object} itemsField */
 export const imageCardGridFields = (itemsField) => ({
   items: itemsField,
   reveal: REVEAL_BOOLEAN_FIELD,
-  heading_level: HEADING_LEVEL_FIELD,
   image_aspect_ratio: IMAGE_ASPECT_RATIO_FIELD,
-  ...HEADER_FIELDS,
+  intro_content: INTRO_CONTENT_FIELD,
 });
 
 /** Overlay content + class fields shared between background blocks. */

--- a/src/pages/chobble-template.md
+++ b/src/pages/chobble-template.md
@@ -48,8 +48,7 @@ blocks:
 
   # Marquee Images Demo
   - type: marquee-images
-    header_intro: "## Trusted By These Fictional Brands"
-    header_align: center
+    intro_content: "## Trusted By These Fictional Brands"
     speed: "25s"
     height: "60px"
     items:
@@ -88,7 +87,7 @@ blocks:
   # Product Sliders
   - type: items
     collection: featuredProducts
-    intro: |
+    intro_content: |
       ## Product Sliders
 
       Display any collection in grids or with horizontal sliders.
@@ -101,7 +100,7 @@ blocks:
       - src/products/mini-gizmo.md
       - src/products/ultrawidget-pro.md
       - src/products/heritage-thingy-deluxe.md
-    intro: |
+    intro_content: |
       ## A Selection of Products
 
       Hand-pick specific items from any collection using the items array block.
@@ -110,7 +109,7 @@ blocks:
   - type: items
     collection: reviews
     masonry: true
-    intro: |
+    intro_content: |
       ## Customer Reviews
 
       Display reviews in a masonry grid — cards flow naturally based on content height.
@@ -118,7 +117,7 @@ blocks:
   # Gallery Masonry
   - type: gallery
     masonry: true
-    intro: |
+    intro_content: |
       ## Gallery
 
       Mix images of any aspect ratio, with or without captions. The masonry layout packs them into columns with no ragged gaps.
@@ -138,7 +137,7 @@ blocks:
   - type: socials
     directory: instagram-posts
     horizontal: true
-    intro: |
+    intro_content: |
       ## From our Socials
 
       Point the block at any directory of JSON posts — `instagram-posts`, `mastodon-posts`, whatever you like. Absolute URLs open in a new tab.
@@ -149,7 +148,7 @@ blocks:
 
   # Features - Everything Your Business Needs
   - type: features
-    header_intro: |-
+    intro_content: |-
       ## What's Included
 
       Product catalogs, event calendars, holiday lets, restaurant menus, and more. All from one template.
@@ -262,12 +261,11 @@ blocks:
   # E-Commerce Features (with header, centered, custom colors)
   - type: features
 
-    header_intro: |-
+    intro_content: |-
       ## Commerce Options
 
       Sell products, take quotes, or both. Card payments and enquiry forms are built in.
     center: true
-    heading_level: 4
     items:
       - icon: "hugeicons:credit-card"
         title: Card Checkout
@@ -301,11 +299,10 @@ blocks:
   # SEO Features (with header)
   - type: features
 
-    header_intro: |-
+    intro_content: |-
       ## Built-in SEO
 
       Structured data is generated automatically from your content.
-    heading_level: 4
     items:
       - title: Schema.org Markup
         description: Products, events, FAQs, organizations, and breadcrumbs - all with proper JSON-LD.
@@ -374,7 +371,7 @@ blocks:
 
   # Icon Links
   - type: icon-links
-    intro: |
+    intro_content: |
       ## Quick Links
     items:
       - icon: "hugeicons:github"

--- a/test/unit/data/eleventy-computed/blocks.test.js
+++ b/test/unit/data/eleventy-computed/blocks.test.js
@@ -41,12 +41,11 @@ describe("eleventyComputed.blocks", () => {
     ).toThrow("src/products/example.md");
   });
 
-  test("applies the features defaults (reveal, heading_level, center)", () => {
+  test("applies the features defaults (reveal, center)", () => {
     expect(runSingle({ type: "features", items: [] })).toEqual({
       type: "features",
       items: [],
       reveal: true,
-      heading_level: 3,
       center: false,
       dark: false,
     });
@@ -99,12 +98,11 @@ describe("eleventyComputed.blocks", () => {
     });
   });
 
-  test("applies the image-cards defaults (reveal, heading_level)", () => {
+  test("applies the image-cards defaults (reveal)", () => {
     expect(runSingle({ type: "image-cards", items: [] })).toEqual({
       type: "image-cards",
       items: [],
       reveal: true,
-      heading_level: 3,
       dark: false,
     });
   });
@@ -125,11 +123,10 @@ describe("eleventyComputed.blocks", () => {
     const block = runSingle({
       type: "features",
       reveal: false,
-      heading_level: 2,
+      center: true,
     });
     expect(block.reveal).toBe(false);
-    expect(block.heading_level).toBe(2);
-    expect(block.center).toBe(false);
+    expect(block.center).toBe(true);
   });
 
   test("allows user to override the dark default to true", () => {


### PR DESCRIPTION
## Summary

- Consolidates the redundant `header_intro` (rendered via the styled `section-header` partial) and existing `intro` markdown field into a single `intro_content` field rendered as `.prose`.
- Removes the `heading_level` field — markdown headings inside `intro_content` already control hierarchy, and per-item titles in `features` / `image-cards` / `buy-options` now hardcode to `<h3>`.
- `figure_heading_level` on `split-buy-options` is intentionally kept (distinct field name; controls the single product card title).
- Affected blocks: `features`, `image-cards`, `buy-options`, `gallery`, `items`, `items-array`, `socials`, `link-columns`, `icon-links`, `downloads`, `contact-form`, `custom-contact-form`, `iframe-embed`, `marquee-images`.
- `block-intro.html` simplified to render only `block.intro_content`; per-block templates now include it.
- Schemas, `eleventyComputed.blocks` defaults, the demo page (`src/pages/chobble-template.md`), `BLOCKS_LAYOUT.md`, `.pages.yml`, and `pages-cms-generated.d.ts` regenerated to match.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test test/unit/` — 2701 tests pass
- [x] `bun test test/integration/` — 113 tests pass
- [x] `bun test test/unit/code-quality/` — 336 tests pass
- [x] `bun run build` completes successfully
- [ ] Visual smoke test on the demo page after deploy (intro markdown renders as `.prose` above each block; feature/card titles render as `<h3>`)

https://claude.ai/code/session_01EC6yTEeQcKgLJveH8jJCbX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EC6yTEeQcKgLJveH8jJCbX)_