### PR TITLE
Wrap marquee-images intro_content in container-wide

### DIFF
--- a/src/_includes/design-system/marquee-images.html
+++ b/src/_includes/design-system/marquee-images.html
@@ -15,7 +15,11 @@ Parameters (via block object):
   - block.intro_content: Optional markdown intro rendered above the marquee
 {%- endcomment -%}
 
-{%- include "design-system/block-intro.html" -%}
+{%- if block.intro_content -%}
+  <div class="container-wide">
+    {%- include "design-system/block-intro.html" -%}
+  </div>
+{%- endif -%}
 
 {%- if block.items.size > 0 -%}
   {%- assign speed = block.speed | default: "30s" -%}


### PR DESCRIPTION
## Summary
- The `marquee-images` block has `containerWidth: "full"`, so `render-full-width-block.html` does not wrap it in a container.
- That meant any `intro_content` was rendered flush against the viewport edges instead of aligning with surrounding prose like other intro blocks (`features`, `gallery`, `downloads`, etc., which inherit a container from their `wide`/`narrow` width).
- This change wraps just the intro in `<div class="container-wide">` while keeping the marquee track itself full-width.

## Test plan
- [x] `bun test test/unit/` — 2701 passing
- [x] `bun run build` — succeeds
- [ ] Visual check: render a page with a marquee-images block that has `intro_content` and confirm the intro aligns with surrounding wide containers while the marquee scrolls full-width.

https://claude.ai/code/session_01SsV93m6AFaNhwd6VJYLCpM

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsV93m6AFaNhwd6VJYLCpM)_