### PR TITLE
Move quote layouts onto design-system-base

### DIFF
--- a/src/_layouts/design-system-base.html
+++ b/src/_layouts/design-system-base.html
@@ -44,6 +44,7 @@
   {%- include "design-system/footer.html" -%}
   {%- include "image-popup.html" -%}
   {%- include "client-templates.html" -%}
+  {% slot "templates" %}
   {%- include "theme-switcher.html" -%}
   {%- include "cart-icon.html" -%}
   {%- include "cart-overlay.html" -%}

--- a/src/_layouts/quote-complete.html
+++ b/src/_layouts/quote-complete.html
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: design-system-base
 ---
 
-{{ content }}
+<div class="prose">{{ content }}</div>

--- a/src/_layouts/quote.html
+++ b/src/_layouts/quote.html
@@ -1,5 +1,5 @@
 ---
-layout: base
+layout: design-system-base
 ---
 
 {%- include "quote-layout-header.html" -%}


### PR DESCRIPTION
## Summary
- Add `{% slot "templates" %}` to `design-system-base.html` so child layouts can push client-side `<template>` elements the same way they do under `base.html`
- Switch `quote.html` from `layout: base` to `layout: design-system-base`
- Switch `quote-complete.html` from `layout: page` to `layout: design-system-base`, inlining the `<div class="prose">` wrapper that `page.html` was providing

## Test plan
- [x] `bun run build` succeeds and `_site/quote/index.html` contains the pushed `quote-step-indicator` / `quote-price` `<template>` elements
- [x] `bun test test/unit/code-quality/design-system-scoping.test.js` passes
- [x] `bun test test/unit/frontend/quote-steps.test.js test/unit/frontend/quote-checkout.test.js` passes
- [ ] Visually verify the `/quote/` and `/quote-complete/` pages render correctly under the design-system styles

https://claude.ai/code/session_014tyb2rWzkix9ie8tYicZTp

---
_Generated by [Claude Code](https://claude.ai/code/session_014tyb2rWzkix9ie8tYicZTp)_