### PR TITLE
Include cart styles in design-system bundle

### DIFF
--- a/src/css/design-system-bundle.scss
+++ b/src/css/design-system-bundle.scss
@@ -7,5 +7,6 @@
 
 @use "fonts";
 @use "design-system";
+@use "cart";
 @use "image-popup";
 @use "theme"; // client theme overrides - must be last


### PR DESCRIPTION
## Summary

Pages using `design-system-base.html` only loaded `design-system-bundle.css`, but `cart.scss` (which has `.list-item-cart-controls`, `.item-quantity`, and the cart overlay styles) was only bundled into `bundle.scss`. The layout includes `cart-icon.html` and `cart-overlay.html`, so those styles need to be present.

This adds `@use "cart"` to `design-system-bundle.scss` so cart styling — including the quantity-selector flex row used by the recently added `add-to-cart` block (#1373) — is available wherever the design-system layout is used.

## Test plan

- [x] `bun test` (full suite: lint, typecheck, typecheck:strict, cpd:design-system, cpd, build, tests) — all passing
- [x] Verified `list-item-cart-controls`, `item-quantity`, and `cart-overlay` selectors compile into `_site/css/design-system-bundle.css`


---
_Generated by [Claude Code](https://claude.ai/code/session_01B4WeaeomyH9N28AmvxfbM2)_