### PR TITLE
Disable LQIP for marquee-images block

### DIFF
--- a/src/_includes/design-system/marquee-images.html
+++ b/src/_includes/design-system/marquee-images.html
@@ -30,9 +30,9 @@ Parameters (via block object):
         {%- assign image = item.image -%}
         {%- capture alt_text -%}{%- if item.alt -%}{{ item.alt }}{%- else -%}{%- include "get-alt-text.html" -%}{%- endif -%}{%- endcapture -%}
         {%- if item.link_url -%}
-        <a href="{{ item.link_url }}" class="marquee-images__link">{%- image item.image, alt_text -%}</a>
+        <a href="{{ item.link_url }}" class="marquee-images__link">{%- image item.image, alt_text, "", "", "", "", "", true -%}</a>
         {%- else -%}
-        {%- image item.image, alt_text -%}
+        {%- image item.image, alt_text, "", "", "", "", "", true -%}
         {%- endif -%}
       {%- endfor -%}
     </div>


### PR DESCRIPTION
## Summary
- Pass `noLqip: true` to the `{% image %}` shortcode inside `src/_includes/design-system/marquee-images.html` so marquee images (typically brand logos) skip the LQIP placeholder background.

## Test plan
- [x] `bun run build` succeeds
- [x] Verified rendered marquee `image-wrapper` divs no longer carry a `background-image:` LQIP style on `_site/index.html`

https://claude.ai/code/session_01MtYwPKzEyD36o5Xbsi5YrH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtYwPKzEyD36o5Xbsi5YrH)_