### PR TITLE
Skip LQIP for images with transparent pixels

### DIFF
--- a/src/_lib/media/image-crop.js
+++ b/src/_lib/media/image-crop.js
@@ -66,4 +66,4 @@ const getMetadata = memoize(async (imagePath) => {
   return metadata;
 });
 
-export { cropImage, getAspectRatio, getMetadata };
+export { cropImage, getAspectRatio, getMetadata, getSharp };

--- a/src/_lib/media/image-lqip.js
+++ b/src/_lib/media/image-lqip.js
@@ -6,8 +6,10 @@
  *
  * Skips placeholder generation for:
  * - SVG images (vector, don't need placeholders)
+ * - Images with any transparent pixels (placeholder would show through)
  * - Small images under 5KB (overhead not worth it)
  */
+import { getSharp } from "#media/image-crop.js";
 import { mapObject } from "#toolkit/fp/object.js";
 
 // Node.js caches dynamic imports, no memoization needed
@@ -18,14 +20,21 @@ const PLACEHOLDER_SIZE_THRESHOLD = 5 * 1024;
 
 /**
  * Check if LQIP should be generated for an image.
- * Uses Bun.file().size for faster file size check.
+ * Skips SVGs, files under the size threshold, and any image with transparent
+ * pixels (placeholder would show through). Sharp's stats() is only invoked
+ * when the metadata reports an alpha channel.
  * @param {string} imagePath - Path to the image file
- * @param {{ format: string }} metadata - Image metadata from sharp
- * @returns {boolean} Whether to generate LQIP
+ * @param {{ format: string, hasAlpha?: boolean }} metadata - Image metadata from sharp
+ * @returns {Promise<boolean>} Whether to generate LQIP
  */
-const shouldGenerateLqip = (imagePath, metadata) =>
-  metadata.format !== "svg" &&
-  Bun.file(imagePath).size >= PLACEHOLDER_SIZE_THRESHOLD;
+const shouldGenerateLqip = async (imagePath, metadata) => {
+  if (metadata.format === "svg") return false;
+  if (Bun.file(imagePath).size < PLACEHOLDER_SIZE_THRESHOLD) return false;
+  if (!metadata.hasAlpha) return true;
+  const sharp = await getSharp();
+  const stats = await sharp(imagePath).stats();
+  return stats.isOpaque;
+};
 
 /**
  * Extract LQIP data URL from eleventy-img metadata.

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -77,8 +77,9 @@ const processImageData = dedupeAsync(
 
     const { default: Image } = await getEleventyImg();
 
-    // Check if LQIP should be generated (skip for SVGs, small files, or if noLqip is set)
-    const generateLqip = !noLqip && shouldGenerateLqip(finalPath, metadata);
+    // Check if LQIP should be generated (skip for SVGs, transparent images, small files, or if noLqip is set)
+    const generateLqip =
+      !noLqip && (await shouldGenerateLqip(finalPath, metadata));
 
     // Include LQIP width in the webp widths for single-pass processing
     const requestedWidths = parseWidths(widths);

--- a/test/unit/media/image-lqip.test.js
+++ b/test/unit/media/image-lqip.test.js
@@ -46,8 +46,10 @@ describe("image-lqip", () => {
         "lqip-svg",
         "image.svg",
         Buffer.alloc(10000),
-        (_dir, filePath) => {
-          expect(shouldGenerateLqip(filePath, { format: "svg" })).toBe(false);
+        async (_dir, filePath) => {
+          expect(await shouldGenerateLqip(filePath, { format: "svg" })).toBe(
+            false,
+          );
         },
       ));
 
@@ -56,20 +58,63 @@ describe("image-lqip", () => {
         "lqip-small",
         "small.webp",
         Buffer.alloc(100),
-        (_dir, filePath) => {
-          expect(shouldGenerateLqip(filePath, { format: "webp" })).toBe(false);
+        async (_dir, filePath) => {
+          expect(await shouldGenerateLqip(filePath, { format: "webp" })).toBe(
+            false,
+          );
         },
       ));
 
-    test("returns true for large non-svg images", () =>
+    test("returns true for large non-svg images without alpha channel", () =>
       withTempFile(
         "lqip-large",
         "large.webp",
         Buffer.alloc(6000),
-        (_dir, filePath) => {
-          expect(shouldGenerateLqip(filePath, { format: "webp" })).toBe(true);
+        async (_dir, filePath) => {
+          expect(await shouldGenerateLqip(filePath, { format: "webp" })).toBe(
+            true,
+          );
         },
       ));
+
+    const writeRandomPng = async (filePath, alpha) => {
+      const sharp = (await import("sharp")).default;
+      const width = 200;
+      const height = 200;
+      const pixels = Buffer.alloc(width * height * 4);
+      for (let i = 0; i < pixels.length; i += 4) {
+        pixels[i] = Math.floor(Math.random() * 256);
+        pixels[i + 1] = Math.floor(Math.random() * 256);
+        pixels[i + 2] = Math.floor(Math.random() * 256);
+        pixels[i + 3] = alpha;
+      }
+      await sharp(pixels, { raw: { width, height, channels: 4 } })
+        .png()
+        .toFile(filePath);
+      return sharp(filePath).metadata();
+    };
+
+    const expectLqipForAlpha = (label, alpha, expected) =>
+      test(label, () =>
+        withTempDirAsync(`lqip-png-alpha-${alpha}`, async (tempDir) => {
+          const filePath = path.join(tempDir, "image.png");
+          const metadata = await writeRandomPng(filePath, alpha);
+          expect(metadata.hasAlpha).toBe(true);
+          expect(Bun.file(filePath).size).toBeGreaterThan(5 * 1024);
+          expect(await shouldGenerateLqip(filePath, metadata)).toBe(expected);
+        }),
+      );
+
+    expectLqipForAlpha(
+      "returns false for png with transparent pixels",
+      128,
+      false,
+    );
+    expectLqipForAlpha(
+      "returns true for png with alpha channel but all opaque pixels",
+      255,
+      true,
+    );
   });
 
   describe("removeLqip", () => {


### PR DESCRIPTION
## Summary
- `shouldGenerateLqip` now skips images with any non-opaque pixels in addition to SVGs and small files. The LQIP placeholder is rendered as a CSS `background-image`, so any transparency in the source produces visible bleed-through artifacts.
- Detection uses sharp's `stats().isOpaque` and only runs when `metadata.hasAlpha` is true, so opaque formats (jpeg) and PNGs/WebPs without an alpha channel skip the extra pass.
- The function becomes async; the single call site in `src/_lib/media/image.js` awaits it.
- `getSharp` is now exported from `image-crop.js` and reused, avoiding a duplicate loader (caught by the `duplicate-methods` code-quality test).

## Test plan
- [x] `bun test test/unit/media/image-lqip.test.js` — new tests cover transparent PNG (skipped) and PNG with alpha channel but all-opaque pixels (generated).
- [x] `bun test test/unit/code-quality/` — duplicate-methods, single-use-functions, and cpd all pass.
- [x] `bun run test:unit` — full unit suite (2703 tests) passes.
- [x] `bun run lint` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abnu1LboXtu1E5gXNvnTvb)_