### PR TITLE
Use --color-dark-bg variable for dark sections

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -277,9 +277,9 @@
 
 // Dark section custom properties
 @mixin dark-section-vars {
-  background: #{$color-dark-bg};
+  background: var(--color-dark-bg);
   color: #{$color-dark-text};
-  --color-bg: #{$color-dark-bg};
+  --color-bg: var(--color-dark-bg);
   --body-background-alt: #{$color-dark-card-bg};
   --color-text: #{$color-dark-text};
   --color-text-muted: #{$color-dark-text-muted};

--- a/src/css/design-system/_base.scss
+++ b/src/css/design-system/_base.scss
@@ -37,6 +37,7 @@
   --color-video-play-bg: #{$color-video-play-bg};
   --color-video-play-hover: #{$color-video-play-hover};
   --body-background: #{$color-bg};
+  --color-dark-bg: #{$color-dark-bg};
   --color-dark-bg-alt: #{$color-dark-bg-alt};
   --font-family-body: #{$font-sans};
   --font-family-heading: #{$font-sans};


### PR DESCRIPTION
## Summary

The `dark-section-vars` mixin compiled `.design-system section.dark { background: #1f2937; }` — a hardcoded color that themes could not override via the cascade. The companion `--color-dark-bg-alt` was already exposed as a CSS custom property (and used by even-row dark sections), but `--color-dark-bg` was missing.

- Expose `--color-dark-bg` at `:root` in `_base.scss` alongside the existing `--color-dark-bg-alt`
- Update `dark-section-vars` mixin in `_mixins.scss` to use `var(--color-dark-bg)` for both the `background` declaration and the inner `--color-bg` override

## Test plan

- [x] `bun run build` succeeds
- [x] `bun run lint` clean
- [x] Verified compiled `_site/css/bundle.css` now contains `.design-system section.dark { background: var(--color-dark-bg); }` and `:root { ...; --color-dark-bg: #1f2937; ... }`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XjZ1jxrwa9Wj3RH8iYYw65)_