### PR TITLE
Fix search query pre-fill and remove search from nav

### DIFF
--- a/src/_lib/public/ui/search.js
+++ b/src/_lib/public/ui/search.js
@@ -103,9 +103,7 @@ const initSearch = () => {
   const container = document.querySelector("#search-results");
   if (!container) return;
 
-  const form = container
-    .closest(".design-system")
-    ?.querySelector(".search-box");
+  const form = container.parentElement?.querySelector(".search-box");
 
   const controller = createSearchController({
     list: container.querySelector(".search-results-list"),

--- a/src/pages/search.md
+++ b/src/pages/search.md
@@ -2,9 +2,6 @@
 title: Search
 layout: design-system-base.html
 permalink: /search/
-eleventyNavigation:
-  key: Search
-  order: 99
 header_text: Search
 blocks:
   - type: section-header

--- a/test/unit/frontend/search.test.js
+++ b/test/unit/frontend/search.test.js
@@ -312,6 +312,40 @@ describe("initSearch", () => {
     expect(document.querySelector("input[type='search']").value).toBe("hello");
   });
 
+  test("populates page input, not unrelated navigation search box", () => {
+    document.body.innerHTML = `
+      <body class="design-system">
+        <nav>
+          <form class="search-box">
+            <input type="search" name="q" id="nav-input">
+          </form>
+        </nav>
+        <main>
+          <div data-pagefind-ignore>
+            <div class="design-system">
+              <form action="/search/" method="get" class="search-box">
+                <input type="search" name="q" id="page-input">
+              </form>
+            </div>
+            <div id="search-results">
+              <p class="search-message"></p>
+              <ul class="search-results-list"></ul>
+              <button class="search-load-more" hidden></button>
+            </div>
+          </div>
+        </main>
+      </body>
+    `;
+    window.pagefind = createMockPagefind();
+
+    setSearchParam("hello");
+
+    initSearch();
+
+    expect(document.querySelector("#page-input").value).toBe("hello");
+    expect(document.querySelector("#nav-input").value).toBe("");
+  });
+
   test("form submit with empty input does not search", () => {
     document.body.innerHTML = SEARCH_HTML;
     window.pagefind = createMockPagefind();


### PR DESCRIPTION
## Summary

- Removed `eleventyNavigation` from `src/pages/search.md` so the search page no longer appears in site navigation.
- Fixed a bug where the search page's input wasn't pre-filled from the `?q=` URL parameter.

## The bug

In `src/_lib/public/ui/search.js`, `initSearch()` located the page form via:

```js
container.closest(".design-system")?.querySelector(".search-box")
```

In production, the form's wrapping `<div class="design-system">` (added by `search-box.html`) is a *sibling* of `#search-results`, not an ancestor. `closest()` walks up past it to `<body class="design-system">`, then `querySelector(".search-box")` returns the first match — which is the navigation search box, not the page form. So submitting a search from the nav navigated to `/search/?q=foo`, but the page input stayed empty (the nav input got pre-filled instead, where the user can't see it).

The unit test didn't catch it because its DOM fixture wraps both the form and `#search-results` inside the same `.design-system` div, so `closest()` happens to find the right wrapper.

## The fix

Use `container.parentElement?.querySelector(".search-box")` to stay scoped to the form's actual container.

## Test plan

- [x] Existing search tests still pass (`bun test test/unit/frontend/search.test.js`)
- [x] New regression test added: `populates page input, not unrelated navigation search box` — fails on the old code, passes on the fix
- [x] Full suite: 2817 pass / 0 fail
- [ ] Manual: visit `/search/?q=foo` and confirm the page input shows `foo` and results render

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHHgaafshsUEUFjhYDYQxs)_