### PR TITLE
Stretch video-background thumbnail to cover container

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -565,6 +565,21 @@
 // Shared styles for video-background and image-background content overlays.
 // No background tint is applied — tint the source image or video if needed.
 
+@mixin media-background-cover-image {
+  .image-wrapper {
+    position: absolute;
+    inset: 0;
+    height: 100%;
+    background-size: cover;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
 @mixin media-background-content {
   > figure {
     position: absolute;

--- a/src/css/design-system/_image-background.scss
+++ b/src/css/design-system/_image-background.scss
@@ -32,18 +32,7 @@
       position: absolute;
       inset: 0;
 
-      img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
-      .image-wrapper {
-        position: absolute;
-        inset: 0;
-        height: 100%;
-        background-size: cover;
-      }
+      @include media-background-cover-image;
     }
 
     @include media-background-content;

--- a/src/css/design-system/_video-background.scss
+++ b/src/css/design-system/_video-background.scss
@@ -39,18 +39,7 @@
         pointer-events: none;
       }
 
-      .image-wrapper {
-        position: absolute;
-        inset: 0;
-        height: 100%;
-        background-size: cover;
-      }
-
-      img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
+      @include media-background-cover-image;
     }
 
     // The iframe covers the entire container

--- a/src/css/design-system/_video-background.scss
+++ b/src/css/design-system/_video-background.scss
@@ -39,6 +39,13 @@
         pointer-events: none;
       }
 
+      .image-wrapper {
+        position: absolute;
+        inset: 0;
+        height: 100%;
+        background-size: cover;
+      }
+
       img {
         width: 100%;
         height: 100%;


### PR DESCRIPTION
## Summary

- The placeholder image inside `.video-background` (used by both YouTube and Bunny background blocks) was wrapped in an `image-wrapper` div with its own `aspect-ratio: 16/9` and `max-width`. The wrapper sat un-stretched inside the absolute-positioned `__thumbnail`, so on mobile (where the container switches to 4/3) the thumbnail was letterboxed against the dark background.
- Pin `.image-wrapper` to the thumbnail with `position: absolute; inset: 0; height: 100%` and `background-size: cover`, mirroring the existing `image-background` block. The inner `<img>` already had `object-fit: cover`, so the placeholder now fills the container at every aspect ratio.

## Test plan

- [ ] Visit a page using a video-background block on desktop (16/9) — thumbnail fills the container exactly.
- [ ] Resize to mobile breakpoint (4/3 container) — thumbnail covers the container with no dark bars.
- [ ] Confirm the same on a Bunny video-background block.
- [ ] Verify the thumbnail still fades out (`is-hidden`) once the video starts.

https://claude.ai/code/session_01L5QbU5vSkFANNL3wmiWUXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5QbU5vSkFANNL3wmiWUXF)_