### PR TITLE
Render Liquid expressions in block values

### DIFF
--- a/src/_includes/design-system/blocks.html
+++ b/src/_includes/design-system/blocks.html
@@ -1,4 +1,5 @@
-{%- assign split = blocks | splitBlocksForColumns: tags, blockLayouts -%}
+{%- assign processed_blocks = blocks | process_blocks -%}
+{%- assign split = processed_blocks | splitBlocksForColumns: tags, blockLayouts -%}
 {%- for block in split.before -%}
   {%- include "design-system/render-full-width-block.html", block: block -%}
 {%- endfor -%}

--- a/src/_includes/design-system/blocks.html
+++ b/src/_includes/design-system/blocks.html
@@ -1,5 +1,5 @@
-{%- assign processed_blocks = blocks | process_blocks -%}
-{%- assign split = processed_blocks | splitBlocksForColumns: tags, blockLayouts -%}
+{%- assign rendered_blocks = blocks | render_block_liquid -%}
+{%- assign split = rendered_blocks | splitBlocksForColumns: tags, blockLayouts -%}
 {%- for block in split.before -%}
   {%- include "design-system/render-full-width-block.html", block: block -%}
 {%- endfor -%}

--- a/src/_lib/eleventy/file-utils.js
+++ b/src/_lib/eleventy/file-utils.js
@@ -179,7 +179,7 @@ async function snippetBlocksFilter(name) {
  * @this {LiquidFilterContext}
  * @param {Record<string, unknown>[] | undefined | null} blocks
  */
-async function processBlocksFilter(blocks) {
+async function renderBlockLiquidFilter(blocks) {
   if (!blocks) return [];
   return processLiquidStrings(blocks, this.context.environments);
 }
@@ -213,7 +213,7 @@ const configureFileUtils = (eleventyConfig) => {
   eleventyConfig.addFilter("file_missing", fileMissingFilter);
   eleventyConfig.addFilter("snippet_data", snippetDataFilter);
   eleventyConfig.addAsyncFilter("snippet_blocks", snippetBlocksFilter);
-  eleventyConfig.addAsyncFilter("process_blocks", processBlocksFilter);
+  eleventyConfig.addAsyncFilter("render_block_liquid", renderBlockLiquidFilter);
   eleventyConfig.addFilter("escape_html", escapeHtmlFilter);
 
   eleventyConfig.addAsyncShortcode(

--- a/src/_lib/eleventy/file-utils.js
+++ b/src/_lib/eleventy/file-utils.js
@@ -175,6 +175,15 @@ async function snippetBlocksFilter(name) {
   return processLiquidStrings(data.blocks, this.context.environments);
 }
 
+/**
+ * @this {LiquidFilterContext}
+ * @param {Record<string, unknown>[] | undefined | null} blocks
+ */
+async function processBlocksFilter(blocks) {
+  if (!blocks) return [];
+  return processLiquidStrings(blocks, this.context.environments);
+}
+
 /** @param {string} str */
 const escapeHtmlFilter = (str) =>
   str
@@ -204,6 +213,7 @@ const configureFileUtils = (eleventyConfig) => {
   eleventyConfig.addFilter("file_missing", fileMissingFilter);
   eleventyConfig.addFilter("snippet_data", snippetDataFilter);
   eleventyConfig.addAsyncFilter("snippet_blocks", snippetBlocksFilter);
+  eleventyConfig.addAsyncFilter("process_blocks", processBlocksFilter);
   eleventyConfig.addFilter("escape_html", escapeHtmlFilter);
 
   eleventyConfig.addAsyncShortcode(

--- a/test/unit/utils/file-utils.test.js
+++ b/test/unit/utils/file-utils.test.js
@@ -445,4 +445,40 @@ blocks:
       );
     });
   });
+
+  describe("process_blocks filter", () => {
+    const callProcessBlocks = (blocks, pageContext) => {
+      const mockConfig = createConfiguredMock();
+      const filter = mockConfig.asyncFilters.process_blocks;
+      return filter.call({ context: { environments: pageContext } }, blocks);
+    };
+
+    test("Registers as an async filter", () => {
+      const mockConfig = createMockEleventyConfig();
+      configureFileUtils(mockConfig);
+      expect(typeof mockConfig.asyncFilters.process_blocks).toBe("function");
+    });
+
+    test("Returns empty array for null/undefined blocks", async () => {
+      expect(await callProcessBlocks(null, {})).toEqual([]);
+      expect(await callProcessBlocks(undefined, {})).toEqual([]);
+    });
+
+    test("Resolves Liquid expressions in block strings with page context", async () => {
+      const blocks = [
+        { type: "markdown", content: "Visit [us]({{ site.url }})" },
+      ];
+      const result = await callProcessBlocks(blocks, {
+        site: { url: "https://example.com" },
+      });
+      expect(result[0].content).toBe("Visit [us](https://example.com)");
+      expect(result[0].type).toBe("markdown");
+    });
+
+    test("Leaves strings without Liquid syntax unchanged", async () => {
+      const blocks = [{ type: "markdown", content: "No templates here" }];
+      const result = await callProcessBlocks(blocks, { title: "Unused" });
+      expect(result[0].content).toBe("No templates here");
+    });
+  });
 });

--- a/test/unit/utils/file-utils.test.js
+++ b/test/unit/utils/file-utils.test.js
@@ -446,29 +446,31 @@ blocks:
     });
   });
 
-  describe("process_blocks filter", () => {
-    const callProcessBlocks = (blocks, pageContext) => {
+  describe("render_block_liquid filter", () => {
+    const callRenderBlockLiquid = (blocks, pageContext) => {
       const mockConfig = createConfiguredMock();
-      const filter = mockConfig.asyncFilters.process_blocks;
+      const filter = mockConfig.asyncFilters.render_block_liquid;
       return filter.call({ context: { environments: pageContext } }, blocks);
     };
 
     test("Registers as an async filter", () => {
       const mockConfig = createMockEleventyConfig();
       configureFileUtils(mockConfig);
-      expect(typeof mockConfig.asyncFilters.process_blocks).toBe("function");
+      expect(typeof mockConfig.asyncFilters.render_block_liquid).toBe(
+        "function",
+      );
     });
 
     test("Returns empty array for null/undefined blocks", async () => {
-      expect(await callProcessBlocks(null, {})).toEqual([]);
-      expect(await callProcessBlocks(undefined, {})).toEqual([]);
+      expect(await callRenderBlockLiquid(null, {})).toEqual([]);
+      expect(await callRenderBlockLiquid(undefined, {})).toEqual([]);
     });
 
     test("Resolves Liquid expressions in block strings with page context", async () => {
       const blocks = [
         { type: "markdown", content: "Visit [us]({{ site.url }})" },
       ];
-      const result = await callProcessBlocks(blocks, {
+      const result = await callRenderBlockLiquid(blocks, {
         site: { url: "https://example.com" },
       });
       expect(result[0].content).toBe("Visit [us](https://example.com)");
@@ -477,7 +479,7 @@ blocks:
 
     test("Leaves strings without Liquid syntax unchanged", async () => {
       const blocks = [{ type: "markdown", content: "No templates here" }];
-      const result = await callProcessBlocks(blocks, { title: "Unused" });
+      const result = await callRenderBlockLiquid(blocks, { title: "Unused" });
       expect(result[0].content).toBe("No templates here");
     });
   });


### PR DESCRIPTION
## Summary

Fixes a bug where Liquid expressions inside YAML block values (e.g. `{{ site.socials.Facebook }}` in a `markdown` block's `content`) were rendered as literal text instead of being evaluated.

The `news` page and `instructions` page both contain this kind of content; both were affected.

## Approach

The codebase already has a `processLiquidStrings` helper and a `snippet_blocks` filter that pre-renders Liquid expressions in snippet blocks against the page's data context. This change adds a sibling `process_blocks` filter for already-loaded block arrays and applies it once at the top of `design-system/blocks.html`, so every caller of that include gets the pre-processing automatically (no per-layout changes needed).

This means any string field on any block — `content`, `title`, `description`, etc. — now supports Liquid expressions referencing the page's data cascade (`site`, `config`, `item`, `page`, etc.).

## Test plan

- [x] News page renders the Facebook/Mastodon links instead of raw `{{ site.socials.X }}` text
- [x] Instructions page renders the `{{ config.template_repo_url }}` link
- [x] Existing snippet flow (CTA on product pages with `{{ title }}`) still works
- [x] Full test suite: 2897 pass, 0 fail
- [x] CPD (code duplication) check passes


---
_Generated by [Claude Code](https://claude.ai/code/session_013FxavYcfuNRmAKEzr2WoHU)_