### PR TITLE
Remove misleading "JavaScript is required" notice from sort dropdown

### DIFF
--- a/src/_includes/filter-sort-dropdown.html
+++ b/src/_includes/filter-sort-dropdown.html
@@ -12,7 +12,6 @@ Parameters:
   </select>
 </label>
 <noscript>
-  <p>JavaScript is required for the sort dropdown.</p>
   {%- assign options = group.options -%}
   {%- include "filter-options-list.html" -%}
 </noscript>


### PR DESCRIPTION
## Summary
- The `<noscript>` fallback for the sort dropdown already renders a fully working list of sort links, so claiming "JavaScript is required for the sort dropdown" is inaccurate — users without JS can still sort by clicking the links.
- Removed the misleading `<p>` notice from `src/_includes/filter-sort-dropdown.html`; the link-list fallback remains.

## Test plan
- [ ] Disable JavaScript in the browser, visit a category page (e.g. `/categories/doodahs`), and confirm the sort link list renders without the misleading paragraph.
- [ ] With JavaScript enabled, confirm the `<select>` dropdown still works and the noscript content stays hidden.

https://claude.ai/code/session_01L87rRST6ndvyUzJpMr8fLe

---
_Generated by [Claude Code](https://claude.ai/code/session_01L87rRST6ndvyUzJpMr8fLe)_