### PR TITLE
Style nested ULs in filter-groups as horizontal flex rows

### DIFF
--- a/src/css/item-filter.scss
+++ b/src/css/item-filter.scss
@@ -79,7 +79,7 @@
         font-weight: 600;
       }
 
-      > ul {
+      ul {
         @include flex-wrap($space-xs);
 
         li {


### PR DESCRIPTION
## Summary
- The `.filter-groups > li > ul` direct-child selector skipped any `<ul>` not directly nested under the filter-group `<li>` — notably the noscript fallback list inside `filter-sort-dropdown.html`, which renders `<noscript><p>…</p><ul>…</ul></noscript>`.
- Drop the `>` so any `<ul>` inside a filter-group `<li>` gets the horizontal `flex-wrap` layout and pill-style option styling, regardless of nesting depth.

## Test plan
- [ ] Build the site (`bun run build`) and confirm the filter UI renders unchanged with JS enabled.
- [ ] Disable JavaScript and verify the sort dropdown's noscript fallback list now lays out as a horizontal flex row of pills, matching the other filter groups.

https://claude.ai/code/session_015esHZx6y73YG4ZcyPs8EDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGT77SLhirnFtMYgr7k9rS)_