### PR TITLE
Force filter-group option ULs to flex-row direction

### DIFF
--- a/src/css/item-filter.scss
+++ b/src/css/item-filter.scss
@@ -79,7 +79,7 @@
         font-weight: 600;
       }
 
-      > ul {
+      ul {
         @include flex-wrap($space-xs);
 
         li {

--- a/src/css/item-filter.scss
+++ b/src/css/item-filter.scss
@@ -80,7 +80,9 @@
       }
 
       ul {
-        @include flex-wrap($space-xs);
+        @include flex-row($space-xs);
+
+        flex-wrap: wrap;
 
         li {
           font-size: $font-size-sm;


### PR DESCRIPTION
## Summary
- The unclassed `<ul>` inside each `.filter-groups > li` was inheriting `flex-direction: column` from `.design-system ul:not([class])`, since the `flex-wrap` mixin only sets `display: flex`, `flex-wrap: wrap`, and `gap` — it doesn't set `flex-direction`, so the column rule still applied for that property.
- Switch the inner `ul` to `flex-row` (which sets `flex-direction: row` explicitly) plus a separate `flex-wrap: wrap`, mirroring the parent `li` styling. Options now lay out as a horizontal wrapping row.

## Test plan
- [ ] Build the site (`bun run build`) and verify in a browser that filter-group option lists (Price, Size, etc.) render as a horizontal row of pills, not stacked.
- [ ] Disable JavaScript and confirm the sort dropdown's noscript fallback list also renders horizontally.

https://claude.ai/code/session_015esHZx6y73YG4ZcyPs8EDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGT77SLhirnFtMYgr7k9rS)_