### PR TITLE
Set min-width 100% on tables inside scrollable-table

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -333,6 +333,7 @@ dialog {
 
   > table {
     margin: 0;
+    min-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `min-width: 100%` to tables inside `.scrollable-table` so narrow tables still fill their container, keeping borders and headers aligned with surrounding layout while still scrolling horizontally when content overflows.

## Test plan
- [ ] Verify a narrow table inside `.scrollable-table` now spans the full container width
- [ ] Verify a wide table inside `.scrollable-table` still scrolls horizontally as expected

https://claude.ai/code/session_013rhDVZ646uDdbvB1YDDnLX

---
_Generated by [Claude Code](https://claude.ai/code/session_013rhDVZ646uDdbvB1YDDnLX)_