### PR TITLE
Make hero block fill its section, removing section padding

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -96,6 +96,16 @@
   padding-bottom: var(--section-padding-y);
 }
 
+// Self-padding for elements that replace section padding (e.g. hero, split-full
+// panels) — vertical from --section-padding-y, horizontal responsive.
+@mixin section-self-padding {
+  padding: var(--section-padding-y) $space-md;
+
+  @include breakpoint.up("md") {
+    padding: var(--section-padding-y) $space-lg;
+  }
+}
+
 // Compact section padding override
 @mixin section-compact {
   --section-padding-y: calc(#{$space-2xl} * 0.6);

--- a/src/css/design-system/_base.scss
+++ b/src/css/design-system/_base.scss
@@ -274,6 +274,12 @@
       padding-top: 0;
       padding-bottom: 0;
     }
+
+    // Sections containing a hero have no padding; the hero fills the section
+    &:has(> .hero) {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
   }
 
   // ===========================================================================

--- a/src/css/design-system/_hero.scss
+++ b/src/css/design-system/_hero.scss
@@ -10,11 +10,11 @@
   .hero {
     @include flex-col($space-lg, center, center);
 
-    padding: 0 $space-md;
+    padding: var(--section-padding-y) $space-md;
     text-align: center;
 
     @include breakpoint.up("md") {
-      padding: 0 $space-lg;
+      padding: var(--section-padding-y) $space-lg;
     }
 
     h1 {

--- a/src/css/design-system/_hero.scss
+++ b/src/css/design-system/_hero.scss
@@ -9,13 +9,9 @@
 .design-system {
   .hero {
     @include flex-col($space-lg, center, center);
+    @include section-self-padding;
 
-    padding: var(--section-padding-y) $space-md;
     text-align: center;
-
-    @include breakpoint.up("md") {
-      padding: var(--section-padding-y) $space-lg;
-    }
 
     h1 {
       max-width: $width-default;

--- a/src/css/design-system/_split.scss
+++ b/src/css/design-system/_split.scss
@@ -57,13 +57,10 @@
     // Child panels
     .left,
     .right {
+      @include section-self-padding;
+
       display: flex;
       flex: 1;
-      padding: var(--section-padding-y) $space-md;
-
-      @include breakpoint.up("md") {
-        padding: var(--section-padding-y) $space-lg;
-      }
 
       > * {
         justify-content: center;


### PR DESCRIPTION
## Summary
- Sections containing a `.hero` child now drop their top/bottom padding via `:has(> .hero)`, matching the existing pattern used for `.split-full`.
- The hero takes over vertical spacing using `var(--section-padding-y)`, so the visual breathing room is preserved while the hero visually fills the section.

## Test plan
- [x] `bun run build` (SCSS compiles, site builds)
- [x] `bun test test/unit/code-quality/design-system-scoping.test.js`
- [x] `bun run lint`
- [ ] Visual check: hero renders edge-to-edge inside its section (no extra section padding above/below)

https://claude.ai/code/session_011NsQNUCWvsNiL6ksrYpbFD

---
_Generated by [Claude Code](https://claude.ai/code/session_011NsQNUCWvsNiL6ksrYpbFD)_