### PR TITLE
Convert not-found to design-system-base; skip canonical on noindex

### DIFF
--- a/src/_includes/head-meta.html
+++ b/src/_includes/head-meta.html
@@ -21,14 +21,14 @@
   content="{{ eleventy.generator }}"
 >
 
-<link
-  rel="canonical"
-  href="{{ page.url | canonicalUrl }}"
->
-
 {%- if no_index -%}
   <meta
     name="robots"
     value="noindex,nofollow"
+  >
+{%- else -%}
+  <link
+    rel="canonical"
+    href="{{ page.url | canonicalUrl }}"
   >
 {%- endif -%}

--- a/src/pages/not-found.md
+++ b/src/pages/not-found.md
@@ -1,12 +1,13 @@
 ---
 name: Not Found
-meta_description:
 meta_title: Not Found
 no_index: true
-
+layout: design-system-base.html
 permalink: /bunnycdn_errors/404.html
+blocks:
+  - type: markdown
+    content: |
+      ## Page Not Found
+
+      Whoops! It looks like you followed an invalid link - **[click here to go back to the homepage](/)**.
 ---
-
-## Page Not Found
-
-Whoops! It looks like you followed an invalid link - **[click here to go back to the homepage](/)**.


### PR DESCRIPTION
## Summary

- Convert `src/pages/not-found.md` to use the `design-system-base.html` layout, expressing the body as a `markdown` block in frontmatter (required by `validatePageBodyContent`).
- Skip the `<link rel="canonical">` tag in `head-meta.html` when `no_index` is set — noindexed pages shouldn't advertise a canonical URL.

## Test plan

- [x] `bun run build` succeeds
- [x] `/bunnycdn_errors/404.html` renders via design-system-base (body class includes `design-system design-system-base`) with no canonical tag, only the `noindex,nofollow` robots meta
- [x] `/about/` and `/` still emit a canonical tag
- [x] Related tests pass (`sitemap`, `news`, `canonical-url`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4LH3dpHaqE7qkbgJGah1b)_