### PR TITLE
Show event time alongside date when provided

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1353,6 +1353,10 @@ content:
         type: string
         label: Recurring Date (e.g. "Every Friday at 2 PM")
         required: false
+      - name: event_time
+        type: string
+        label: Event Time (e.g. "10:00am – 5:00pm")
+        required: false
       - { name: event_location, type: string, label: Event Location }
       - { name: products, component: products_list }
       - name: map_embed_src

--- a/scripts/customise-cms/item-builders.js
+++ b/scripts/customise-cms/item-builders.js
@@ -108,6 +108,12 @@ export const buildEventsFields = (config, fields) =>
       required: false,
     },
     config.features.event_locations_and_dates && {
+      name: "event_time",
+      type: "string",
+      label: 'Event Time (e.g. "10:00am – 5:00pm")',
+      required: false,
+    },
+    config.features.event_locations_and_dates && {
       name: "event_location",
       type: "string",
       label: "Event Location",

--- a/src/_includes/item-event-details.html
+++ b/src/_includes/item-event-details.html
@@ -16,6 +16,14 @@
         </em>
       </li>
     {%- endif -%}
+    {%- if event_time -%}
+      <li>
+        <em>
+          Time:
+          <strong>{{ event_time }}</strong>
+        </em>
+      </li>
+    {%- endif -%}
     {%- if event_location != blank -%}
       <li>
         <em>

--- a/src/_includes/list-item-event-date.html
+++ b/src/_includes/list-item-event-date.html
@@ -2,5 +2,6 @@
   <p>
     <strong>Date:</strong>
     {{ item.data.recurring_date | default: item.data.event_date | date: "%b %-d, %Y" }}
+    {%- if item.data.event_time %} · {{ item.data.event_time }}{% endif -%}
   </p>
 {%- endif -%}

--- a/src/_includes/recurring-events-list.html
+++ b/src/_includes/recurring-events-list.html
@@ -9,6 +9,9 @@
     <strong><a href="{{ event.url }}{{ config.internal_link_suffix }}">{{ event_data.name }}</a></strong
     ><br />
     {{ event_data.recurring_date }}
+    {%- if event_data.event_time -%}
+    <br />{{ event_data.event_time }}
+    {%- endif -%}
     {%- if event_data.event_location != blank -%}
     <br />{{ event_data.event_location }}
     {%- endif -%}

--- a/src/_lib/eleventy/recurring-events.js
+++ b/src/_lib/eleventy/recurring-events.js
@@ -13,7 +13,7 @@ const getTemplate = createTemplateLoader("recurring-events-list.html");
 /**
  * Render recurring events as HTML list using Liquid template
  *
- * @param {Array<{url: string, data: {name: string, recurring_date: string, event_location?: string}}>} events
+ * @param {Array<{url: string, data: {name: string, recurring_date: string, event_time?: string, event_location?: string}}>} events
  * @returns {Promise<string>}
  */
 const renderRecurringEvents = createTemplateRenderer(getTemplate, "events");
@@ -55,6 +55,7 @@ const getRecurringEventsHtml = memoize(async () => {
           data: {
             name: data.name,
             recurring_date: data.recurring_date,
+            event_time: data.event_time,
             event_location: data.event_location,
           },
         },

--- a/src/_lib/types/eleventy.d.ts
+++ b/src/_lib/types/eleventy.d.ts
@@ -110,6 +110,8 @@ export type EventItemData = BaseItemData & {
   event_date?: string;
   /** Recurring date pattern */
   recurring_date?: string;
+  /** Event time, free-text (e.g. "10:00am – 5:00pm") */
+  event_time?: string;
   /** Event location description */
   event_location?: string;
   /** iCal URL */

--- a/src/events/2026-06-19-summer-expo.md
+++ b/src/events/2026-06-19-summer-expo.md
@@ -3,6 +3,7 @@ name: Summer Expo
 subtitle: Exclusive deals aplenty!
 meta_description: Join us for our upcoming Summer Expo with exclusive deals
 event_date: 2026-06-19
+event_time: 10:00am – 5:00pm
 event_location: City Exhibition Hall
 featured: true
 products:

--- a/test/integration/eleventy/recurring-events.test.js
+++ b/test/integration/eleventy/recurring-events.test.js
@@ -228,4 +228,20 @@ describe("recurring-events", () => {
         );
       },
     ));
+
+  test("Recurring events render event_time when provided", async () =>
+    withTestSite(
+      {
+        files: [
+          eventFile("yoga-class", "Yoga Class", "Every Wednesday", {
+            event_time: "6:30pm – 7:30pm",
+          }),
+          eventsTestPage(),
+        ],
+      },
+      async (site) => {
+        const html = site.getOutput("/test/index.html");
+        expect(html.includes("6:30pm – 7:30pm")).toBe(true);
+      },
+    ));
 });

--- a/test/unit/scripts/customise-cms/generator.test.js
+++ b/test/unit/scripts/customise-cms/generator.test.js
@@ -272,6 +272,7 @@ describe("generatePagesYaml events", () => {
     const section = getEventsSection(yaml);
 
     expect(section).toContain("name: event_date");
+    expect(section).toContain("name: event_time");
     expect(section).toContain("name: event_location");
     expect(section).toContain("name: map_embed_src");
   });
@@ -283,6 +284,7 @@ describe("generatePagesYaml events", () => {
     const section = getEventsSection(yaml);
 
     expect(section).not.toContain("name: event_date");
+    expect(section).not.toContain("name: event_time");
     expect(section).not.toContain("name: event_location");
   });
 


### PR DESCRIPTION
## Summary

Adds an optional `event_time` free-text frontmatter field for events, so the time of an event is shown wherever the date is rendered (when one exists).

- New `event_time` frontmatter field (free-text string, e.g. `"10:00am – 5:00pm"`) rendered on the event detail page, in event list items, and in the recurring events shortcode
- Field plumbed through `recurring-events.js` data extraction so it appears in the recurring events list
- Exposed in the PagesCMS schema (`.pages.yml`) and field generator (`scripts/customise-cms/item-builders.js`) so editors can fill it in
- Added to `EventItemData` JSDoc type
- Summer Expo example event updated to demonstrate the field

Free-text was chosen (over structured HH:MM) to match the existing `recurring_date` field style and let editors write whatever makes sense (e.g. `"Doors at 6pm, music at 8pm"`). The iCal generator continues to emit all-day events; structured time export wasn't part of the ask.

## Test plan

- [x] `bun test` (3035 pass)
- [x] New integration test verifies `event_time` renders in the recurring events shortcode output
- [x] New unit test asserts `event_time` is included/excluded by the CMS generator alongside the other event-locations-and-dates fields
- [x] Manual build inspection — `_site/events/summer-expo/index.html` shows the new Time row; `_site/events/index.html` shows `Jun 19, 2026 · 10:00am – 5:00pm`

---
_Generated by [Claude Code](https://claude.ai/code/session_017oPMtL3wkSmfpPGWGuZeok)_