### PR TITLE
Fix unreadable table thead in dark split-full panels

### DIFF
--- a/src/css/design-system/_split.scss
+++ b/src/css/design-system/_split.scss
@@ -100,14 +100,11 @@
     // Dark colored panels
     &.dark-left .left,
     &.dark-right .right {
-      --color-text: #{$color-dark-text};
-      --color-text-muted: #{$color-dark-text-muted};
+      @include dark-section-vars;
+
       --split-btn-color: #{$color-dark-text};
       --split-btn-hover-bg: #{$color-dark-text};
       --split-btn-hover-color: #{$color-dark-bg};
-
-      color: $color-dark-text;
-      background: $color-dark-bg;
     }
 
     // Primary colored panels


### PR DESCRIPTION
## Summary

Tables placed inside a `.split-full.dark-left .left` / `.dark-right .right` panel had unreadable thead text: light text on a light background.

The dark split panels only overrode `--color-text` (to light) but never `--color-bg`. The global `table thead { background-color: var(--color-bg); }` rule therefore stayed light, while the inherited text color was light — light-on-light, invisible.

Fix: replace the duplicated partial overrides in `_split.scss` with `@include dark-section-vars;`, matching how `section.dark` already behaves. The mixin sets `--color-bg: var(--color-dark-bg)`, so the thead now gets a dark background that contrasts with the inherited light text.

This is a small net simplification — the mixin already contains every property the dark-panel block was setting (`--color-text`, `--color-text-muted`, `color:`, `background:`), plus the missing `--color-bg`/`--color-card-bg`/`--color-tint` overrides.

## Known follow-up (not in this PR)

Striped table rows (`tr:nth-child(even)`) use `var(--color-accent)`, which is also not overridden in dark contexts — including in the existing `dark-section-vars` mixin. So even rows remain invisible in both dark splits and `section.dark`. Same root cause, but out of scope for the user's specific "thead" request. Easy follow-up: add `--color-accent: #{$color-dark-card-bg};` to the mixin in `src/css/_mixins.scss`.

## Test plan

- [x] `bun run lint` passes
- [x] `bun run build` succeeds
- [x] Compiled CSS shows `.split-full.dark-left .left` now emits `--color-bg: var(--color-dark-bg)`
- [x] Visual verification: rendered a table inside a dark-left split panel, with both global `bundle.css` and `design-system-bundle.css` loaded. Before fix: thead row invisible (light-on-light). After fix: thead readable (light text on dark background).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YarXHxus9XXo6jB7fPzmFP)_