### PR TITLE
Add intro_content support to the stats block

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -711,6 +711,9 @@ components:
         fields:
           - { name: value, type: string, label: Value, required: true }
           - { name: label, type: string, label: Label, required: true }
+      - name: intro_content
+        type: rich-text
+        label: Intro Content (Markdown)
   block_video_background:
     label: Video Background
     type: object

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -142,6 +142,7 @@ Key metrics displayed as large numbers with labels.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `items` | array | **required** | Stat objects: `{value, label}` or pipe-delimited strings `"value|label"`. |
+| `intro_content` | string | — | Markdown content rendered above the block in `.prose`. |
 | `reveal` | boolean | `true` | Adds `data-reveal` to each stat. |
 
 ---

--- a/src/_includes/design-system/blocks/stats.html
+++ b/src/_includes/design-system/blocks/stats.html
@@ -4,10 +4,11 @@ Stats display as a description list with dt (label) and dd (value).
 Parameters (via block object):
   - block.items: Array of stat objects with 'value' and 'label' properties
   - block.reveal: If true, adds data-reveal to each item (default: true)
+  - block.intro_content: Optional markdown intro rendered above the stats
 
 Embeddable form:
   - items: pass an items array directly (sugar blocks like `hire-pricing`
-    pre-format the values).
+    pre-format the values); skips intro_content.
 
 Usage:
   {% assign myStats = "99%|Uptime,50k|Users,24/7|Support" | split: "," %}
@@ -22,6 +23,7 @@ Or with objects:
 {%- assign _items = items | default: block.items -%}
 {%- assign reveal = block.reveal | default: true -%}
 
+{%- unless items -%}{%- include "design-system/block-intro.html" -%}{%- endunless -%}
 <dl class="stats">
   {%- for item in _items -%}
     {%- comment -%} Handle both "value|label" strings and {value, label} objects {%- endcomment -%}

--- a/src/_lib/utils/block-schema/stats.js
+++ b/src/_lib/utils/block-schema/stats.js
@@ -1,4 +1,8 @@
-import { objectList, str } from "#utils/block-schema/shared.js";
+import {
+  INTRO_CONTENT_FIELD,
+  objectList,
+  str,
+} from "#utils/block-schema/shared.js";
 
 export const type = "stats";
 
@@ -14,6 +18,7 @@ export const fields = {
       'Stat objects: `{value, label}` or pipe-delimited strings `"value|label"`.',
   },
   /* jscpd:ignore-end */
+  intro_content: INTRO_CONTENT_FIELD,
   reveal: {
     type: "boolean",
     default: "true",


### PR DESCRIPTION
## Summary

Adds optional `intro_content` (markdown) support to the `stats` block type, matching the pattern already used by `features` and the items-style blocks. Editors can now render a markdown intro above the stats grid.

## Changes

- **`src/_lib/utils/block-schema/stats.js`** — add `intro_content: INTRO_CONTENT_FIELD` to the block's field schema (placed after `items`, before `reveal`).
- **`src/_includes/design-system/blocks/stats.html`** — render `block-intro.html` above the `<dl class="stats">`, guarded by `{%- unless items -%}` so the embeddable `items:` form (used by sugar blocks like `hire-pricing`) skips it. Documented the new param in the template comment.
- **`.pages.yml`** / **`BLOCKS_LAYOUT.md`** — regenerated from the schema via the existing generators (`generate-pages-yml`, `generate-blocks-reference`).

## Testing

- `block-schema`, `pages-yml-block-sync`, `pages-yml-freshness`, `block-docs`, `type-generation-freshness`, and `block-markdown-rendering` tests all pass.
- `bun run lint` clean.

The `intro_content` field renders through `renderContent: "md"` inside a `.prose` wrapper (via the shared `block-intro.html`), satisfying the markdown-rendering quality checks automatically.

https://claude.ai/code/session_01Eard4sBoUQFfBB42Aj6vUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eard4sBoUQFfBB42Aj6vUb)_