### PR TITLE
Fix Pagefind indexing redirect stubs by removing stale exclude-selectors

### DIFF
--- a/scripts/eleventy-build.js
+++ b/scripts/eleventy-build.js
@@ -84,13 +84,7 @@ const runPagefind = () => {
   console.log("\nRunning Pagefind indexer...");
   const result = spawnSync(
     "bun",
-    [
-      "./node_modules/.bin/pagefind",
-      "--site",
-      "_site",
-      "--exclude-selectors",
-      "body.filtered-properties [data-pagefind-body], body.base [data-pagefind-body]",
-    ],
+    ["./node_modules/.bin/pagefind", "--site", "_site"],
     { stdio: "inherit", env: process.env },
   );
   if (result.status !== 0) {

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -72,11 +72,13 @@ const enrichVideoCards = async (block) => {
 export default {
   /**
    * Whether this page should be indexed by Pagefind.
-   * True when any of the page's tags appear in config.search_collections.
+   * True when any of the page's tags appear in config.search_collections,
+   * unless the page is marked no_index.
    * @param {import("#lib/types").EleventyComputedData} data - Page data
    * @returns {boolean}
    */
   pagefind_body: (data) => {
+    if (data.no_index) return false;
     const collections = data.config?.search_collections;
     if (!collections) return false;
     return (data.tags || []).some((tag) => collections.includes(tag));

--- a/src/_includes/redirect-page.html
+++ b/src/_includes/redirect-page.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en">
   <meta charset="utf-8" />
   <title>Redirecting&hellip;</title>
   <link rel="canonical" href="{{ redirect_url | canonicalUrl }}" />

--- a/src/_lib/config/helpers.js
+++ b/src/_lib/config/helpers.js
@@ -40,6 +40,7 @@ const DEFAULTS = frozenObject({
     "events",
     "properties",
     "news",
+    "pages",
   ],
   linkify_urls: true,
 });

--- a/src/pages/products-search.md
+++ b/src/pages/products-search.md
@@ -1,6 +1,7 @@
 ---
 permalink: "/{{ strings.product_permalink_dir }}/search/"
 name: All Products
+no_index: true
 eleventyExcludeFromCollections: true
 blocks:
   - type: include

--- a/src/pages/search.md
+++ b/src/pages/search.md
@@ -1,6 +1,7 @@
 ---
 name: Search
 permalink: /search/
+no_index: true
 blocks:
   - type: section-header
     intro: |-

--- a/test/integration/eleventy/search.test.js
+++ b/test/integration/eleventy/search.test.js
@@ -74,6 +74,24 @@ describe("search", () => {
     });
   });
 
+  test("redirect stubs are not indexable and match the site language", async () => {
+    const files = [
+      contentFile("products", "widget", "Widget", {
+        redirect_from: ["/old-widget/"],
+      }),
+    ];
+
+    await withTestSite({ files }, async (site) => {
+      const stubDoc = await site.getDoc("old-widget/index.html");
+      expect(stubDoc.querySelector("[data-pagefind-body]")).toBe(null);
+
+      const productDoc = await site.getDoc("products/widget/index.html");
+      expect(stubDoc.documentElement.getAttribute("lang")).toBe(
+        productDoc.documentElement.getAttribute("lang"),
+      );
+    });
+  });
+
   test("search_collections config controls which pages are indexed", async () => {
     const files = [
       contentFile("products", "gadget", "Gadget"),

--- a/test/integration/eleventy/search.test.js
+++ b/test/integration/eleventy/search.test.js
@@ -12,11 +12,15 @@ const contentFile = (collection, slug, name, extras = {}) => ({
 });
 
 describe("search", () => {
-  test("product and category pages get data-pagefind-body, other pages do not", async () => {
+  test("collection and static pages get data-pagefind-body, no_index pages do not", async () => {
     const files = [
       contentFile("products", "widget", "Widget"),
       contentFile("categories", "tools", "Tools"),
       contentFile("pages", "about", "About Us", { permalink: "/about/" }),
+      contentFile("pages", "checkout", "Checkout", {
+        permalink: "/checkout/",
+        no_index: true,
+      }),
     ];
 
     await withTestSite({ files }, async (site) => {
@@ -31,7 +35,12 @@ describe("search", () => {
       );
 
       const aboutDoc = await site.getDoc("about/index.html");
-      expect(aboutDoc.querySelector("[data-pagefind-body]")).toBe(null);
+      expect(aboutDoc.querySelector("[data-pagefind-body]") !== null).toBe(
+        true,
+      );
+
+      const checkoutDoc = await site.getDoc("checkout/index.html");
+      expect(checkoutDoc.querySelector("[data-pagefind-body]")).toBe(null);
     });
   });
 

--- a/test/unit/data/eleventy-computed/search-nav.test.js
+++ b/test/unit/data/eleventy-computed/search-nav.test.js
@@ -33,6 +33,16 @@ describe("eleventyComputed.pagefind_body", () => {
       }),
     ).toBe(false);
   });
+
+  test("returns false for no_index pages even when tags match", () => {
+    expect(
+      eleventyComputed.pagefind_body({
+        no_index: true,
+        tags: ["products"],
+        config: { search_collections: ["products"] },
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("eleventyComputed.eleventyNavigation", () => {


### PR DESCRIPTION
## Problem

Pagefind was indexing every page on a default site — including the `redirect_from` "Redirecting…" stubs — and registering two languages (`en-US` from the stubs vs `en` from real pages), polluting search results.

## Root cause

The template *does* set `data-pagefind-body` correctly: `eleventyComputed.pagefind_body` is true for pages whose tags appear in `config.search_collections`, and `base.html` puts the attribute on `<main>`.

But the Pagefind invocation in `scripts/eleventy-build.js` passed:

```
--exclude-selectors "body.filtered-properties [data-pagefind-body], body.base [data-pagefind-body]"
```

Since the layout consolidation (#1428 etc.), **every page uses `base.html`**, so every body has the `base` class. The selector therefore stripped `data-pagefind-body` from every page before Pagefind's body detection ran. Pagefind reported "Did not find a data-pagefind-body element on the site" and fell back to indexing all 89 `<body>` elements — redirect stubs included. The `filtered-properties` half of the selector was dead anyway: product/property filtering is client-side now and no layout produces that body class.

This also explains why the flag looked "inverted": it excluded exactly the content that had opted in.

## Fix

- Remove the `--exclude-selectors` flag entirely, restoring the designed opt-in behaviour. No need to sprinkle `data-pagefind-body` over `.prose` divs — the existing `<main data-pagefind-body>` mechanism works once the selector stops cancelling it.
- Align the redirect stub's `lang="en-US"` with the site's `lang="en"` so stubs can never register a second language.
- Add `"pages"` to the default `search_collections` so static content (about, contact, services…) is searchable.
- Make `pagefind_body` return false for `no_index` pages — this automatically keeps the existing utility pages (checkout, thank-you, order-complete, quote, not-found, …) out of site search.
- Mark the search page and the products filter page `no_index`, keeping these internal search surfaces out of both the Pagefind index and search engines (per Google's guidance on internal search result pages).
- Integration tests pin all of the above: redirect stubs aren't indexable and match the site language; static pages opt in; `no_index` pages opt out.

## Result

| | Before | After |
|---|---|---|
| Body detection | "Did not find a data-pagefind-body element" → indexes all bodies | "Found a data-pagefind-body element… Ignoring pages without this tag" |
| Pages indexed | 89 (incl. redirect stubs, search pages, checkout, etc.) | 53 (collections + static pages; no stubs, no search/`no_index` utility pages) |
| Languages | 2 (`en-us`, `en`) | 1 (`en`) |

Full suite passes: 2,974 tests, lint clean.

https://claude.ai/code/session_016n4SA5xkjECXypStprst6Z