### PR TITLE
Guard script/style bodies from entity escaping during linkification

### DIFF
--- a/src/_lib/eleventy/html-transform.js
+++ b/src/_lib/eleventy/html-transform.js
@@ -26,6 +26,10 @@ import {
   linkifyPhones,
   SKIP_TAGS,
 } from "#transforms/linkify.js";
+import {
+  extractRawTextElements,
+  restoreRawTextElements,
+} from "#transforms/raw-text-guard.js";
 import { hasReadMoreMarker, processReadMore } from "#transforms/read-more.js";
 import { wrapTables } from "#transforms/responsive-tables.js";
 import { loadDOM, withDOMSlot } from "#utils/lazy-dom.js";
@@ -70,6 +74,26 @@ const applyDomTransforms = (html, config, processAndWrapImage) =>
   });
 
 /**
+ * Linkify URLs/emails with raw-text elements guarded: linkify-html's
+ * ignoreTags only prevents linkification, but its tokenizer still
+ * entity-escapes script/style text nodes when re-serialising, corrupting
+ * inline JS and CSS. Extract those elements first and restore them after.
+ * @param {string} content
+ * @param {object} config
+ * @returns {string}
+ */
+const linkifyHtml = (content, config) => {
+  const { content: guarded, blocks } = extractRawTextElements(content);
+  const linkified = linkifyHtmlLib(guarded, {
+    ignoreTags: [...SKIP_TAGS],
+    target: config.externalLinksTargetBlank ? "_blank" : null,
+    rel: config.externalLinksTargetBlank ? "noopener noreferrer" : null,
+    format: { url: formatUrlDisplay },
+  });
+  return restoreRawTextElements(linkified, blocks);
+};
+
+/**
  * Apply string-based transforms (URL/email linkification, external link attrs)
  * Skips linkification when FAST_INACCURATE_BUILDS is enabled.
  * @param {string} content
@@ -80,12 +104,7 @@ const applyStringTransforms = (content, config) => {
   const processed =
     FAST_INACCURATE_BUILDS || !config.linkify_urls
       ? content
-      : linkifyHtmlLib(content, {
-          ignoreTags: [...SKIP_TAGS],
-          target: config.externalLinksTargetBlank ? "_blank" : null,
-          rel: config.externalLinksTargetBlank ? "noopener noreferrer" : null,
-          format: { url: formatUrlDisplay },
-        });
+      : linkifyHtml(content, config);
   return addExternalLinkAttrs(processed, config);
 };
 

--- a/src/_lib/transforms/raw-text-guard.js
+++ b/src/_lib/transforms/raw-text-guard.js
@@ -1,0 +1,59 @@
+/**
+ * String-level guard for raw-text elements (<script> and <style>).
+ *
+ * HTML treats script and style bodies as raw text: browsers never decode
+ * character entities inside them. String transforms that tokenize and
+ * re-serialise whole pages (like linkify-html) entity-escape every text
+ * node, including these, silently corrupting inline JavaScript
+ * (`(a) => a` becomes `(a) =&gt; a`) and CSS (`.a > .b` becomes
+ * `.a &gt; .b`). Extract the elements before such a transform and restore
+ * them afterwards so their bodies pass through byte-for-byte.
+ */
+
+/** Matches a complete <script> or <style> element, including its body */
+const RAW_TEXT_ELEMENT_PATTERN = /<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
+
+/** @type {(index: number) => string} */
+const placeholderFor = (index) => `\u0000raw-text-${index}\u0000`;
+
+/**
+ * Replace raw-text elements with placeholders, returning the extracted
+ * elements alongside the substituted content. NUL bytes cannot appear in
+ * valid HTML, so the placeholders cannot collide with page content.
+ * @param {string} content
+ * @returns {{ content: string, blocks: string[] }}
+ */
+const extractRawTextElements = (content) => {
+  if (content.includes("\u0000")) {
+    throw new Error(
+      "Content contains NUL bytes; cannot guard raw-text elements",
+    );
+  }
+  const blocks = [...content.matchAll(RAW_TEXT_ELEMENT_PATTERN)].map(
+    ([element]) => element,
+  );
+  const extracted = blocks.reduce(
+    (acc, element, index) => acc.replace(element, () => placeholderFor(index)),
+    content,
+  );
+  return { content: extracted, blocks };
+};
+
+/**
+ * Restore previously extracted raw-text elements. The replacement uses a
+ * function so `$` sequences inside script bodies are not treated as
+ * substitution patterns.
+ * @param {string} content
+ * @param {string[]} blocks
+ * @returns {string}
+ */
+const restoreRawTextElements = (content, blocks) =>
+  blocks.reduce((acc, element, index) => {
+    const placeholder = placeholderFor(index);
+    if (!acc.includes(placeholder)) {
+      throw new Error(`Raw-text placeholder ${index} missing after transform`);
+    }
+    return acc.replace(placeholder, () => element);
+  }, content);
+
+export { extractRawTextElements, restoreRawTextElements };

--- a/test/unit/eleventy/html-transform.test.js
+++ b/test/unit/eleventy/html-transform.test.js
@@ -53,6 +53,27 @@ describe("html-transform", () => {
       expect(result).toContain(">example.com</a>");
     });
 
+    test("leaves inline script bodies unescaped while linkifying", async () => {
+      const transform = createHtmlTransform(mockImageProcessor);
+      const script = "<script>const f = (a) => a > 1 && a < 5;</script>";
+      const html = `<html><body><p>Visit https://example.com</p>${script}</body></html>`;
+      const result = await transform(html, "index.html");
+
+      expect(result).toContain(script);
+      expect(result).not.toContain("&gt;");
+      expect(result).toContain('href="https://example.com"');
+    });
+
+    test("leaves inline style bodies unescaped while linkifying", async () => {
+      const transform = createHtmlTransform(mockImageProcessor);
+      const style = "<style>.parent > .child { color: red; }</style>";
+      const html = `<html><body><p>Visit https://example.com</p>${style}</body></html>`;
+      const result = await transform(html, "index.html");
+
+      expect(result).toContain(style);
+      expect(result).not.toContain("&gt;");
+    });
+
     test("linkifies and encrypts email addresses", async () => {
       const transform = createHtmlTransform(mockImageProcessor);
       const html = "<html><body><p>Contact hello@example.com</p></body></html>";

--- a/test/unit/transforms/raw-text-guard.test.js
+++ b/test/unit/transforms/raw-text-guard.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  extractRawTextElements,
+  restoreRawTextElements,
+} from "#transforms/raw-text-guard.js";
+
+describe("raw-text-guard", () => {
+  describe("extractRawTextElements", () => {
+    test("removes script elements from content", () => {
+      const html = "<p>before</p><script>const a = 1;</script><p>after</p>";
+      const { content } = extractRawTextElements(html);
+      expect(content).not.toContain("<script>");
+      expect(content).toContain("<p>before</p>");
+      expect(content).toContain("<p>after</p>");
+    });
+
+    test("captures the full element including attributes and body", () => {
+      const html = '<script type="module">const a = (b) => b > 1;</script>';
+      const { blocks } = extractRawTextElements(html);
+      expect(blocks).toEqual([html]);
+    });
+
+    test("extracts style elements", () => {
+      const html = "<style>.a > .b { color: red; }</style>";
+      const { blocks } = extractRawTextElements(html);
+      expect(blocks).toEqual([html]);
+    });
+
+    test("extracts multiple elements in document order", () => {
+      const html =
+        "<script>first()</script><p>mid</p><style>.x > .y {}</style>";
+      const { blocks } = extractRawTextElements(html);
+      expect(blocks).toEqual([
+        "<script>first()</script>",
+        "<style>.x > .y {}</style>",
+      ]);
+    });
+
+    test("leaves content without raw-text elements unchanged", () => {
+      const html = "<p>Visit https://example.com</p>";
+      const { content, blocks } = extractRawTextElements(html);
+      expect(content).toBe(html);
+      expect(blocks).toEqual([]);
+    });
+
+    test("throws when content already contains NUL bytes", () => {
+      expect(() => extractRawTextElements("<p>\u0000</p>")).toThrow(
+        "NUL bytes",
+      );
+    });
+  });
+
+  describe("restoreRawTextElements", () => {
+    const extractAndRestore = (html) => {
+      const { content, blocks } = extractRawTextElements(html);
+      return restoreRawTextElements(content, blocks);
+    };
+
+    test("round-trips content byte-for-byte", () => {
+      const html =
+        "<p>x</p><script>if (a > b && c < d) f();</script><style>.a > .b {}</style>";
+      expect(extractAndRestore(html)).toBe(html);
+    });
+
+    test("preserves $ substitution patterns in script bodies", () => {
+      const html = '<script>str.replace(/x/, "$& $\' $1");</script>';
+      expect(extractAndRestore(html)).toBe(html);
+    });
+
+    test("round-trips duplicate identical script elements", () => {
+      const html =
+        "<script>same()</script><p>https://example.com</p><script>same()</script>";
+      expect(extractAndRestore(html)).toBe(html);
+    });
+
+    test("restores blocks after surrounding content was transformed", () => {
+      const html = "<p>plain</p><script>const f = (a) => a;</script>";
+      const { content, blocks } = extractRawTextElements(html);
+      const transformed = content.replace("plain", "<a>linked</a>");
+      expect(restoreRawTextElements(transformed, blocks)).toBe(
+        "<p><a>linked</a></p><script>const f = (a) => a;</script>",
+      );
+    });
+
+    test("throws when a placeholder was destroyed by the transform", () => {
+      const { content, blocks } = extractRawTextElements(
+        "<script>a()</script>",
+      );
+      const mangled = content.replace("\u0000", "");
+      expect(() => restoreRawTextElements(mangled, blocks)).toThrow(
+        "missing after transform",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`linkify-html` is called on full page HTML with `ignoreTags: ["script", "style", ...]`, but `ignoreTags` only prevents *linkification* inside those tags — the library's tokenizer still re-serialises their text nodes with entity escaping. Since browsers never decode entities inside raw-text elements, any page with an inline script containing an arrow function or comparison shipped silently broken JavaScript:

```html
<!-- input -->
<script>const f = (a) => a > 1 && a < 5;</script>
<!-- output -->
<script>const f = (a) =&gt; a &gt; 1 && a &lt; 5;</script>
```

Inline `<style>` child combinators (`.a > .b`) were corrupted the same way.

## Fix

New `src/_lib/transforms/raw-text-guard.js` provides a string-level guard:

- `extractRawTextElements` swaps complete `<script>`/`<style>` elements for NUL-delimited placeholders (NUL bytes can't appear in valid HTML, so collisions are impossible; a fail-fast check enforces this)
- `restoreRawTextElements` puts them back byte-for-byte, throwing if a placeholder was destroyed by the intermediate transform

`applyStringTransforms` in `html-transform.js` now wraps the `linkify-html` call with this guard. The other transforms were verified safe: `addExternalLinkAttrs` (simple-html-tokenizer) re-emits character tokens raw, and the happy-dom phase serialises raw-text elements correctly.

## Testing

- Unit tests for extract/restore, including `$&`-style substitution patterns in script bodies and duplicate identical script elements
- Regression tests at the `createHtmlTransform` level, confirmed to fail without the fix
- Full suite (`bun test`, 2985 tests) and lint pass

https://claude.ai/code/session_019ZqSPvLBCnZRV2TxcrfaUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZqSPvLBCnZRV2TxcrfaUQ)_