### PR TITLE
Render right-content snippet as a sidebar (finish the two-columns feature)

### DIFF
--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -1283,6 +1283,25 @@ These block types are rejected at build time if listed inside any column (they n
 
 ---
 
+## Right column (site-wide sidebar)
+
+Create `src/snippets/right-content.md` to render a sidebar `<aside class="right-column">` beside `<main>` on every page that uses `base.html`. Presence of the file is the switch — no frontmatter flags or config. The body element gets a `two-columns` class (otherwise `one-column`), and the grid activates at the `lg` breakpoint; below it the sidebar stacks under the main content.
+
+Two content modes:
+
+- **Blocks** — give the snippet a `blocks:` frontmatter array. Blocks render directly (via `render-block.html`), without the full-width section wrappers and background striping that page blocks get, since those don't make sense in a narrow column. Only column-safe block types are allowed: the same types disallowed inside `blockLayouts.json` columns (see "Disallowed block types" above) fail the build with `Block type "X" is not supported inside the right-content sidebar.`
+- **Markdown** — plain snippet body content renders inside a `.prose` wrapper, with `{% opening_times %}` and `{% recurring_events %}` support like other snippets.
+
+The aside is a sibling of `<main>`, not a child, so sidebar text never enters the Pagefind search index (`data-pagefind-body` lives on `<main>`). Sidebar width is themable via the `--right-column-width` token (default `16rem`), declared at `:root` like the other sizing tokens.
+
+Relationship to `blockLayouts.json` columns: that system splits a page's own blocks into columns per collection; the right column is shared site-wide furniture. They compose — the `.page-columns` grid wraps whatever `main` renders, including block-columns layouts.
+
+### Banner hoisting
+
+When the sidebar is active and a page's **first** block is `image-background`, that block is hoisted above the `.page-columns` grid so the banner spans the full width (content + sidebar) instead of being squeezed into the main column. All remaining blocks render inside `<main>` as usual. Without the sidebar, no hoisting happens.
+
+---
+
 ## Supporting Components
 
 These are not blocks themselves but are used by multiple blocks.

--- a/src/_includes/design-system/hoisted-banner.html
+++ b/src/_includes/design-system/hoisted-banner.html
@@ -1,0 +1,11 @@
+{%- comment -%}
+Renders banner blocks hoisted above the .page-columns grid (so they span
+content + sidebar). `banner` comes from the splitHoistedBanner filter and is
+empty whenever there is nothing to hoist.
+{%- endcomment -%}
+{%- if banner.size > 0 -%}
+  {%- assign hoisted_banner_blocks = banner | render_block_liquid -%}
+  {%- for block in hoisted_banner_blocks -%}
+    {%- include "design-system/render-full-width-block.html", block: block -%}
+  {%- endfor -%}
+{%- endif -%}

--- a/src/_includes/design-system/right-column.html
+++ b/src/_includes/design-system/right-column.html
@@ -1,0 +1,18 @@
+{%- comment -%}
+The right-content sidebar. Renders nothing unless src/snippets/right-content.md
+exists (has_right_content global data). Snippet `blocks:` frontmatter renders
+per-block without the full-width section wrappers; plain markdown body content
+falls back to a prose wrapper.
+{%- endcomment -%}
+{%- if has_right_content -%}
+  <aside class="right-column design-system">
+    {%- assign right_blocks = "right-content" | sidebar_blocks -%}
+    {%- if right_blocks.size > 0 -%}
+      {%- for block in right_blocks -%}
+        {%- include "design-system/render-block.html", block: block -%}
+      {%- endfor -%}
+    {%- else -%}
+      <div class="prose">{% render_snippet "right-content", "" %}</div>
+    {%- endif -%}
+  </aside>
+{%- endif -%}

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -22,12 +22,7 @@
     {%- include "navigation.html" -%}
   {%- endunless -%}
   {%- assign banner_split = blocks | splitHoistedBanner: has_right_content -%}
-  {%- if banner_split.banner.size > 0 -%}
-    {%- assign hoisted_banner_blocks = banner_split.banner | render_block_liquid -%}
-    {%- for block in hoisted_banner_blocks -%}
-      {%- include "design-system/render-full-width-block.html", block: block -%}
-    {%- endfor -%}
-  {%- endif -%}
+  {%- include "design-system/hoisted-banner.html", banner: banner_split.banner -%}
   <div class="page-columns">
     <main{% if pagefind_body %} data-pagefind-body{% endif %}>
       {%- if config.show_breadcrumbs and page.url != "/" -%}
@@ -42,19 +37,7 @@
         {%- include "design-system/blocks.html", blocks: footer_snippet_data.blocks -%}
       {%- endif -%}
     </main>
-    {%- if has_right_content -%}
-      <aside class="right-column design-system">
-        {%- assign right_snippet_data = "right-content" | snippet_data -%}
-        {%- if right_snippet_data.blocks -%}
-          {%- assign right_blocks = right_snippet_data.blocks | validateSidebarBlocks | render_block_liquid -%}
-          {%- for block in right_blocks -%}
-            {%- include "design-system/render-block.html", block: block -%}
-          {%- endfor -%}
-        {%- else -%}
-          <div class="prose">{% render_snippet "right-content", "" %}</div>
-        {%- endif -%}
-      </aside>
-    {%- endif -%}
+    {%- include "design-system/right-column.html" -%}
   </div>
   {%- include "design-system/footer.html" -%}
   {%- include "image-popup.html" -%}

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -21,19 +21,41 @@
   {%- unless no_navigation -%}
     {%- include "navigation.html" -%}
   {%- endunless -%}
-  <main{% if pagefind_body %} data-pagefind-body{% endif %}>
-    {%- if config.show_breadcrumbs and page.url != "/" -%}
-      {%- include "breadcrumbs-nav.html" -%}
+  {%- assign banner_split = blocks | splitHoistedBanner: has_right_content -%}
+  {%- if banner_split.banner.size > 0 -%}
+    {%- assign hoisted_banner_blocks = banner_split.banner | render_block_liquid -%}
+    {%- for block in hoisted_banner_blocks -%}
+      {%- include "design-system/render-full-width-block.html", block: block -%}
+    {%- endfor -%}
+  {%- endif -%}
+  <div class="page-columns">
+    <main{% if pagefind_body %} data-pagefind-body{% endif %}>
+      {%- if config.show_breadcrumbs and page.url != "/" -%}
+        {%- include "breadcrumbs-nav.html" -%}
+      {%- endif -%}
+      {{- content | validatePageBodyContent: layout, page.inputPath -}}
+      {%- if banner_split.rest.size > 0 -%}
+        {%- include "design-system/blocks.html", blocks: banner_split.rest -%}
+      {%- endif -%}
+      {%- assign footer_snippet_data = "footer-content" | snippet_data -%}
+      {%- if footer_snippet_data.blocks -%}
+        {%- include "design-system/blocks.html", blocks: footer_snippet_data.blocks -%}
+      {%- endif -%}
+    </main>
+    {%- if has_right_content -%}
+      <aside class="right-column design-system">
+        {%- assign right_snippet_data = "right-content" | snippet_data -%}
+        {%- if right_snippet_data.blocks -%}
+          {%- assign right_blocks = right_snippet_data.blocks | validateSidebarBlocks | render_block_liquid -%}
+          {%- for block in right_blocks -%}
+            {%- include "design-system/render-block.html", block: block -%}
+          {%- endfor -%}
+        {%- else -%}
+          <div class="prose">{% render_snippet "right-content", "" %}</div>
+        {%- endif -%}
+      </aside>
     {%- endif -%}
-    {{- content | validatePageBodyContent: layout, page.inputPath -}}
-    {%- if blocks -%}
-      {%- include "design-system/blocks.html", blocks: blocks -%}
-    {%- endif -%}
-    {%- assign footer_snippet_data = "footer-content" | snippet_data -%}
-    {%- if footer_snippet_data.blocks -%}
-      {%- include "design-system/blocks.html", blocks: footer_snippet_data.blocks -%}
-    {%- endif -%}
-  </main>
+  </div>
   {%- include "design-system/footer.html" -%}
   {%- include "image-popup.html" -%}
   {%- include "client-templates.html" -%}

--- a/src/_lib/eleventy/blocks.js
+++ b/src/_lib/eleventy/blocks.js
@@ -6,10 +6,7 @@ import {
   getBlockContainerWidth,
   getBlockTemplate,
 } from "#utils/block-schema.js";
-import {
-  splitHoistedBanner,
-  validateSidebarBlocks,
-} from "#utils/sidebar-blocks.js";
+import { splitHoistedBanner } from "#utils/sidebar-blocks.js";
 
 const BASE_LAYOUTS = ["base.html", "base"];
 
@@ -46,6 +43,5 @@ export const configureBlocks = (eleventyConfig) => {
       splitBlocksForColumns(blocks, getLayoutForTags(tags, layouts)),
   );
   eleventyConfig.addFilter("validatePageBodyContent", validatePageBodyContent);
-  eleventyConfig.addFilter("validateSidebarBlocks", validateSidebarBlocks);
   eleventyConfig.addFilter("splitHoistedBanner", splitHoistedBanner);
 };

--- a/src/_lib/eleventy/blocks.js
+++ b/src/_lib/eleventy/blocks.js
@@ -6,6 +6,10 @@ import {
   getBlockContainerWidth,
   getBlockTemplate,
 } from "#utils/block-schema.js";
+import {
+  splitHoistedBanner,
+  validateSidebarBlocks,
+} from "#utils/sidebar-blocks.js";
 
 const BASE_LAYOUTS = ["base.html", "base"];
 
@@ -42,4 +46,6 @@ export const configureBlocks = (eleventyConfig) => {
       splitBlocksForColumns(blocks, getLayoutForTags(tags, layouts)),
   );
   eleventyConfig.addFilter("validatePageBodyContent", validatePageBodyContent);
+  eleventyConfig.addFilter("validateSidebarBlocks", validateSidebarBlocks);
+  eleventyConfig.addFilter("splitHoistedBanner", splitHoistedBanner);
 };

--- a/src/_lib/eleventy/file-utils.js
+++ b/src/_lib/eleventy/file-utils.js
@@ -6,6 +6,7 @@ import { getOpeningTimesHtml } from "#eleventy/opening-times.js";
 import { getRecurringEventsHtml } from "#eleventy/recurring-events.js";
 import { memoize } from "#toolkit/fp/memoize.js";
 import { processLiquidStrings } from "#utils/liquid-render.js";
+import { validateSidebarBlocks } from "#utils/sidebar-blocks.js";
 
 /**
  * @typedef {{ type: string, content: string }} MarkdownToken
@@ -170,9 +171,36 @@ const snippetDataFilter = (name) => readSnippetData(name);
  * @param {string} name
  */
 async function snippetBlocksFilter(name) {
+  return resolveSnippetBlocks(name, this.context.environments);
+}
+
+/**
+ * Reads a snippet's blocks, optionally validates them, and resolves Liquid
+ * expressions against the page context.
+ *
+ * @param {string} name
+ * @param {Record<string, unknown>} context
+ * @param {(blocks: Record<string, unknown>[]) => Record<string, unknown>[]} [validate]
+ */
+const resolveSnippetBlocks = (name, context, validate = (blocks) => blocks) => {
   const data = readSnippetData(name);
   if (!data?.blocks) return [];
-  return processLiquidStrings(data.blocks, this.context.environments);
+  return processLiquidStrings(validate(data.blocks), context);
+};
+
+/**
+ * Like snippet_blocks, but enforces that every block type is safe inside the
+ * narrow right-content sidebar column.
+ *
+ * @this {LiquidFilterContext}
+ * @param {string} name
+ */
+async function sidebarBlocksFilter(name) {
+  return resolveSnippetBlocks(
+    name,
+    this.context.environments,
+    validateSidebarBlocks,
+  );
 }
 
 /**
@@ -213,6 +241,7 @@ const configureFileUtils = (eleventyConfig) => {
   eleventyConfig.addFilter("file_missing", fileMissingFilter);
   eleventyConfig.addFilter("snippet_data", snippetDataFilter);
   eleventyConfig.addAsyncFilter("snippet_blocks", snippetBlocksFilter);
+  eleventyConfig.addAsyncFilter("sidebar_blocks", sidebarBlocksFilter);
   eleventyConfig.addAsyncFilter("render_block_liquid", renderBlockLiquidFilter);
   eleventyConfig.addFilter("escape_html", escapeHtmlFilter);
   eleventyConfig.addFilter("markdown", (str) =>

--- a/src/_lib/eleventy/style-bundle.js
+++ b/src/_lib/eleventy/style-bundle.js
@@ -71,4 +71,5 @@ const getBodyClasses = (
 
 export const configureStyleBundle = (eleventyConfig) => {
   eleventyConfig.addFilter("getBodyClasses", getBodyClasses);
+  eleventyConfig.addGlobalData("has_right_content", detectRightContent);
 };

--- a/src/_lib/utils/block-columns.js
+++ b/src/_lib/utils/block-columns.js
@@ -41,8 +41,28 @@ export const COLUMN_DISALLOWED_TYPES = [
 ];
 
 /** @param {string} type */
-const isSafeInColumn = (type) =>
+export const isColumnSafeType = (type) =>
   !COLUMN_DISALLOWED_TYPES.includes(type) && !type.startsWith("split-");
+
+/**
+ * @param {unknown} blocks
+ * @returns {Array<{ type: string } & Record<string, unknown>>}
+ */
+export const toBlockArray = (blocks) => (Array.isArray(blocks) ? blocks : []);
+
+/**
+ * Throws if any type is not safe inside a narrow column.
+ * @param {string[]} types
+ * @param {string} where - Location description for the error message
+ */
+export const assertColumnSafeTypes = (types, where) => {
+  const disallowed = types.find((type) => !isColumnSafeType(type));
+  if (disallowed) {
+    throw new Error(
+      `Block type "${disallowed}" is not supported inside ${where}.`,
+    );
+  }
+};
 
 /**
  * @typedef {{
@@ -95,14 +115,11 @@ const collectLayoutSlots = (layoutCols) =>
 /**
  * @param {Array<{ type: string, ci: number }>} slots
  */
-const validateLayoutSlots = (slots) => {
-  const disallowed = slots.find(({ type }) => !isSafeInColumn(type));
-  if (disallowed) {
-    throw new Error(
-      `Block type "${disallowed.type}" is not supported inside a block-columns layout.`,
-    );
-  }
-};
+const validateLayoutSlots = (slots) =>
+  assertColumnSafeTypes(
+    slots.map(({ type }) => type),
+    "a block-columns layout",
+  );
 
 /**
  * @typedef {{ type: string } & Record<string, unknown>} Block
@@ -173,7 +190,7 @@ const buildColumns = (safeBlocks, layoutCols, usedBefore) => {
  * @returns {{ before: Block[], columns: Block[][] | null, rest: Block[] }}
  */
 export const splitBlocksForColumns = (blocks, layout) => {
-  const safeBlocks = Array.isArray(blocks) ? blocks : [];
+  const safeBlocks = toBlockArray(blocks);
   const beforeSlots = collectBeforeSlots(layout?.before);
   const layoutCols = Array.isArray(layout?.columns) ? layout.columns : null;
   if (beforeSlots.length === 0 && !layoutCols) {

--- a/src/_lib/utils/sidebar-blocks.js
+++ b/src/_lib/utils/sidebar-blocks.js
@@ -1,0 +1,47 @@
+/**
+ * Helpers for the right-content sidebar rendered by base.html.
+ *
+ * The sidebar is a ~16rem column, so the same block types that are banned
+ * inside block-columns layouts (full-viewport-width and split-* types) are
+ * banned here too.
+ */
+
+import { assertColumnSafeTypes, toBlockArray } from "#utils/block-columns.js";
+
+/**
+ * @typedef {{ type: string } & Record<string, unknown>} Block
+ */
+
+/**
+ * Validates that every sidebar block type is safe inside a narrow column.
+ * Returns the blocks unchanged so it can be used as a pass-through filter.
+ *
+ * @param {Block[] | undefined | null} blocks
+ * @returns {Block[]}
+ */
+export const validateSidebarBlocks = (blocks) => {
+  const safeBlocks = toBlockArray(blocks);
+  assertColumnSafeTypes(
+    safeBlocks.map(({ type }) => type),
+    "the right-content sidebar",
+  );
+  return safeBlocks;
+};
+
+/**
+ * When the two-column sidebar is active and a page's first block is an
+ * image-background banner, hoist it out of the page-columns grid so it spans
+ * content + sidebar. Otherwise everything stays in `rest`.
+ *
+ * @param {Block[] | undefined | null} blocks
+ * @param {boolean} hasRightContent
+ * @returns {{ banner: Block[], rest: Block[] }}
+ */
+export const splitHoistedBanner = (blocks, hasRightContent) => {
+  const safeBlocks = toBlockArray(blocks);
+  const [first, ...rest] = safeBlocks;
+  if (!hasRightContent || first?.type !== "image-background") {
+    return { banner: [], rest: safeBlocks };
+  }
+  return { banner: [first], rest };
+};

--- a/src/css/design-system/_base.scss
+++ b/src/css/design-system/_base.scss
@@ -61,6 +61,7 @@
   --space-2xl: calc(var(--space-unit) * 8);
   --space-3xl: calc(var(--space-unit) * 12);
   --space-4xl: calc(var(--space-unit) * 16);
+  --right-column-width: 16rem;
   --section-padding-y-sm: calc(var(--space-3xl) * 0.6);
   --section-padding-y-md: var(--space-3xl);
   --section-padding-y-main-sm: calc(var(--space-3xl) * 0.3);

--- a/src/css/design-system/_index.scss
+++ b/src/css/design-system/_index.scss
@@ -36,6 +36,7 @@
 @forward "split-callout";
 @forward "grid";
 @forward "block-columns";
+@forward "page-columns";
 @forward "slider";
 @forward "items";
 @forward "reviews";

--- a/src/css/design-system/_page-columns.scss
+++ b/src/css/design-system/_page-columns.scss
@@ -1,0 +1,42 @@
+@use "../breakpoints" as breakpoint;
+
+// =============================================================================
+// PAGE COLUMNS (right-content sidebar)
+// =============================================================================
+// base.html always wraps <main> in .page-columns; the grid only activates
+// when body has .two-columns (i.e. src/snippets/right-content.md exists) at
+// the lg breakpoint and up. Below that the aside stacks under main.
+// Width is themable via --right-column-width (declared in _base.scss :root).
+
+.design-system {
+  @include breakpoint.up("lg") {
+    &.two-columns .page-columns {
+      display: grid;
+      grid-template-columns: 1fr var(--right-column-width, 16rem);
+      align-items: start;
+
+      > main {
+        // Without this, any wide child (slider, 1200px .container-wide) sets
+        // the 1fr track's min-content size and blows the grid out past its
+        // container, shoving the sidebar.
+        min-width: 0;
+      }
+    }
+  }
+
+  .right-column {
+    padding: var(--space-md) var(--space-sm);
+
+    // Sliders don't make sense in a narrow column: stack them.
+    .slider-container .items.slider {
+      display: flex;
+      flex-direction: column;
+      overflow: visible;
+
+      > li {
+        width: 100%;
+        min-width: 0;
+      }
+    }
+  }
+}

--- a/src/snippets/README.md
+++ b/src/snippets/README.md
@@ -8,4 +8,10 @@ Create a file in this folder called "snippet-name.md" and it'll be rendered in t
   also define design-system `blocks` in this snippet's frontmatter; they will
   be rendered at the end of `<main>` on every page (before the `<footer>`), so
   you can build a consistent "fancy footer" that appears across the whole site
-- `right-content.md` - An optional right column that appears on each page
+- `right-content.md` - An optional right column (sidebar) that appears beside
+  the main content on every page. Define design-system `blocks` in the
+  frontmatter (column-safe types only — no hero, `*-background`,
+  marquee-images, or `split-*`), or just write markdown body content. Width
+  is themable via the `--right-column-width` CSS token. When this file
+  exists, a page whose first block is `image-background` gets that banner
+  hoisted above the columns so it spans content + sidebar

--- a/test/integration/eleventy/right-content.test.js
+++ b/test/integration/eleventy/right-content.test.js
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { createTestSite, withTestSite } from "#test/test-site-factory.js";
+
+const SIDEBAR_TEXT = "Sidebar contact details";
+const PAGE_BLOCK = { type: "markdown", content: "Page body" };
+const BANNER_BLOCK = {
+  type: "image-background",
+  image: "src/images/party.jpg",
+  content: "Banner text",
+};
+
+const homePage = (blocks) => ({
+  path: "pages/index.md",
+  frontmatter: {
+    name: "Home",
+    permalink: "/",
+    blocks,
+  },
+});
+
+const rightContentSnippet = (blocks) => ({
+  path: "snippets/right-content.md",
+  frontmatter: { blocks },
+});
+
+const sidebarSnippet = () =>
+  rightContentSnippet([{ type: "markdown", content: SIDEBAR_TEXT }]);
+
+const bannerSiteOptions = (files) => ({ images: ["party.jpg"], files });
+
+/** Load the built homepage and locate its image-background banner */
+const getRenderedBanner = async (site) => {
+  const doc = await site.getDoc("index.html");
+  const banner = doc.querySelector(".image-background");
+  expect(banner).not.toBeNull();
+  return { doc, banner };
+};
+
+describe("right-content sidebar", () => {
+  test("renders the snippet's blocks in an aside outside main", async () => {
+    await withTestSite(
+      { files: [homePage([PAGE_BLOCK]), sidebarSnippet()] },
+      async (site) => {
+        const doc = await site.getDoc("index.html");
+
+        expect(doc.body.classList.contains("two-columns")).toBe(true);
+
+        const aside = doc.querySelector("aside.right-column");
+        expect(aside).not.toBeNull();
+        expect(aside.textContent).toContain(SIDEBAR_TEXT);
+        expect(aside.classList.contains("design-system")).toBe(true);
+
+        // Sibling of main inside the columns wrapper, never inside main —
+        // keeps sidebar text out of the Pagefind index (data-pagefind-body
+        // lives on main).
+        const main = doc.querySelector("main");
+        expect(main.querySelector("aside.right-column")).toBeNull();
+        expect(main.textContent).not.toContain(SIDEBAR_TEXT);
+        expect(aside.parentElement.classList.contains("page-columns")).toBe(
+          true,
+        );
+        expect(main.parentElement).toBe(aside.parentElement);
+      },
+    );
+  });
+
+  test("renders plain markdown snippet content as a prose fallback", async () => {
+    const markdownSnippet = {
+      path: "snippets/right-content.md",
+      frontmatter: {},
+      content: `### Contact\n\n${SIDEBAR_TEXT}`,
+    };
+    await withTestSite(
+      { files: [homePage([PAGE_BLOCK]), markdownSnippet] },
+      async (site) => {
+        const doc = await site.getDoc("index.html");
+        const prose = doc.querySelector("aside.right-column .prose");
+        expect(prose).not.toBeNull();
+        expect(prose.textContent).toContain(SIDEBAR_TEXT);
+      },
+    );
+  });
+
+  test("without the snippet the body is one-column and has no aside", async () => {
+    await withTestSite({ files: [homePage([PAGE_BLOCK])] }, async (site) => {
+      const doc = await site.getDoc("index.html");
+      expect(doc.body.classList.contains("one-column")).toBe(true);
+      expect(doc.querySelector("aside.right-column")).toBeNull();
+      // The wrapper div is always present so the DOM shape is stable.
+      expect(doc.querySelector(".page-columns main")).not.toBeNull();
+    });
+  });
+
+  test("a disallowed block type in the snippet fails the build", async () => {
+    const site = await createTestSite({
+      files: [
+        homePage([PAGE_BLOCK]),
+        rightContentSnippet([{ type: "hero", name: "Nope" }]),
+      ],
+    });
+    try {
+      await expect(site.build()).rejects.toThrow(
+        'Block type "hero" is not supported inside the right-content sidebar',
+      );
+    } finally {
+      site.cleanup();
+    }
+  });
+
+  test("a leading image-background block is hoisted above the columns", async () => {
+    await withTestSite(
+      bannerSiteOptions([
+        homePage([BANNER_BLOCK, PAGE_BLOCK]),
+        sidebarSnippet(),
+      ]),
+      async (site) => {
+        const { doc, banner } = await getRenderedBanner(site);
+        // The banner is rendered before (and outside) the page-columns grid
+        // so it spans content + sidebar.
+        expect(banner.closest(".page-columns")).toBeNull();
+        expect(banner.closest("main")).toBeNull();
+        const columns = doc.querySelector(".page-columns");
+        const bodyChildren = [...doc.body.children];
+        expect(bodyChildren.indexOf(banner.closest("section"))).toBeLessThan(
+          bodyChildren.indexOf(columns),
+        );
+        // The remaining blocks still render inside main.
+        expect(doc.querySelector("main").textContent).toContain("Page body");
+      },
+    );
+  });
+
+  test("a leading image-background stays inside main without a sidebar", async () => {
+    await withTestSite(
+      bannerSiteOptions([homePage([BANNER_BLOCK])]),
+      async (site) => {
+        const { banner } = await getRenderedBanner(site);
+        expect(banner.closest("main")).not.toBeNull();
+      },
+    );
+  });
+});

--- a/test/unit/utils/file-utils.test.js
+++ b/test/unit/utils/file-utils.test.js
@@ -68,6 +68,20 @@ const testSnippet = (testName, snippetName, content, callback) =>
     await callback(result);
   });
 
+/**
+ * Run a snippet-reading async filter against a temp snippet with a page
+ * context. The callback receives a runner so tests can also assert throws.
+ */
+const testSnippetFilterCtx = (filterName) => {
+  return (testName, snippetName, content, pageContext, callback) =>
+    withSnippetSetup(testName, snippetName, content, async (mockConfig) => {
+      const filter = mockConfig.asyncFilters[filterName];
+      await callback(() =>
+        filter.call({ context: { environments: pageContext } }, snippetName),
+      );
+    });
+};
+
 const testSnippetData = (testName, snippetName, content, callback) =>
   withSnippetSetup(testName, snippetName, content, (mockConfig) => {
     callback(mockConfig.filters.snippet_data(snippetName));
@@ -328,6 +342,7 @@ Unicode: café résumé naïve`;
   });
 
   describe("snippet_blocks filter", () => {
+    const runSnippetBlocks = testSnippetFilterCtx("snippet_blocks");
     const testSnippetBlocksCtx = (
       testName,
       snippetName,
@@ -335,14 +350,13 @@ Unicode: café résumé naïve`;
       pageContext,
       callback,
     ) =>
-      withSnippetSetup(testName, snippetName, content, async (mockConfig) => {
-        const filter = mockConfig.asyncFilters.snippet_blocks;
-        const result = await filter.call(
-          { context: { environments: pageContext } },
-          snippetName,
-        );
-        await callback(result);
-      });
+      runSnippetBlocks(
+        testName,
+        snippetName,
+        content,
+        pageContext,
+        async (run) => callback(await run()),
+      );
 
     test("Registers as an async filter", () => {
       const mockConfig = createMockEleventyConfig();
@@ -460,6 +474,67 @@ blocks:
           expect(result[0].columns).toBe(3);
           expect(result[0].items[0].value).toBe("Gizmo");
           expect(result[0].items[0].label).toBe("Name");
+        },
+      );
+    });
+  });
+
+  describe("sidebar_blocks filter", () => {
+    const testSidebarBlocksCtx = testSnippetFilterCtx("sidebar_blocks");
+
+    test("Registers as an async filter", () => {
+      const mockConfig = createConfiguredMock();
+      expect(typeof mockConfig.asyncFilters.sidebar_blocks).toBe("function");
+    });
+
+    test("Returns empty array for missing snippet", async () => {
+      await testSidebarBlocksCtx(
+        "sidebar-missing",
+        "sidebar-nonexistent",
+        null,
+        {},
+        async (run) => {
+          expect(await run()).toEqual([]);
+        },
+      );
+    });
+
+    test("Resolves Liquid in column-safe blocks with page context", async () => {
+      const content = `---
+name: Sidebar
+blocks:
+  - type: cta
+    title: "Contact {{ title }}"
+---`;
+      await testSidebarBlocksCtx(
+        "sidebar-safe",
+        "sidebar-safe",
+        content,
+        { title: "Us" },
+        async (run) => {
+          const result = await run();
+          expect(result.length).toBe(1);
+          expect(result[0].title).toBe("Contact Us");
+        },
+      );
+    });
+
+    test("Throws for a column-disallowed block type", async () => {
+      const content = `---
+name: Sidebar
+blocks:
+  - type: hero
+    name: Nope
+---`;
+      await testSidebarBlocksCtx(
+        "sidebar-disallowed",
+        "sidebar-disallowed",
+        content,
+        {},
+        async (run) => {
+          expect(run).toThrow(
+            'Block type "hero" is not supported inside the right-content sidebar.',
+          );
         },
       );
     });

--- a/test/unit/utils/sidebar-blocks.test.js
+++ b/test/unit/utils/sidebar-blocks.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { COLUMN_DISALLOWED_TYPES } from "#utils/block-columns.js";
+import {
+  splitHoistedBanner,
+  validateSidebarBlocks,
+} from "#utils/sidebar-blocks.js";
+
+describe("validateSidebarBlocks", () => {
+  test("returns column-safe blocks unchanged", () => {
+    const blocks = [
+      { type: "markdown", content: "Hello" },
+      { type: "cta", title: "Call us" },
+    ];
+    expect(validateSidebarBlocks(blocks)).toEqual(blocks);
+  });
+
+  test("returns empty array for missing blocks", () => {
+    expect(validateSidebarBlocks(undefined)).toEqual([]);
+    expect(validateSidebarBlocks(null)).toEqual([]);
+  });
+
+  test("throws for every column-disallowed type", () => {
+    for (const type of COLUMN_DISALLOWED_TYPES) {
+      expect(() => validateSidebarBlocks([{ type }])).toThrow(
+        `Block type "${type}" is not supported inside the right-content sidebar.`,
+      );
+    }
+  });
+
+  test("throws for split-* types", () => {
+    expect(() => validateSidebarBlocks([{ type: "split-callout" }])).toThrow(
+      'Block type "split-callout" is not supported inside the right-content sidebar.',
+    );
+  });
+});
+
+describe("splitHoistedBanner", () => {
+  const banner = { type: "image-background", image: "x.jpg" };
+  const markdown = { type: "markdown", content: "Hello" };
+
+  test("hoists a leading image-background when sidebar is active", () => {
+    const { banner: hoisted, rest } = splitHoistedBanner(
+      [banner, markdown],
+      true,
+    );
+    expect(hoisted).toEqual([banner]);
+    expect(rest).toEqual([markdown]);
+  });
+
+  test("does not hoist when sidebar is inactive", () => {
+    const blocks = [banner, markdown];
+    expect(splitHoistedBanner(blocks, false)).toEqual({
+      banner: [],
+      rest: blocks,
+    });
+  });
+
+  test("does not hoist a non-leading image-background", () => {
+    const blocks = [markdown, banner];
+    expect(splitHoistedBanner(blocks, true)).toEqual({
+      banner: [],
+      rest: blocks,
+    });
+  });
+
+  test("handles missing blocks", () => {
+    expect(splitHoistedBanner(undefined, true)).toEqual({
+      banner: [],
+      rest: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `two-columns` body class and `detectRightContent()` in `style-bundle.js` existed but nothing rendered the snippet — clients wanting a sidebar had to override all of `base.html`. This lands the sidebar upstream, plus the related banner hoist, so that override can be deleted.

### Sidebar
- When `src/snippets/right-content.md` exists, `base.html` renders it in an `<aside class="right-column design-system">` beside `<main>` inside an always-present `.page-columns` wrapper. The grid activates only under `body.two-columns` at the `lg` breakpoint; below it the aside stacks under main.
- Two content modes: `blocks:` frontmatter (rendered via `render-block.html` directly — no full-width section wrappers or background striping) or plain markdown content (`.prose` fallback, with `{% opening_times %}` / `{% recurring_events %}` support, which keeps the existing demo snippet working).
- The aside is a **sibling** of `<main>`, so sidebar text never enters the Pagefind index (`data-pagefind-body` lives on main).
- Column-unsafe types (hero, `*-background`, marquee-images, `split-*`) fail the build with `Block type "X" is not supported inside the right-content sidebar.` — sharing the column-safety check with `block-columns.js`.
- New `--right-column-width` token (default `16rem`) at `:root`, themable like the other sizing tokens.
- `min-width: 0` on `main` prevents wide children (sliders, 1200px `.container-wide`) from blowing the `1fr` track out past its container. Sliders inside the sidebar stack vertically.

### Banner hoist
When the sidebar is active and a page's **first** block is `image-background`, the banner is hoisted above `.page-columns` so it spans content + sidebar. Without the sidebar, behaviour is unchanged.

### Tests & docs
- Unit tests for `validateSidebarBlocks` / `splitHoistedBanner`.
- Integration tests: aside placement/Pagefind isolation, prose fallback, one-column without snippet, build failure on disallowed type, banner hoist with and without sidebar.
- Docs in `BLOCKS_LAYOUT.md` (new "Right column" section, including the relationship to `blockLayouts.json` columns) and `src/snippets/README.md`.

Full suite: 3002 pass, 0 fail.

https://claude.ai/code/session_01QMHTBe9DJcGojX2BCq4Fwo

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMHTBe9DJcGojX2BCq4Fwo)_