### PR TITLE
Fix raw HTML rendering in markdown content

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -33,7 +33,7 @@ import { configureCollectionFilter } from "#eleventy/collection-filter.js";
 import { configureCapture } from "#eleventy/capture.js";
 import { configureFeed } from "#eleventy/feed.js";
 import { configureFileInfo } from "#eleventy/file-info.js";
-import { configureFileUtils, stripPlusPlus } from "#eleventy/file-utils.js";
+import { amendMarkdown, configureFileUtils } from "#eleventy/file-utils.js";
 import { configureFormatPrice } from "#eleventy/format-price.js";
 import { configureFormHelpers } from "#eleventy/form-helpers.js";
 import { configureGitDates } from "#eleventy/git-dates.js";
@@ -80,7 +80,7 @@ export default async function (eleventyConfig) {
   eleventyConfig.addPlugin(schemaPlugin);
   eleventyConfig.addPlugin(RenderPlugin);
 
-  eleventyConfig.amendLibrary("md", stripPlusPlus);
+  eleventyConfig.amendLibrary("md", amendMarkdown);
 
   // configureLayoutAliases(eleventyConfig);
 

--- a/src/_lib/eleventy/file-utils.js
+++ b/src/_lib/eleventy/file-utils.js
@@ -36,9 +36,25 @@ const stripPlusPlus = (md) => {
   md.core.ruler.after("inline", "strip_plus_plus", stripPlusPlusRule);
 };
 
+/**
+ * Disable indented code blocks so HTML emitted by Liquid includes inside
+ * markdown content is never escaped into a code block. Fenced ``` blocks
+ * still work for intentional code samples.
+ * @param {any} md
+ */
+const disableIndentedCode = (md) => {
+  md.disable("code");
+};
+
+/** @param {any} md */
+const amendMarkdown = (md) => {
+  stripPlusPlus(md);
+  disableIndentedCode(md);
+};
+
 const createMarkdownRenderer = () => {
   const md = new markdownIt({ html: true });
-  stripPlusPlus(md);
+  amendMarkdown(md);
   return md;
 };
 
@@ -261,4 +277,4 @@ const configureFileUtils = (eleventyConfig) => {
   eleventyConfig.addShortcode("read_file", readFileShortcode);
 };
 
-export { configureFileUtils, ensureDir, stripPlusPlus };
+export { amendMarkdown, configureFileUtils, ensureDir };

--- a/test/integration/eleventy/raw-html-output.test.js
+++ b/test/integration/eleventy/raw-html-output.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { withTestSite } from "#test/test-site-factory.js";
+
+const markdownPage = (slug, content) => ({
+  path: `pages/${slug}.md`,
+  frontmatter: {
+    name: slug,
+    permalink: `/${slug}/`,
+    blocks: [{ type: "markdown", content }],
+  },
+});
+
+describe("raw HTML never reaches the front end", () => {
+  test("indented HTML in markdown content renders as HTML across all built pages", async () => {
+    const files = [
+      markdownPage(
+        "indented-html",
+        'Filters below:\n\n    <ul>\n    <li><a href="/products#price-asc">Price: Low to High</a></li>\n    </ul>',
+      ),
+      markdownPage(
+        "code-sample",
+        "An intentional sample:\n\n```\n<ul><li>example</li></ul>\n```",
+      ),
+    ];
+
+    // Escaped tags outside intentional code samples (pre/code/script
+    // contents) mean raw HTML is being shown to visitors.
+    const findEscapedTags = (html) =>
+      html
+        .replace(/<pre[\s>][\s\S]*?<\/pre>/gi, "")
+        .replace(/<code[\s>][\s\S]*?<\/code>/gi, "")
+        .replace(/<script[\s>][\s\S]*?<\/script>/gi, "")
+        .match(/&lt;\/?[a-z][^&]{0,40}/gi);
+
+    const walkHtmlFiles = (dir) =>
+      fs
+        .readdirSync(dir, { recursive: true })
+        .filter((file) => file.endsWith(".html"))
+        .map((file) => path.join(dir, file));
+
+    await withTestSite({ files }, (site) => {
+      const page = site.getOutput("indented-html/index.html");
+      expect(page).toContain(
+        '<a href="/products#price-asc">Price: Low to High</a>',
+      );
+
+      const codePage = site.getOutput("code-sample/index.html");
+      expect(codePage).toContain("&lt;ul&gt;");
+
+      for (const file of walkHtmlFiles(site.outputDir)) {
+        const escaped = findEscapedTags(fs.readFileSync(file, "utf8"));
+        expect(
+          escaped,
+          `Escaped HTML rendered to visitors in ${file}: ${escaped?.join(", ")}`,
+        ).toBeNull();
+      }
+    });
+  });
+});

--- a/test/unit/eleventy/markdown-renderer.test.js
+++ b/test/unit/eleventy/markdown-renderer.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import markdownIt from "markdown-it";
+import { amendMarkdown } from "#eleventy/file-utils.js";
+
+const createRenderer = () => {
+  const md = new markdownIt({ html: true });
+  amendMarkdown(md);
+  return md;
+};
+
+describe("amendMarkdown", () => {
+  test("indented HTML renders as HTML, not an escaped code block", () => {
+    const html = createRenderer().render(
+      'Intro text\n\n    <ul>\n    <li><a href="/products">Default</a></li>\n    </ul>\n',
+    );
+    expect(html).toContain('<a href="/products">Default</a>');
+    expect(html).not.toContain("&lt;");
+    expect(html).not.toContain("<code>");
+  });
+
+  test("fenced code blocks still render as escaped code", () => {
+    const html = createRenderer().render(
+      "```\n<ul><li>sample</li></ul>\n```\n",
+    );
+    expect(html).toContain("<pre><code>");
+    expect(html).toContain("&lt;ul&gt;");
+  });
+
+  test("strips ++ markers from text", () => {
+    const html = createRenderer().render("Hello ++world++");
+    expect(html).toContain("Hello world");
+    expect(html).not.toContain("++");
+  });
+});


### PR DESCRIPTION
## Problem

The filter options list (and potentially any include) was rendering as raw escaped HTML on `/products/`:

```
<ul><li class="active"> <a href="/products" data-filter-key="" ...>Default</a> </li>...
```

## Root cause

Liquid includes emit indented HTML lines — almost every file in `src/_includes/` has lines indented 4+ spaces. When that output lands inside markdown content, markdown-it's *indented code block* rule treats those lines as a code block and escapes them, so visitors see raw markup.

Removing `{%-` dashes per-template wouldn't scale: ~100 includes have indented lines.

## Fix (systemwide)

Disable markdown-it's indented `code` rule in both markdown pipelines (the Eleventy `md` library via `amendLibrary`, and the snippet renderer in `file-utils.js`). Fenced ``` blocks still work for intentional code samples — verified the existing code samples on `/`, `/services/`, and `/instructions/` build identically before and after.

## Tests

- `test/unit/eleventy/markdown-renderer.test.js` — indented HTML renders as HTML, fenced blocks still escape, `++` stripping still works
- `test/integration/eleventy/raw-html-output.test.js` — builds a test site and scans every output HTML file for escaped tags (`&lt;...`) outside `pre`/`code`/`script`, ensuring no raw HTML reaches visitors

Full suite passes (3010 tests).

https://claude.ai/code/session_01LVR2yaDS2JQ3Jgr7pWP8mJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVR2yaDS2JQ3Jgr7pWP8mJ)_