### PR TITLE
Let media background blocks grow when overlay content overflows

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -609,10 +609,17 @@
   list-style: none;
 }
 
-@mixin media-background-container($aspect-ratio, $overflow: hidden) {
+@mixin media-background-container($aspect-ratio) {
   position: relative;
 
-  overflow: $overflow;
+  // Grid (not flex) so the in-flow overlay figure stretches to fill the
+  // box while still growing it when content is taller than the ratio.
+  display: grid;
+
+  // `clip` (unlike `hidden`) doesn't create a scroll container, so the
+  // aspect ratio acts as a minimum height: in-flow overlay content taller
+  // than the ratio grows the box instead of being cut off.
+  overflow: clip;
 
   aspect-ratio: $aspect-ratio;
   width: 100%;
@@ -647,8 +654,11 @@
     --color-text: var(--color-contrast-text);
     --color-text-muted: var(--color-contrast-text-muted);
 
-    position: absolute;
-    inset: 0;
+    // In flow (not absolute) so tall content grows the container instead
+    // of being clipped by the aspect-ratio height.
+    position: relative;
+    z-index: 1;
+    margin: 0;
     padding: $space-lg;
     color: var(--color-contrast-text);
 
@@ -661,6 +671,15 @@
 
     max-width: 100%;
     text-align: center;
+
+    .prose {
+      align-items: center;
+      max-width: $width-default;
+
+      p {
+        max-width: $width-narrow;
+      }
+    }
 
     h1, h2, h3, h4, h5, h6 {
       color: var(--color-contrast-text);

--- a/src/css/design-system/_image-background.scss
+++ b/src/css/design-system/_image-background.scss
@@ -17,7 +17,7 @@
   }
 
   .image-background {
-    @include media-background-container(8/3, clip);
+    @include media-background-container(8/3);
 
     // The image covers the entire container
     > div {


### PR DESCRIPTION
## Problem

On smaller devices, `image-background` and `video-background` blocks clipped their overlay content. The container's height was fixed by `aspect-ratio` with `overflow: hidden`/`clip`, and the overlay `<figure>` was absolutely positioned (`inset: 0`) — so a badge + heading + paragraphs + buttons taller than the ratio height was simply cut off.

Separately, `.prose` inside these overlays spanned the full block width on desktop.

## Fix (pure CSS, no breakpoints disabled)

- The overlay `<figure>` is now an in-flow grid child instead of absolutely positioned, and the container uses `overflow: clip` everywhere. Since `clip` (unlike `hidden`) doesn't create a scroll container, the CSS automatic content-based minimum applies: **the aspect ratio acts as a minimum height** — blocks keep their exact ratio when content fits, and grow just enough when it doesn't. (Note: `display: grid` is load-bearing here; Chromium doesn't apply the content-based minimum with `display: flex`.)
- `.prose` inside the overlays is constrained to match the hero block: 900px overall, 680px for paragraphs.

The absolutely-positioned media layers (cover image, parallax inset, video iframe, thumbnail, tint gradient) are unaffected — they still fill whatever height the container ends up with.

## Verification

Tested with a build + Playwright against an `image-background` block containing a filled-out badge, h1 + two paragraphs, and two buttons:

| Viewport | Before | After |
|----------|--------|-------|
| 375px (mobile) | Container 281px, content needed 667px — badge, most text, and both buttons clipped | Container grows to fit; everything visible |
| 768px (tablet) | Fit (borderline) | Fits, prose constrained |
| 1440px (desktop) | Fit, but prose spanned full width | Prose constrained to 680px; block grows slightly to fit taller text |

Homepage `video-background` (16/9) and parallax `image-background` (8/3) blocks verified unchanged when content fits. Full test suite passes (3018 tests), lint clean.

https://claude.ai/code/session_012KWzrYp6SJaa95iTqUZDpd

---
_Generated by [Claude Code](https://claude.ai/code/session_012KWzrYp6SJaa95iTqUZDpd)_