### PR TITLE
Fix illegible buttons and badge over image/video backgrounds

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -651,8 +651,11 @@
 
 @mixin media-background-content {
   > figure {
-    --color-text: var(--color-contrast-text);
-    --color-text-muted: var(--color-contrast-text-muted);
+    // Remap the tint to the link color so tint-bg components (badges) pair
+    // it with the remapped contrast text instead of white-on-light.
+    --color-tint: var(--color-link);
+
+    @include contrast-text-vars;
 
     // In flow (not absolute) so tall content grows the container instead
     // of being clipped by the aspect-ratio height.
@@ -660,7 +663,6 @@
     z-index: 1;
     margin: 0;
     padding: $space-lg;
-    color: var(--color-contrast-text);
 
     @include flex-center;
   }
@@ -691,22 +693,29 @@
       text-shadow: var(--shadow-sm);
     }
 
+    // Buttons sit on arbitrary imagery, so pair --color-link with
+    // --color-contrast-text(-muted) — themes define these as a contrasting
+    // pair (same approach as .cta).
     .btn, a.btn {
       border-color: transparent;
-      color: var(--color-text);
+      color: var(--color-link);
       background: var(--color-contrast-text-muted);
 
       &:hover {
+        color: var(--color-link);
         background: var(--color-contrast-text);
       }
     }
 
-    .btn--primary {
+    // a.btn--primary keeps specificity above the a.btn rule, which would
+    // otherwise win on element count and turn primary into the pale pill.
+    .btn--primary, a.btn--primary {
       border-color: transparent;
       color: var(--color-contrast-text);
       background: var(--color-link);
 
       &:hover {
+        color: var(--color-contrast-text);
         background: var(--color-link-hover);
       }
     }


### PR DESCRIPTION
## Problem

Primary and secondary buttons, and the badge, were hard to read inside `image-background` and `video-background` blocks in many themes (including the default) — both background and foreground rendered light.

## Diagnosis

All three issues trace to the `media-background-content` mixin (`src/css/_mixins.scss`). The overlay `> figure` remaps `--color-text` → `--color-contrast-text` (white in most themes), which broke components pairing `--color-text` with a light background:

1. **Base/secondary buttons**: the figcaption `.btn` pill style set `color: var(--color-text)` on a `--color-contrast-text-muted` (white 80%) background → white text on white pill.
2. **Primary buttons**: the buttons are rendered as `<a class="btn btn--primary">`, and the `figcaption a.btn` selector (0,3,2) outranks the `figcaption .btn--primary` override (0,3,1) on element count, so primary buttons got the same broken pill style — and a white hover background under white text.
3. **Badge**: the `tint-bg` mixin paired the remapped (light) `--color-text` with the theme's unchanged light `--color-tint` (`#dbeafe` in the default theme) → white on pale blue.

## Fix (consistent with existing design-system patterns)

- Overlay buttons now pair `--color-link` text with the `--color-contrast-text(-muted)` pill background — the same pairing `.cta` already uses. Themes define these two as a contrasting pair, so this reads correctly in every theme.
- Added `a.btn--primary` to the primary override so it wins specificity against `a.btn`, and pinned its hover color, restoring the standard link-bg/contrast-text primary look.
- Remapped `--color-tint: var(--color-link)` on the overlay figure — the same lever `dark-section-vars` uses to keep `tint-bg` badges readable on dark sections.
- Replaced the hand-rolled text-var remap with the existing `contrast-text-vars` mixin.

Applies to both `image-background` and `video-background` (both include the mixin).

## Testing

- `bun run lint` clean
- `bun run build` succeeds; verified compiled CSS contains the corrected selectors and figure variable remaps
- Full `bun test`: 3018 pass, 0 fail

https://claude.ai/code/session_014XX5xRonY97Bgt77pu6WWW

---
_Generated by [Claude Code](https://claude.ai/code/session_014XX5xRonY97Bgt77pu6WWW)_