### PR TITLE
Raise image-background overlay figure above tint gradient

### DIFF
--- a/src/css/design-system/_image-background.scss
+++ b/src/css/design-system/_image-background.scss
@@ -29,6 +29,13 @@
 
     @include media-background-content;
 
+    // Keep the overlay content above the optional tint gradient (z-index 2).
+    // The shared mixin sets this figure to z-index 1, which would otherwise
+    // sit *under* a tint, so raise it here at the base level.
+    > figure {
+      z-index: 3;
+    }
+
     &.tinted {
       isolation: isolate;
       position: relative;
@@ -47,10 +54,6 @@
           rgb(10 8 6 / 35%) 0%,
           rgb(10 8 6 / 55%) 100%
         );
-      }
-
-      > figure {
-        z-index: 3;
       }
     }
 


### PR DESCRIPTION
## What

Fixes the overlay content on `.image-background` blocks appearing **under** the tint gradient when the `tint` option is enabled.

## Why

The overlay figure's `z-index: 3` only existed inside the `.tinted` block. The base rule `.design-system .image-background > figure` (emitted by the shared `media-background-content` mixin) was `z-index: 1` — *below* the tint's `::before` at `z-index: 2`. The content only stayed above the tint thanks to the more-specific `.tinted > figure` override, which is fragile.

## Change

- Set `.design-system .image-background > figure` to `z-index: 3` at the **base** level, so it sits above the tint gradient (`z-index: 2`) unconditionally.
- Removed the now-redundant `.tinted > figure { z-index: 3 }` override.

Verified against the compiled bundle: base figure resolves to `z-index: 3`, tint `::before` stays at `z-index: 2`. Lint and build pass.

https://claude.ai/code/session_01WXQLHeU9kP9ZtwDyAenQB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXQLHeU9kP9ZtwDyAenQB3)_