### PR TITLE
Fix hero/media backgrounds locking to aspect ratio in Safari

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @use "variables" as *;
 @use "breakpoints" as breakpoint;
 
@@ -609,25 +610,45 @@
   list-style: none;
 }
 
-@mixin media-background-container($aspect-ratio) {
+@mixin media-background-container($ratio-w, $ratio-h) {
   position: relative;
 
-  // Grid (not flex) so the in-flow overlay figure stretches to fill the
-  // box while still growing it when content is taller than the ratio.
-  display: grid;
-
   // `clip` (unlike `hidden`) doesn't create a scroll container, so the
-  // aspect ratio acts as a minimum height: in-flow overlay content taller
-  // than the ratio grows the box instead of being cut off.
+  // absolutely-positioned media (and parallax overflow) is trimmed to the box.
   overflow: clip;
 
-  aspect-ratio: $aspect-ratio;
+  // Single stacking cell: the overlay figure and the aspect-ratio spacer
+  // (::before) both occupy 1/1, so the row grows to whichever is taller.
+  display: grid;
+  grid-template-columns: 1fr;
+
   width: 100%;
 
   background: $color-dark-bg;
 
-  @include breakpoint.down("md") {
-    aspect-ratio: 4/3;
+  // Enforce the aspect ratio as a *minimum* height via a spacer rather than
+  // the `aspect-ratio` property on this box. WebKit/Safari treats
+  // `aspect-ratio` combined with a non-visible `overflow` (clip or hidden) as
+  // a hard height and clips overlay content taller than the ratio, where
+  // Chrome and Firefox grow the box. A padding spacer sharing the overlay's
+  // grid cell lets the box grow in every engine while still falling back to
+  // the ratio when content is short. (Verified against WebKit 26 / Safari 26.)
+  //
+  // Uses ::after, not ::before — the `.image-background.tinted` overlay owns
+  // ::before, and a shared pseudo-element would inherit its `position:
+  // absolute` and stop reserving grid height.
+  &::after {
+    content: "";
+    grid-area: 1 / 1;
+
+    // Width-only contribution; percentage padding resolves against the grid
+    // area's width, so this stays 0-wide but reserves height = width * h/w.
+    width: 0;
+    padding-top: math.percentage(math.div($ratio-h, $ratio-w));
+
+    @include breakpoint.down("md") {
+      padding-top: math.percentage(math.div(3, 4));
+    }
   }
 }
 
@@ -657,10 +678,14 @@
 
     @include contrast-text-vars;
 
-    // In flow (not absolute) so tall content grows the container instead
-    // of being clipped by the aspect-ratio height.
     position: relative;
     z-index: 1;
+
+    // Share the single grid cell with the ::before spacer (1/1) so the row
+    // sizes to the taller of the two. In flow (not absolute) so tall content
+    // grows the container instead of being clipped by the minimum height.
+    grid-area: 1 / 1;
+
     margin: 0;
     padding: $space-lg;
 

--- a/src/css/design-system/_image-background.scss
+++ b/src/css/design-system/_image-background.scss
@@ -17,7 +17,7 @@
   }
 
   .image-background {
-    @include media-background-container(8/3);
+    @include media-background-container(8, 3);
 
     // The image covers the entire container
     > div {

--- a/src/css/design-system/_video-background.scss
+++ b/src/css/design-system/_video-background.scss
@@ -17,7 +17,7 @@
   }
 
   .video-background {
-    @include media-background-container(16/9);
+    @include media-background-container(16, 9);
 
     // Thumbnail image shown while video loads
     &__thumbnail {


### PR DESCRIPTION
## The problem

`.image-background` and `.video-background` (the "hero" media blocks) set `aspect-ratio` + `overflow: clip` on a CSS grid container, so the ratio acts as a **minimum** height — overlay content taller than the ratio is meant to grow the box. Chrome and Firefox do this; **Safari leaves the box locked to the aspect ratio and clips the overflowing content.**

## Root cause

Per the CSS Box Sizing spec, `aspect-ratio` sets a *preferred* size that a box's content-based automatic minimum size can override (so the box grows). That content-based minimum is kept when `overflow` is `visible` **or `clip`**, but zeroed for `hidden`/`auto`/`scroll`. The code deliberately chose `overflow: clip` to get growth while still trimming the cover image.

**WebKit/Safari diverges here: it treats `overflow: clip` like `hidden`**, zeroing the content-based minimum, so `aspect-ratio` becomes a hard height and taller overlay content gets clipped.

Confirmed empirically with Playwright driving **real WebKit 26** (Safari 26's engine). Reduced case, 800px-wide grid box, `aspect-ratio: 16/9` (450px), 700px of content:

| `overflow` | Chromium | WebKit |
|---|---|---|
| `clip` | 700px (grows) | **450px (stuck — clipped)** |
| `visible` | 700px (grows) | 700px (grows) |
| `hidden` | 450px (stuck) | 450px (stuck) |

This matches the reported behaviour exactly. See also: [CSS-Tricks `aspect-ratio` almanac](https://css-tricks.com/almanac/properties/a/aspect-ratio/), [DEV: aspect-ratio sets preferable sizes](https://dev.to/avcat/aspect-ratio-sets-preferable-sizes-but-does-not-force-the-size-41ga), [rachelandrew/gridbugs](https://github.com/rachelandrew/gridbugs).

## The fix

Stop relying on the buggy `aspect-ratio` + `overflow: clip` interaction. Instead, establish the ratio as a minimum height with a padding-based **spacer pseudo-element** that shares the overlay's single grid cell (`grid-area: 1 / 1`), so the grid row sizes to whichever is taller (spacer or content). `overflow: clip` is kept purely for trimming the cover image / parallax.

The spacer uses `::after` because `.image-background.tinted` already owns `::before` for its gradient overlay — a shared pseudo-element would inherit `position: absolute` and stop reserving grid height.

## Verification (real WebKit 26, via Playwright)

End-to-end with the actual compiled production CSS:

| Engine | Short content | Tall content |
|---|---|---|
| Chromium — plain | 450px (holds ratio) ✓ | 949px (grows) ✓ |
| Chromium — tinted | 450px ✓ | 949px ✓ |
| WebKit — plain | 450px ✓ | 948px ✓ |
| WebKit — tinted | 450px ✓ | 948px ✓ |

Before/after screenshots in WebKit (clipped buttons → fully contained) are attached in the originating session.

- `stylelint` clean, SCSS bundle compiles, CSS scoping + unused-class + scss build tests pass.

https://claude.ai/code/session_01P9KZNabESLjnNj1CCe6F9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9KZNabESLjnNj1CCe6F9R)_