### PR TITLE
Remove block gap from design-system wrapper and drop redundant class

### DIFF
--- a/src/_includes/design-system/right-column.html
+++ b/src/_includes/design-system/right-column.html
@@ -5,7 +5,7 @@ per-block without the full-width section wrappers; plain markdown body content
 falls back to a prose wrapper.
 {%- endcomment -%}
 {%- if has_right_content -%}
-  <aside class="right-column design-system">
+  <aside class="right-column">
     {%- assign right_blocks = "right-content" | sidebar_blocks -%}
     {%- if right_blocks.size > 0 -%}
       {%- for block in right_blocks -%}

--- a/src/css/design-system/_base.scss
+++ b/src/css/design-system/_base.scss
@@ -364,10 +364,10 @@
   // BLOCK LAYOUT
   // ===========================================================================
   // When .design-system is used as a content wrapper (not on body/section),
-  // it becomes a flex column with consistent gap between blocks.
+  // it becomes a flex column.
 
   &:not(body, section) {
-    @include flex-col($space-2xl);
+    @include flex-col(0);
   }
 
   // ===========================================================================

--- a/test/integration/eleventy/right-content.test.js
+++ b/test/integration/eleventy/right-content.test.js
@@ -46,7 +46,6 @@ describe("right-content sidebar", () => {
         const aside = doc.querySelector("aside.right-column");
         expect(aside).not.toBeNull();
         expect(aside.textContent).toContain(SIDEBAR_TEXT);
-        expect(aside.classList.contains("design-system")).toBe(true);
 
         // Sibling of main inside the columns wrapper, never inside main —
         // keeps sidebar text out of the Pagefind index (data-pagefind-body


### PR DESCRIPTION
## Summary

- Remove the gap applied by `.design-system:not(body, section)`. The wrapper still lays blocks out as a flex column, but no longer adds `$space-2xl` between them (`flex-col(0)`).
- Remove the `design-system` class from the `right-column` aside in `right-column.html`. The whole site is wrapped in `body.design-system` now, so the class on inner elements is redundant.

The `.design-system` **selectors** are intentionally kept in the SCSS, since this template is also applied to sites that bring their own base layouts and aren't fully design-system'd. The `.right-column` styling still applies via the `.design-system .right-column` descendant selector (the body still carries the class).

## Testing

- `bun run build` completes successfully.

https://claude.ai/code/session_019E1fBy8QCkqGCaPUoQZuoU

---
_Generated by [Claude Code](https://claude.ai/code/session_019E1fBy8QCkqGCaPUoQZuoU)_