### PR TITLE
Require a blank line before markdown lists

### DIFF
--- a/src/_lib/eleventy/file-utils.js
+++ b/src/_lib/eleventy/file-utils.js
@@ -46,10 +46,40 @@ const disableIndentedCode = (md) => {
   md.disable("code");
 };
 
+/**
+ * Require a blank line before a list. Front matter content is hard-wrapped at
+ * 80 chars, so a wrapped prose sentence often continues on a line that starts
+ * with a dash (e.g. "- and then..."). CommonMark normally lets such a line
+ * interrupt a paragraph and turn into a bullet list. We refuse that
+ * interruption, so a marker only starts a list when it follows a blank line.
+ *
+ * The guard fires only for top-level paragraphs (`listIndent < 0`): inside a
+ * list, the same paragraph-terminator mechanism is what separates one item
+ * from the next, so list items, nested lists and blank-line-separated lists
+ * all keep working.
+ * @param {any} md
+ */
+const requireBlankLineBeforeLists = (md) => {
+  const ruler = md.block.ruler;
+  const rule = ruler.__rules__[ruler.__find__("list")];
+  const listRule = rule.fn;
+  ruler.at(
+    "list",
+    (state, startLine, endLine, silent) => {
+      if (silent && state.parentType === "paragraph" && state.listIndent < 0) {
+        return false;
+      }
+      return listRule(state, startLine, endLine, silent);
+    },
+    { alt: rule.alt.slice() },
+  );
+};
+
 /** @param {any} md */
 const amendMarkdown = (md) => {
   stripPlusPlus(md);
   disableIndentedCode(md);
+  requireBlankLineBeforeLists(md);
 };
 
 const createMarkdownRenderer = () => {

--- a/src/_lib/eleventy/file-utils.js
+++ b/src/_lib/eleventy/file-utils.js
@@ -60,9 +60,11 @@ const disableIndentedCode = (md) => {
  * @param {any} md
  */
 const requireBlankLineBeforeLists = (md) => {
-  const ruler = md.block.ruler;
-  const rule = ruler.__rules__[ruler.__find__("list")];
-  const listRule = rule.fn;
+  const { ruler } = md.block;
+  // Capture the original rule before ruler.at() replaces it in place;
+  // ruler.at() mutates the rule object, so reading `.fn` afterwards would
+  // point back at this wrapper and recurse forever.
+  const { fn: listRule, alt } = ruler.__rules__[ruler.__find__("list")];
   ruler.at(
     "list",
     (state, startLine, endLine, silent) => {
@@ -71,7 +73,7 @@ const requireBlankLineBeforeLists = (md) => {
       }
       return listRule(state, startLine, endLine, silent);
     },
-    { alt: rule.alt.slice() },
+    { alt: alt.slice() },
   );
 };
 

--- a/test/unit/eleventy/markdown-renderer.test.js
+++ b/test/unit/eleventy/markdown-renderer.test.js
@@ -31,4 +31,35 @@ describe("amendMarkdown", () => {
     expect(html).toContain("Hello world");
     expect(html).not.toContain("++");
   });
+
+  test("a dash on a wrapped prose line does not start a list", () => {
+    const html = createRenderer().render(
+      "here's the first line and i want to add\n- that dash as part of the sentence but\nit is interpreted as a bullet",
+    );
+    expect(html).not.toContain("<ul>");
+    expect(html).not.toContain("<li>");
+    expect(html).toContain("- that dash as part of the sentence but");
+  });
+
+  test("a list still renders when preceded by a blank line", () => {
+    const html = createRenderer().render(
+      "intro paragraph\n\n- one\n- two\n- three",
+    );
+    expect(html).toContain("<li>one</li>");
+    expect(html).toContain("<li>two</li>");
+    expect(html).toContain("<li>three</li>");
+  });
+
+  test("a list at the very start of the content still renders", () => {
+    const html = createRenderer().render("- one\n- two");
+    expect(html).toContain("<li>one</li>");
+    expect(html).toContain("<li>two</li>");
+  });
+
+  test("nested lists without a blank line still render", () => {
+    const html = createRenderer().render("- outer\n  - inner\n- outer2");
+    expect(html).toContain("<li>inner</li>");
+    expect(html).toContain("<li>outer2</li>");
+    expect(html).toContain("<ul>\n<li>inner</li>");
+  });
 });


### PR DESCRIPTION
## Problem

Front matter content (e.g. `blocks` → `type: markdown` → `content`) is hard-wrapped at 80 chars. When a wrapped prose sentence continues onto a line that happens to start with a dash, markdown-it (following CommonMark) lets that line **interrupt the paragraph** and turns it into a bullet list:

```
blocks:
  - type: markdown
    content: |
      here's the first line and i want to add
      - that dash as part of the sentence but
      it is interpreted as a bullet
```

renders as:

```html
<p>here's the first line and i want to add</p>
<ul><li>that dash as part of the sentence but
it is interpreted as a bullet</li></ul>
```

## Fix

Wrap markdown-it's block `list` rule so a list marker no longer interrupts a **top-level** paragraph — a marker now only starts a list when it follows a blank line.

The guard is scoped with `state.listIndent < 0` (top level only). Inside a list, the same paragraph-terminator mechanism is what separates one item from the next, so **list items, nested lists, and blank-line-separated lists all keep working**. The rule's `alt` options are preserved when re-registering so the terminator chains stay intact.

Applied in `amendMarkdown`, so it covers both the `markdown` filter and the `renderContent: "md"` path used by markdown blocks.

## Behaviour after the fix

| Input | Result |
|---|---|
| prose line then `- dash` line (no blank) | single `<p>` (fixed) |
| blank line then `- one`/`- two` | proper `<ul>` ✓ |
| `- one`/`- two` at start of content | proper `<ul>` ✓ |
| nested list without blank line | proper nested `<ul>` ✓ |
| loose lists | unchanged ✓ |

## Tests

Added 4 cases to `test/unit/eleventy/markdown-renderer.test.js` covering the prose-dash case plus the list cases that must keep working. Full lint and build pass.

https://claude.ai/code/session_01HSfbrBKzpxdxDNX98a6sMP

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSfbrBKzpxdxDNX98a6sMP)_