### PR TITLE
Center .cta p with margin auto

### DIFF
--- a/src/css/design-system/_cta.scss
+++ b/src/css/design-system/_cta.scss
@@ -19,6 +19,8 @@
     p {
       @include body-lg;
 
+      margin-left: auto;
+      margin-right: auto;
       max-width: $width-narrow;
       opacity: 0.9;
     }


### PR DESCRIPTION
Adds `margin-left: auto` and `margin-right: auto` to `.design-system .cta p` so the paragraph centers within the CTA block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAAvL1h3ZHiYDaRjZwu7xr)_