### PR TITLE
Fix double-section nesting in block partials; add compact block flag

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -25,6 +25,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: video_url
         type: string
         label: Bunny Stream Embed URL
@@ -48,6 +49,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: items
         type: object
         label: Products
@@ -74,6 +76,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: variant
         type: string
         label: Variant (info | warning | success | danger)
@@ -87,6 +90,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: filename, type: string, label: Filename, required: true }
       - { name: code, type: string, label: Code, required: true }
       - { name: language, type: string, label: Language }
@@ -95,6 +99,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: content, type: rich-text, label: Content }
       - name: intro_content
         type: rich-text
@@ -104,6 +109,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: content, type: rich-text, label: Content, required: true }
       - name: button
         type: object
@@ -118,6 +124,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: content, type: rich-text, label: Intro Content }
       - name: fields
         type: object
@@ -143,6 +150,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: intro_content
         type: rich-text
         label: Intro Content (Markdown)
@@ -162,6 +170,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: items
         type: object
         label: FAQs
@@ -178,6 +187,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: items
         type: object
         label: Features
@@ -199,6 +209,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: items
         type: object
         label: Gallery Images
@@ -217,11 +228,13 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_hero:
     label: Hero
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: badge, type: string, label: Badge Text }
       - { name: content, type: rich-text, label: Content, required: true }
       - name: buttons
@@ -239,12 +252,14 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: content, type: string, label: Raw HTML, required: true }
   block_icon_links:
     label: Icon Links
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: intro_content
         type: rich-text
         label: Intro Content (Markdown)
@@ -265,6 +280,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: src, type: string, label: Iframe URL, required: true }
       - { name: name, type: string, label: Accessible Name, required: true }
       - { name: width, type: number, label: Width (px) }
@@ -284,6 +300,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: image, type: image, label: Background Image, required: true }
       - { name: image_alt, type: string, label: Image Alt Text }
       - { name: class, type: string, label: CSS Class }
@@ -305,6 +322,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: items
         type: object
         label: Cards
@@ -324,12 +342,14 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: file, type: string, label: Template File Path, required: true }
   block_items:
     label: Items
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: collection
         type: string
         label: Collection Name
@@ -357,6 +377,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: items, type: string, label: Items, list: true }
       - name: intro_content
         type: rich-text
@@ -378,6 +399,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: collection
         type: string
         label: Collection Name
@@ -390,6 +412,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: text, type: string, label: Button Text, required: true }
       - { name: href, type: string, label: URL, required: true }
       - { name: variant, type: string, label: Variant }
@@ -400,6 +423,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: collection
         type: string
         label: Collection Name
@@ -422,12 +446,14 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: content, type: rich-text, label: Markdown, required: true }
   block_marquee_images:
     label: Marquee Images
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: items
         type: object
         label: Images
@@ -447,21 +473,25 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_quote_cart:
     label: Quote Cart
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_quote_checkout:
     label: Quote Checkout
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_reviews:
     label: Reviews
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: current_item, type: boolean, label: Filter to Current Item }
       - { name: minimum_rating, type: number, label: Minimum Rating }
       - { name: horizontal, type: boolean, label: Horizontal Slider }
@@ -471,6 +501,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: intro
         type: rich-text
         label: Section Header Intro
@@ -480,6 +511,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: reference
         label: Snippet
         type: reference
@@ -493,6 +525,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: directory, type: string, label: Directory, required: true }
       - name: intro_content
         type: rich-text
@@ -513,6 +546,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
@@ -548,6 +582,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
@@ -572,6 +607,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
@@ -593,6 +629,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: variant, type: string, label: Variant }
       - { name: left_content, type: rich-text, label: Left Content }
       - name: left_button
@@ -617,6 +654,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
@@ -639,6 +677,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
@@ -669,6 +708,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
@@ -690,6 +730,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: content, type: rich-text, label: Content }
       - { name: reverse, type: boolean, label: Reverse Layout }
@@ -716,6 +757,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: items
         type: object
         label: Statistics
@@ -732,6 +774,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: video_id, type: string, label: Video Embed URL, required: true }
       - { name: thumbnail_url, type: string, label: Thumbnail URL }
       - { name: video_title, type: string, label: Video Title }
@@ -752,6 +795,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: videos
         type: object
         label: Videos
@@ -782,51 +826,61 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_hire_pricing:
     label: Hire Pricing
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_product_add_ons:
     label: Product Add Ons
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_product_contact_section:
     label: Product Contact Section
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_product_features:
     label: Product Features
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_product_gallery:
     label: Product Gallery
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_product_header:
     label: Product Header
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_product_meta:
     label: Product Meta
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_purchase_link:
     label: Purchase Link
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_category_products:
     label: Category Products
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: intro_content
         type: rich-text
         label: Intro Content (Markdown)
@@ -838,6 +892,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - name: intro_content
         type: rich-text
         label: Intro Content (Markdown)
@@ -849,6 +904,7 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   products_list:
     label: Products
     type: object
@@ -867,96 +923,115 @@ components:
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_event_gallery:
     label: Event Gallery
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_event_header:
     label: Event Header
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_event_map:
     label: Event Map
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_event_meta:
     label: Event Meta
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_event_products:
     label: Event Products
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_freetobook:
     label: Freetobook
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_property_contact_section:
     label: Property Contact Section
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_property_content:
     label: Property Content
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_property_features:
     label: Property Features
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_property_gallery:
     label: Property Gallery
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_property_guides:
     label: Property Guides
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_property_header:
     label: Property Header
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_property_map:
     label: Property Map
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_guide_header:
     label: Guide Header
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_guide_pages_list:
     label: Guide Pages List
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_guide_navigation:
     label: Guide Navigation
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_menu:
     label: Menu
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
   block_menu_pdf_download:
     label: Menu Pdf Download
     type: object
     fields:
       - { name: dark, type: boolean, label: Dark }
+      - { name: compact, type: boolean, label: Compact }
       - { name: text, type: string, label: Button Text }
       - { name: variant, type: string, label: Variant }
       - { name: size, type: string, label: Size }

--- a/src/_includes/design-system/blocks/event-products.html
+++ b/src/_includes/design-system/blocks/event-products.html
@@ -9,9 +9,7 @@ Event-only block. No block-level parameters.
 
 {%- assign eventProducts = collections.products | getProductsByEvent: page.fileSlug, products -%}
 {%- if eventProducts.size > 0 -%}
-<section class="compact">
-  <div class="container-wide">
-    {%- include "items.html", items: eventProducts -%}
-  </div>
-</section>
+<div class="container-wide">
+  {%- include "items.html", items: eventProducts -%}
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/freetobook.html
+++ b/src/_includes/design-system/blocks/freetobook.html
@@ -6,7 +6,7 @@ Property-only block. No block-level parameters.
 {%- endcomment -%}
 
 {%- if freetobook_token -%}
-<section id="freetobook" class="freetobook">
+<div id="freetobook" class="freetobook">
   <details class="container-wide">
     <summary class="btn btn--primary">Check Availability / Book Online</summary>
     <div class="iframe-container">
@@ -16,5 +16,5 @@ Property-only block. No block-level parameters.
       ></iframe>
     </div>
   </details>
-</section>
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/guide-header.html
+++ b/src/_includes/design-system/blocks/guide-header.html
@@ -5,13 +5,11 @@ Used on guide-pages and guide-categories. No block-level parameters. Reads
 `name` and `subtitle` from the page data.
 {%- endcomment -%}
 
-<section class="compact">
-  <div class="container-wide">
-    <header class="guide-header">
-      <h1>{{ name }}</h1>
-      {%- if subtitle -%}
-        <h2>{{ subtitle }}</h2>
-      {%- endif -%}
-    </header>
-  </div>
-</section>
+<div class="container-wide">
+  <header class="guide-header">
+    <h1>{{ name }}</h1>
+    {%- if subtitle -%}
+      <h2>{{ subtitle }}</h2>
+    {%- endif -%}
+  </header>
+</div>

--- a/src/_includes/design-system/blocks/guide-navigation.html
+++ b/src/_includes/design-system/blocks/guide-navigation.html
@@ -7,12 +7,10 @@ Guide-page-only block. No block-level parameters.
 {%- endcomment -%}
 
 {%- if guide-category -%}
-<section class="compact">
-  <div class="container-wide">
-    {%- assign category = collections.guide-categories | getBySlug: guide-category -%}
-    <nav class="guide-navigation" aria-label="Guide breadcrumb">
-      <a href="{{ category.url }}">&larr; Back to {{ category.data.name }}</a>
-    </nav>
-  </div>
-</section>
+<div class="container-wide">
+  {%- assign category = collections.guide-categories | getBySlug: guide-category -%}
+  <nav class="guide-navigation" aria-label="Guide breadcrumb">
+    <a href="{{ category.url }}">&larr; Back to {{ category.data.name }}</a>
+  </nav>
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/guide-pages-list.html
+++ b/src/_includes/design-system/blocks/guide-pages-list.html
@@ -8,18 +8,16 @@ Guide-category-only block. No block-level parameters.
 
 {%- assign guide_pages = collections.guide-pages | guidesByCategory: page.fileSlug -%}
 {%- if guide_pages.size > 0 -%}
-<section>
-  <div class="container">
-    <ul class="guide-list">
-      {%- for guide_page in guide_pages -%}
-        <li>
-          <a href="{{ guide_page.url }}">{{ guide_page.data.name }}</a>
-          {%- if guide_page.data.subtitle -%}
-            <p>{{ guide_page.data.subtitle }}</p>
-          {%- endif -%}
-        </li>
-      {%- endfor -%}
-    </ul>
-  </div>
-</section>
+<div class="container">
+  <ul class="guide-list">
+    {%- for guide_page in guide_pages -%}
+      <li>
+        <a href="{{ guide_page.url }}">{{ guide_page.data.name }}</a>
+        {%- if guide_page.data.subtitle -%}
+          <p>{{ guide_page.data.subtitle }}</p>
+        {%- endif -%}
+      </li>
+    {%- endfor -%}
+  </ul>
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/item-contact-section.html
+++ b/src/_includes/design-system/blocks/item-contact-section.html
@@ -7,8 +7,6 @@ Shared by `product-contact-section` and `event-contact-section`. No
 block-level parameters.
 {%- endcomment -%}
 
-<section class="compact">
-  <div class="container">
-    {%- include "item-contact-section.html" -%}
-  </div>
-</section>
+<div class="container">
+  {%- include "item-contact-section.html" -%}
+</div>

--- a/src/_includes/design-system/blocks/item-gallery.html
+++ b/src/_includes/design-system/blocks/item-gallery.html
@@ -6,7 +6,7 @@ Shared by `product-gallery` and `event-gallery`. No block-level parameters.
 {%- endcomment -%}
 
 {%- if gallery.size > 0 -%}
-  <section class="compact"><div class="container-wide">
+  <div class="container-wide">
     <div class="gallery">{%- include "gallery.html" -%}</div>
-  </div></section>
+  </div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/item-header.html
+++ b/src/_includes/design-system/blocks/item-header.html
@@ -8,14 +8,12 @@ and `ical_url` from the page data; the event-detail include is a no-op when
 those fields are absent.
 {%- endcomment -%}
 
-<section class="compact">
-  <div class="container-wide">
-    <header>
-      <h1>{{ name }}</h1>
-      {%- if subtitle -%}
-        <h2>{{ subtitle }}</h2>
-      {%- endif -%}
-      {%- include "item-event-details.html" -%}
-    </header>
-  </div>
-</section>
+<div class="container-wide">
+  <header>
+    <h1>{{ name }}</h1>
+    {%- if subtitle -%}
+      <h2>{{ subtitle }}</h2>
+    {%- endif -%}
+    {%- include "item-event-details.html" -%}
+  </header>
+</div>

--- a/src/_includes/design-system/blocks/item-meta.html
+++ b/src/_includes/design-system/blocks/item-meta.html
@@ -18,13 +18,11 @@ Shared template for product-meta, event-meta, and property-content.
 {%- endif -%}
 {%- assign meta_html = rating_html | append: categories_html | strip -%}
 {%- if show_about or meta_html != "" -%}
-<section>
-  <div class="container">
-    {{ rating_html }}
-    {%- if show_about -%}
-      <h2>{{ strings.item_about_heading }}</h2>
-    {%- endif -%}
-    {{ categories_html }}
-  </div>
-</section>
+<div class="container">
+  {{ rating_html }}
+  {%- if show_about -%}
+    <h2>{{ strings.item_about_heading }}</h2>
+  {%- endif -%}
+  {{ categories_html }}
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/map.html
+++ b/src/_includes/design-system/blocks/map.html
@@ -7,10 +7,8 @@ Shared template for event-map and property-map.
 {%- endcomment -%}
 {%- assign embed_src = map_embed_src | default: config.map_embed_src -%}
 {%- if embed_src and embed_src != "" -%}
-<section class="compact">
-  <div class="container">
-    <h2>Location</h2>
-    {%- include "map-embed.html" -%}
-  </div>
-</section>
+<div class="container">
+  <h2>Location</h2>
+  {%- include "map-embed.html" -%}
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/property-contact.html
+++ b/src/_includes/design-system/blocks/property-contact.html
@@ -7,12 +7,10 @@ pagination, overrides the contact-form target with the property's
 `formspark_id`, and links back to the property page.
 {%- endcomment -%}
 
-<section class="compact">
-  <div class="container">
-    <h1>Contact {{ item.data.name }}</h1>
-    {%- assign form_target_override = "https://submit-form.com/" | append: item.data.formspark_id -%}
-    {%- include "contact-form.html" -%}
-    {%- assign form_target_override = nil -%}
-    <a href="/{{ strings.property_permalink_dir }}/{{ item.fileSlug }}/" class="btn btn--primary">Back to {{ item.data.name }}</a>
-  </div>
-</section>
+<div class="container">
+  <h1>Contact {{ item.data.name }}</h1>
+  {%- assign form_target_override = "https://submit-form.com/" | append: item.data.formspark_id -%}
+  {%- include "contact-form.html" -%}
+  {%- assign form_target_override = nil -%}
+  <a href="/{{ strings.property_permalink_dir }}/{{ item.fileSlug }}/" class="btn btn--primary">Back to {{ item.data.name }}</a>
+</div>

--- a/src/_includes/design-system/blocks/property-features.html
+++ b/src/_includes/design-system/blocks/property-features.html
@@ -6,14 +6,12 @@ Property-only block. No block-level parameters.
 {%- endcomment -%}
 
 {%- if features and features.size > 0 -%}
-<section class="compact">
-  <div class="container">
-    <h2>Features</h2>
-    <ul class="property-features">
-      {%- for feature in features -%}
-        <li>{{ feature }}</li>
-      {%- endfor -%}
-    </ul>
-  </div>
-</section>
+<div class="container">
+  <h2>Features</h2>
+  <ul class="property-features">
+    {%- for feature in features -%}
+      <li>{{ feature }}</li>
+    {%- endfor -%}
+  </ul>
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/property-gallery.html
+++ b/src/_includes/design-system/blocks/property-gallery.html
@@ -7,9 +7,7 @@ Property-only block. No block-level parameters.
 {%- endcomment -%}
 
 {%- if gallery and gallery.size > 0 -%}
-<section class="compact">
-  <div class="container-wide">
-    {%- include "property-gallery.html" -%}
-  </div>
-</section>
+<div class="container-wide">
+  {%- include "property-gallery.html" -%}
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/property-guides.html
+++ b/src/_includes/design-system/blocks/property-guides.html
@@ -8,24 +8,22 @@ Property-only block. No block-level parameters.
 
 {%- assign propertyGuides = collections.guide-categories | guideCategoriesByProperty: page.fileSlug -%}
 {%- if propertyGuides.size > 0 -%}
-<section class="compact">
-  <div class="container">
-    <h2>{{ strings.guide_name }}</h2>
-    <ul class="features" role="list">
-      {%- for category in propertyGuides -%}
-      <li>
-        <article class="feature" data-reveal>
-          {%- if category.data.icon -%}
-            {%- include "design-system/icon-badge.html", icon: category.data.icon, label: category.data.name -%}
-          {%- endif -%}
-          <h3><a href="{{ category.url }}">{{ category.data.name }}</a></h3>
-          {%- if category.data.subtitle -%}
-            <p>{{ category.data.subtitle }}</p>
-          {%- endif -%}
-        </article>
-      </li>
-      {%- endfor -%}
-    </ul>
-  </div>
-</section>
+<div class="container">
+  <h2>{{ strings.guide_name }}</h2>
+  <ul class="features" role="list">
+    {%- for category in propertyGuides -%}
+    <li>
+      <article class="feature" data-reveal>
+        {%- if category.data.icon -%}
+          {%- include "design-system/icon-badge.html", icon: category.data.icon, label: category.data.name -%}
+        {%- endif -%}
+        <h3><a href="{{ category.url }}">{{ category.data.name }}</a></h3>
+        {%- if category.data.subtitle -%}
+          <p>{{ category.data.subtitle }}</p>
+        {%- endif -%}
+      </article>
+    </li>
+    {%- endfor -%}
+  </ul>
+</div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/property-header.html
+++ b/src/_includes/design-system/blocks/property-header.html
@@ -6,16 +6,14 @@ Property-only block. No block-level parameters. Reads `name`, `subtitle`,
 and `price_per_night` from the property page data.
 {%- endcomment -%}
 
-<section class="compact">
-  <div class="container-wide">
-    <header class="property-header">
-      <h1>{{ name }}</h1>
-      {%- if subtitle -%}
-        <h2>{{ subtitle }}</h2>
-      {%- endif -%}
-      {%- if price_per_night -%}
-        <p class="property-price">From {{ price_per_night | to_price }} per night</p>
-      {%- endif -%}
-    </header>
-  </div>
-</section>
+<div class="container-wide">
+  <header class="property-header">
+    <h1>{{ name }}</h1>
+    {%- if subtitle -%}
+      <h2>{{ subtitle }}</h2>
+    {%- endif -%}
+    {%- if price_per_night -%}
+      <p class="property-price">From {{ price_per_night | to_price }} per night</p>
+    {%- endif -%}
+  </header>
+</div>

--- a/src/_includes/design-system/render-full-width-block.html
+++ b/src/_includes/design-system/render-full-width-block.html
@@ -5,7 +5,10 @@
   {%- assign _block_inner_trimmed = _block_inner | strip -%}
   {%- if _block_inner_trimmed != "" -%}
     {%- assign cw = block.type | blockContainerWidth -%}
-    <section{% if block.dark %} class="dark"{% endif %}>
+    {%- assign _sec_class = "" -%}
+    {%- if block.dark -%}{%- assign _sec_class = "dark" -%}{%- endif -%}
+    {%- if block.compact -%}{%- assign _sec_class = _sec_class | append: " compact" | strip -%}{%- endif -%}
+    <section{% if _sec_class != "" %} class="{{ _sec_class }}"{% endif %}>
       {%- unless cw == "full" -%}<div class="container-{{ cw }}">{%- endunless -%}
       {{- _block_inner -}}
       {%- unless cw == "full" -%}</div>{%- endunless -%}

--- a/src/_lib/utils/block-schema.js
+++ b/src/_lib/utils/block-schema.js
@@ -314,9 +314,10 @@ const FIELD_TYPE_CHECKS = {
 
 const LIST_CHECK = { label: "an array", check: Array.isArray };
 
-/** Field types for wrapper keys (e.g. `dark`) accepted on every block. */
+/** Field types for wrapper keys (e.g. `dark`, `compact`) accepted on every block. */
 const COMMON_FIELD_TYPES = {
   dark: { type: "boolean" },
+  compact: { type: "boolean" },
 };
 
 /**

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -31,7 +31,10 @@ export const objectField = (label, fields) => ({
 });
 
 /** Container wrapper fields common to every CMS block. */
-export const CONTAINER_FIELDS = { dark: bool("Dark"), compact: bool("Compact") };
+export const CONTAINER_FIELDS = {
+  dark: bool("Dark"),
+  compact: bool("Compact"),
+};
 
 /** Button fields shared between hero, split, and cta blocks. */
 export const BUTTON_FIELDS_BASE = {

--- a/src/_lib/utils/block-schema/shared.js
+++ b/src/_lib/utils/block-schema/shared.js
@@ -31,7 +31,7 @@ export const objectField = (label, fields) => ({
 });
 
 /** Container wrapper fields common to every CMS block. */
-export const CONTAINER_FIELDS = { dark: bool("Dark") };
+export const CONTAINER_FIELDS = { dark: bool("Dark"), compact: bool("Compact") };
 
 /** Button fields shared between hero, split, and cta blocks. */
 export const BUTTON_FIELDS_BASE = {

--- a/test/unit/utils/pages-yml-block-sync.test.js
+++ b/test/unit/utils/pages-yml-block-sync.test.js
@@ -13,7 +13,7 @@ const componentNameToBlockType = (componentName) =>
 
 /** Auto-injected wrapper fields that the generator prepends to every block
  *  component. Mirrors CONTAINER_FIELDS in src/_lib/utils/block-schema/shared.js. */
-const CONTAINER_FIELD_NAMES = ["dark"];
+const CONTAINER_FIELD_NAMES = ["dark", "compact"];
 
 const PAGES_YML_PATH = join(rootDir, ".pages.yml");
 const parsedPagesYml = YAML.parse(readFileSync(PAGES_YML_PATH, "utf-8"));


### PR DESCRIPTION
## Summary

- **Fix 1:** Remove the inner `<section>` wrapper from all block partials that had `containerWidth: "full"` — they were double-nesting with the outer `<section>` already added by `render-full-width-block.html`. Affected: `property-*`, `item-*`, `guide-*`, `event-products`, `freetobook`, `map`. The `freetobook` `#freetobook` anchor target moves from the `<section>` onto an inner `<div>` (anchor targets resolve to any element id).
- **Fix 2:** Add a `compact` boolean flag to `render-full-width-block.html` (alongside the existing `dark` flag) so callers can request reduced padding on the loop's single section. Add `compact` to `CONTAINER_FIELDS` / `COMMON_FIELD_TYPES` so block schema validation accepts it, regenerate `.pages.yml`, and update the sync test to mirror the updated `CONTAINER_FIELDS`.

## Test plan

- [ ] All 2903 unit tests pass (`bun test test/unit/`)
- [ ] No block partials have `<section` as their root element (`grep -r '^<section' src/_includes/design-system/blocks/`)
- [ ] Property pages render with a single `<section>` per block (no double-nesting)
- [ ] `compact: true` on a block produces `<section class="compact">` from the loop
- [ ] `dark: true` and `compact: true` together produce `<section class="dark compact">`
- [ ] `freetobook` anchor `#freetobook` still scrolls correctly (id is on the inner div)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LQwnZwCPG8QUEsZ47wFinA)_