### PR TITLE
Test eleventy-img alpha v7 upgrade

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
 
     "@11ty/eleventy-fetch": ["@11ty/eleventy-fetch@5.1.1", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.7", "@rgrove/parse-xml": "^4.2.0", "debug": "^4.4.3", "flatted": "^3.3.3", "p-queue": "6.6.2" } }, "sha512-/xFJLCrqKlcnRKIfO9Qjd1QOs4IpvypljXET955+EgdRPFA+h8Or6bDnZBbcwr6KS7yeUuzp5k1DhXgbentSTA=="],
 
-    "@11ty/eleventy-img": ["@11ty/eleventy-img@7.0.0-alpha.4", "", { "dependencies": { "@11ty/eleventy-fetch": "^5.1.0", "@11ty/eleventy-utils": "^2.0.7", "brotli-size": "^4.0.0", "debug": "^4.4.1", "entities": "^6.0.1", "image-size": "^1.2.1", "p-queue": "^8.1.0", "sharp": "^0.34.3" } }, "sha512-/fgNsdKeBcOBbItpb5gL3eWqiyisF8wfN/ObsoHuev1CzPLgV3+2KtIJFy3WfzDFk+CKVLwKzjog9UOCgxJYyg=="],
+    "@11ty/eleventy-img": ["@11ty/eleventy-img@7.0.0-alpha.4", "", { "dependencies": { "@11ty/eleventy-fetch": "^5.1.2", "@11ty/eleventy-utils": "^2.0.7", "brotli-size": "^4.0.0", "debug": "^4.4.3", "entities": "^6.0.1", "image-size": "^1.2.1", "p-queue": "^8.1.0", "sharp": "^0.34.5" } }, "sha512-7FJD1+ShuWK+rvLNvSpWyWmGKnOzDqPfMYcXyBH5cAMZcsjWAsPhzX1ERjvOROz41D6hLu/Ss6YE77yOmRGQSA=="],
 
     "@11ty/eleventy-navigation": ["@11ty/eleventy-navigation@1.0.5", "", { "dependencies": { "dependency-graph": "^1.0.0" } }, "sha512-zb6xe29cM9viSdYtZywKIkJw2HIROyBINdBcFWC9uD0c/jYOTAex5nwy3HNEuh5t6/Ld/S9V4gEizfmeYuYpCQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "chobble-template",
       "dependencies": {
         "@11ty/eleventy": "^3.1.5",
-        "@11ty/eleventy-img": "github:jornmineur/eleventy-img#f33b5e25c602fafeca5d374339d1e0ace74bea0b",
+        "@11ty/eleventy-img": "7.0.0-alpha.4",
         "@11ty/eleventy-navigation": "^1.0.5",
         "@11ty/eleventy-plugin-rss": "^2.0.4",
         "@botpoison/browser": "^0.1.30",
@@ -64,7 +64,7 @@
 
     "@11ty/eleventy-fetch": ["@11ty/eleventy-fetch@5.1.1", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.7", "@rgrove/parse-xml": "^4.2.0", "debug": "^4.4.3", "flatted": "^3.3.3", "p-queue": "6.6.2" } }, "sha512-/xFJLCrqKlcnRKIfO9Qjd1QOs4IpvypljXET955+EgdRPFA+h8Or6bDnZBbcwr6KS7yeUuzp5k1DhXgbentSTA=="],
 
-    "@11ty/eleventy-img": ["@11ty/eleventy-img@github:jornmineur/eleventy-img#f33b5e2", { "dependencies": { "@11ty/eleventy-fetch": "^5.1.0", "@11ty/eleventy-utils": "^2.0.7", "brotli-size": "^4.0.0", "debug": "^4.4.1", "entities": "^6.0.1", "image-size": "^1.2.1", "p-queue": "^8.1.0", "sharp": "^0.34.3" } }, "jornmineur-eleventy-img-f33b5e2", "sha512-/fgNsdKeBcOBbItpb5gL3eWqiyisF8wfN/ObsoHuev1CzPLgV3+2KtIJFy3WfzDFk+CKVLwKzjog9UOCgxJYyg=="],
+    "@11ty/eleventy-img": ["@11ty/eleventy-img@7.0.0-alpha.4", "", { "dependencies": { "@11ty/eleventy-fetch": "^5.1.0", "@11ty/eleventy-utils": "^2.0.7", "brotli-size": "^4.0.0", "debug": "^4.4.1", "entities": "^6.0.1", "image-size": "^1.2.1", "p-queue": "^8.1.0", "sharp": "^0.34.3" } }, "sha512-/fgNsdKeBcOBbItpb5gL3eWqiyisF8wfN/ObsoHuev1CzPLgV3+2KtIJFy3WfzDFk+CKVLwKzjog9UOCgxJYyg=="],
 
     "@11ty/eleventy-navigation": ["@11ty/eleventy-navigation@1.0.5", "", { "dependencies": { "dependency-graph": "^1.0.0" } }, "sha512-zb6xe29cM9viSdYtZywKIkJw2HIROyBINdBcFWC9uD0c/jYOTAex5nwy3HNEuh5t6/Ld/S9V4gEizfmeYuYpCQ=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	},
 	"dependencies": {
 		"@11ty/eleventy": "^3.1.5",
-		"@11ty/eleventy-img": "github:jornmineur/eleventy-img#f33b5e25c602fafeca5d374339d1e0ace74bea0b",
+		"@11ty/eleventy-img": "7.0.0-alpha.4",
 		"@11ty/eleventy-navigation": "^1.0.5",
 		"@11ty/eleventy-plugin-rss": "^2.0.4",
 		"@botpoison/browser": "^0.1.30",

--- a/src/_lib/transforms/images.js
+++ b/src/_lib/transforms/images.js
@@ -16,6 +16,8 @@ import { availableParallelism } from "node:os";
 
 const ASPECT_RATIO_ATTRIBUTE = "eleventy:aspectRatio";
 const IGNORE_ATTRIBUTE = "eleventy:ignore";
+const WIDTHS_ATTRIBUTE = "eleventy:widths";
+const LEGACY_WIDTHS_ATTRIBUTE = "widths";
 const NO_LQIP_ATTRIBUTE = "chobble:no-lqip";
 const IMAGE_PROCESSING_PARALLELISM = availableParallelism();
 
@@ -49,13 +51,17 @@ const extractImageOptions = (img, document) => {
   const imageName = img.getAttribute("src");
   if (!imageName) throw new Error("img element missing src attribute");
 
+  const widths =
+    img.getAttribute(WIDTHS_ATTRIBUTE) ??
+    img.getAttribute(LEGACY_WIDTHS_ATTRIBUTE);
+
   return {
     logName: `transformImages: ${img}`,
     imageName,
     alt: img.getAttribute("alt"),
     classes: img.getAttribute("class"),
     sizes: img.getAttribute("sizes"),
-    widths: img.getAttribute("widths"),
+    widths,
     aspectRatio,
     loading: null,
     noLqip,
@@ -115,7 +121,9 @@ export {
   extractImageOptions,
   fixDivsInParagraphs,
   IGNORE_ATTRIBUTE,
+  LEGACY_WIDTHS_ATTRIBUTE,
   NO_LQIP_ATTRIBUTE,
   processImageElement,
   processImages,
+  WIDTHS_ATTRIBUTE,
 };

--- a/src/_lib/transforms/images.js
+++ b/src/_lib/transforms/images.js
@@ -51,9 +51,11 @@ const extractImageOptions = (img, document) => {
   const imageName = img.getAttribute("src");
   if (!imageName) throw new Error("img element missing src attribute");
 
+  const eleventyWidths = img.getAttribute(WIDTHS_ATTRIBUTE);
   const widths =
-    img.getAttribute(WIDTHS_ATTRIBUTE) ??
-    img.getAttribute(LEGACY_WIDTHS_ATTRIBUTE);
+    eleventyWidths !== null
+      ? eleventyWidths
+      : img.getAttribute(LEGACY_WIDTHS_ATTRIBUTE);
 
   return {
     logName: `transformImages: ${img}`,

--- a/test/unit/transforms/images.test.js
+++ b/test/unit/transforms/images.test.js
@@ -4,8 +4,10 @@ import {
   extractImageOptions,
   fixDivsInParagraphs,
   IGNORE_ATTRIBUTE,
+  LEGACY_WIDTHS_ATTRIBUTE,
   NO_LQIP_ATTRIBUTE,
   processImages,
+  WIDTHS_ATTRIBUTE,
 } from "#transforms/images.js";
 import { loadDOM } from "#utils/lazy-dom.js";
 
@@ -71,12 +73,26 @@ describe("images transform", () => {
       expect(img.hasAttribute(ASPECT_RATIO_ATTRIBUTE)).toBe(false);
     });
 
-    test("extracts sizes and widths attributes", async () => {
+    test("extracts sizes and eleventy widths attributes", async () => {
       const { options } = await getImageOptions(
-        '<html><body><img src="/images/test.jpg" sizes="100vw" widths="300,600,900"></body></html>',
+        '<html><body><img src="/images/test.jpg" sizes="100vw" eleventy:widths="300,600,900"></body></html>',
       );
       expect(options.sizes).toBe("100vw");
       expect(options.widths).toBe("300,600,900");
+    });
+
+    test("falls back to legacy widths attributes", async () => {
+      const { options } = await getImageOptions(
+        '<html><body><img src="/images/test.jpg" widths="300,600,900"></body></html>',
+      );
+      expect(options.widths).toBe("300,600,900");
+    });
+
+    test("prefers eleventy widths over legacy widths attributes", async () => {
+      const { options } = await getImageOptions(
+        '<html><body><img src="/images/test.jpg" eleventy:widths="320,640" widths="300,600,900"></body></html>',
+      );
+      expect(options.widths).toBe("320,640");
     });
 
     test("returns null for missing attributes", async () => {
@@ -228,6 +244,8 @@ describe("images transform", () => {
 
     test("IGNORE_ATTRIBUTE is correct", () => {
       expect(IGNORE_ATTRIBUTE).toBe("eleventy:ignore");
+      expect(WIDTHS_ATTRIBUTE).toBe("eleventy:widths");
+      expect(LEGACY_WIDTHS_ATTRIBUTE).toBe("widths");
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Upgrade the site image tooling to the `eleventy-img` v7 alpha to match the upstream changes and remove the temporary GitHub fork reference.
- Adjust the internal image transform to be compatible with the new attribute conventions around widths so existing templates keep working.

### Description
- Update dependency from the GitHub fork to `@11ty/eleventy-img: 7.0.0-alpha.4` in `package.json` and `bun.lock`.
- Teach the image transform to read `eleventy:widths` and fall back to the legacy `widths` attribute by adding `WIDTHS_ATTRIBUTE` and `LEGACY_WIDTHS_ATTRIBUTE` and deriving `widths` from them in `src/_lib/transforms/images.js`.
- Export the new constants and update unit tests to cover: reading `eleventy:widths`, falling back to `widths`, and precedence when both are present in `test/unit/transforms/images.test.js`.
- Apply lightweight formatting changes to touched files and commit the updates.

### Testing
- Ran `bun test test/unit/transforms/images.test.js` and the unit tests for the images transform passed.
- Ran `bun run typecheck` (`tsc --noEmit`) and type checks passed.
- Attempted `bun add @11ty/eleventy-img@7.0.0-alpha.4` but the environment blocked registry/GitHub access with `403` so the install could not be verified in this CI environment.
- Ran `bun test test/unit/transforms/images.test.js test/integration/build/image.test.js` where unit tests passed but some integration image tests timed out in this environment (builds invoking Eleventy timed out or were blocked by network restrictions); several integration image tests did succeed before timeouts.
- Ran full `bun test` but the suite was blocked by a network policy when cloning the Pages CMS schema (`git clone` failed with `403`), so the entire test matrix could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d97ec4d70832d9181e92f065a1ccf)