### PR TITLE
Remove maxCacheSize from memoize

### DIFF
--- a/packages/js-toolkit/fp/memoize.js
+++ b/packages/js-toolkit/fp/memoize.js
@@ -6,7 +6,6 @@
  */
 import { buildReverseIndex } from "./grouping.js";
 
-const DEFAULT_MAX_CACHE_SIZE = 2000;
 /** @param {unknown[]} args @returns {string | number} */
 const DEFAULT_KEY_FN = (args) => /** @type {string | number} */ (args[0]);
 
@@ -18,26 +17,17 @@ const DEFAULT_KEY_FN = (args) => /** @type {string | number} */ (args[0]);
  * use memoizeByRef instead - it uses WeakMap for automatic cleanup.
  *
  * @param {Function} fn - Function to memoize
- * @param {{ cacheKey?: (args: unknown[]) => string | number, maxCacheSize?: number }} [options]
+ * @param {{ cacheKey?: (args: unknown[]) => string | number }} [options]
  * @returns {Function} Memoized function
  */
 const memoize = (fn, options = {}) => {
   const cache = new Map();
   const keyFn = options.cacheKey || DEFAULT_KEY_FN;
-  const maxSize = options.maxCacheSize ?? DEFAULT_MAX_CACHE_SIZE;
 
   /** @param {unknown[]} args */
   return (...args) => {
     const key = keyFn(args);
     if (cache.has(key)) return cache.get(key);
-
-    if (cache.size >= maxSize) {
-      throw new Error(
-        `Memoize cache exceeded ${maxSize} entries. This likely indicates a memory leak - ` +
-          "the function is being called with too many unique arguments. " +
-          "Consider using memoizeByRef for collection-based caching, or increase maxCacheSize if this is intentional.",
-      );
-    }
 
     const result = fn(...args);
     cache.set(key, result);

--- a/test/unit/toolkit/memoize.test.js
+++ b/test/unit/toolkit/memoize.test.js
@@ -2,24 +2,10 @@
  * Tests for js-toolkit memoize utilities
  */
 import { describe, expect, test } from "bun:test";
-import { dedupeAsync, memoize, memoizeByRef } from "#toolkit/fp/memoize.js";
+import { dedupeAsync, memoizeByRef } from "#toolkit/fp/memoize.js";
 
 /** Create a counter for tracking function calls in tests */
 const createCounter = () => ({ count: 0 });
-
-describe("memoize", () => {
-  test("throws error when cache exceeds maxCacheSize", () => {
-    const memoized = memoize((x) => x * 2, { maxCacheSize: 3 });
-
-    // Fill the cache to its limit
-    memoized(1);
-    memoized(2);
-    memoized(3);
-
-    // Next unique call should throw
-    expect(() => memoized(4)).toThrow("Memoize cache exceeded 3 entries");
-  });
-});
 
 describe("memoizeByRef", () => {
   test("caches result by object reference", () => {


### PR DESCRIPTION
## Summary

- Removes `DEFAULT_MAX_CACHE_SIZE` (2000) and the size-check throw from `memoize()`
- No production caller ever explicitly passed `maxCacheSize`, so the limit only applied as the default
- `getMetadata` (and all other `memoize` call sites) now cache unboundedly, which is correct for build-time caches keyed on unique file paths
- Removes the corresponding test and unused import

## Test plan

- [ ] `bun test test/unit/toolkit/memoize.test.js` — all 8 tests pass
- [ ] Full `bun test` to confirm no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_012rD6nX2m8t5obxFL6eFeAM)_