### PR TITLE
Quote cart: use design system for quantity controls and continue button

### DIFF
--- a/src/_includes/design-system/blocks/quote-cart.html
+++ b/src/_includes/design-system/blocks/quote-cart.html
@@ -19,7 +19,7 @@ Quote-only block. No block-level parameters.
       </div>
       <ul class="quote-cart-items"></ul>
       <div class="quote-cart-actions" style="display: none">
-        <a href="/checkout/" class="button">Continue to {{ quoteFields.steps[1].name }}</a>
+        <a href="/checkout/" class="btn btn--primary btn--lg">Continue to {{ quoteFields.steps[1].name }}</a>
       </div>
     </div>
 {%- include "quote-templates-tail.html" -%}

--- a/src/_includes/templates/cart.html
+++ b/src/_includes/templates/cart.html
@@ -21,7 +21,9 @@
         <span data-field="price"></span>
       </li>
       <li class="quote-cart-item-actions">
-        {% include "templates/quantity-controls.html" %}
+        <div class="item-quantity">
+          {% include "templates/quantity-controls.html" %}
+        </div>
         <button data-action="remove" data-name="">Remove</button>
       </li>
       <li class="quote-cart-item-subtitle" data-field="subtitle"></li>

--- a/src/css/design-system/_quote-cart.scss
+++ b/src/css/design-system/_quote-cart.scss
@@ -95,9 +95,9 @@
   }
 
   .quote-cart-actions {
-    justify-content: end;
+    display: flex;
+    justify-content: flex-end;
     margin-top: $space-md;
-    text-align: center;
     animation: quoteCartSlideIn 0.4s ease-out forwards;
   }
 


### PR DESCRIPTION
## Summary

- **Quantity controls**: wrap `QUOTE_CART_ITEM`'s quantity buttons in `.item-quantity` so the `-`/input/`+` group gets its connected border group styling — matching what `CART_ITEM` (Stripe cart) already did
- **Continue button**: change `class="button"` to `class="btn btn--primary btn--lg"` on the "Continue to Order Details" link so it picks up the design system's primary button styles
- **Actions container**: add `display: flex` to `.quote-cart-actions` so the existing `justify-content: flex-end` actually takes effect and the button right-aligns correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_014Tgw1D97EUkXXYskjYwM2t)_