### PR TITLE
Add monetary values to quote question answers

### DIFF
--- a/src/_data/quote-fields.json
+++ b/src/_data/quote-fields.json
@@ -53,6 +53,17 @@
           "note": "Select 'Other' if your event type is not listed"
         },
         {
+          "name": "delivery_zone",
+          "type": "radio",
+          "label": "Delivery Zone",
+          "options": [
+            { "label": "Zone A (0-10 miles)", "value": "Zone A", "price": 0 },
+            { "label": "Zone B (10-20 miles)", "value": "Zone B", "price": 25 },
+            { "label": "Zone C (20-30 miles)", "value": "Zone C", "price": 50 }
+          ],
+          "note": "Distance from our base in [Your Town]"
+        },
+        {
           "name": "event_location",
           "label": "Event Location",
           "placeholder": "Venue name and address",

--- a/src/_includes/form-field-radio.html
+++ b/src/_includes/form-field-radio.html
@@ -2,16 +2,19 @@
   <legend>{{ field.label }}</legend>
   <div class="radio-options">
     {%- for option in field.options -%}
+      {%- assign optLabel = option.label | default: option -%}
+      {%- assign optValue = option.value | default: optLabel -%}
       {%- assign optionId = field.name | append: "_" | append: forloop.index -%}
       <label>
         <input
           type="radio"
           id="{{ optionId }}"
           name="{{ field.name }}"
-          value="{{ option }}"
+          value="{{ optValue }}"
+          {%- if option.price %} data-price="{{ option.price }}"{% endif %}
           {%- if field.required and forloop.first %} required{%- endif %}
         />
-        {{ option }}
+        {{ optLabel }}
       </label>
     {%- endfor -%}
   </div>

--- a/src/_includes/form-field-select.html
+++ b/src/_includes/form-field-select.html
@@ -7,7 +7,9 @@
   >
     <option value="" disabled selected>Select an option</option>
     {%- for option in field.options -%}
-      <option value="{{ option }}">{{ option }}</option>
+      {%- assign optLabel = option.label | default: option -%}
+      {%- assign optValue = option.value | default: optLabel -%}
+      <option value="{{ optValue }}"{% if option.price %} data-price="{{ option.price }}"{% endif %}>{{ optLabel }}</option>
     {%- endfor -%}
   </select>
   {%- include "form-field-note.html" -%}

--- a/src/_includes/templates/quote-price.html
+++ b/src/_includes/templates/quote-price.html
@@ -33,5 +33,6 @@
   <li>
     <span data-field="key"></span>
     <span data-field="value"></span>
+    <span data-field="price"></span>
   </li>
 </template>

--- a/src/_lib/public/cart/quote-checkout.js
+++ b/src/_lib/public/cart/quote-checkout.js
@@ -81,16 +81,6 @@ const getDays = () => {
   return start && end ? calculateDays(start, end) : 1;
 };
 
-const setupFieldPriceHandlers = () => {
-  const formContainer = getFormContainer();
-  if (!formContainer) return;
-  formContainer.addEventListener("change", (event) => {
-    if (event.target.matches('select, input[type="radio"]')) {
-      populateForm(getDays());
-    }
-  });
-};
-
 const init = () => {
   const updateQuoteSummary = (days) => {
     populateForm(days);
@@ -100,8 +90,7 @@ const init = () => {
   if (Config.quote_type === "hire") {
     initHireCalculator(updateQuoteSummary);
   }
-  setupDetailsBlurHandlers(getDays);
-  setupFieldPriceHandlers();
+  setupDetailsBlurHandlers(getDays, populateForm);
 };
 
 onReady(init);

--- a/src/_lib/public/cart/quote-checkout.js
+++ b/src/_lib/public/cart/quote-checkout.js
@@ -5,7 +5,7 @@ import {
   calculateDays,
   initHireCalculator,
 } from "#public/cart/hire-calculator.js";
-import { getCart } from "#public/utils/cart-utils.js";
+import { formatPrice, getCart } from "#public/utils/cart-utils.js";
 import Config from "#public/utils/config.js";
 import { onReady } from "#public/utils/on-ready.js";
 import {
@@ -14,6 +14,8 @@ import {
   sanitizeItemName,
 } from "#public/utils/quote-checkout-pricing.js";
 import {
+  collectFieldDetails,
+  getFormContainer,
   setupDetailsBlurHandlers,
   updateQuotePrice,
 } from "#public/utils/quote-price-utils.js";
@@ -35,6 +37,18 @@ const renderCheckoutItem = (item, days) => {
   return template;
 };
 
+const buildAnswerPricesText = () => {
+  const details = collectFieldDetails(getFormContainer());
+  const priced = details.filter((d) => d.price !== null);
+  if (priced.length === 0) return "";
+  return (
+    "\n" +
+    priced
+      .map((d) => `${d.key}: ${d.value} (+${formatPrice(d.price)})`)
+      .join("\n")
+  );
+};
+
 const populateForm = (days) => {
   const cart = getCart();
   const cartItemsField = document.getElementById("cart-items");
@@ -51,8 +65,7 @@ const populateForm = (days) => {
 
   // Build text representation for the hidden field
   const cartText = cart.map((item) => buildCartText(item, days)).join("\n");
-
-  cartItemsField.value = cartText;
+  cartItemsField.value = cartText + buildAnswerPricesText();
 
   // Build visual summary
   itemsEl.replaceChildren(
@@ -68,6 +81,16 @@ const getDays = () => {
   return start && end ? calculateDays(start, end) : 1;
 };
 
+const setupFieldPriceHandlers = () => {
+  const formContainer = getFormContainer();
+  if (!formContainer) return;
+  formContainer.addEventListener("change", (event) => {
+    if (event.target.matches('select, input[type="radio"]')) {
+      populateForm(getDays());
+    }
+  });
+};
+
 const init = () => {
   const updateQuoteSummary = (days) => {
     populateForm(days);
@@ -78,6 +101,7 @@ const init = () => {
     initHireCalculator(updateQuoteSummary);
   }
   setupDetailsBlurHandlers(getDays);
+  setupFieldPriceHandlers();
 };
 
 onReady(init);

--- a/src/_lib/public/utils/quote-price-utils.js
+++ b/src/_lib/public/utils/quote-price-utils.js
@@ -63,7 +63,9 @@ const getFieldValue = (field) => {
 
 const parsePriceAttr = (el) => {
   const priceStr = el.getAttribute("data-price");
-  return priceStr !== null ? Number(priceStr) : null;
+  if (priceStr === null) return null;
+  const price = Number(priceStr);
+  return Number.isNaN(price) ? null : price;
 };
 
 const getSelectPrice = (field) => {

--- a/src/_lib/public/utils/quote-price-utils.js
+++ b/src/_lib/public/utils/quote-price-utils.js
@@ -61,20 +61,21 @@ const getFieldValue = (field) => {
   return field.value;
 };
 
+const parsePriceAttr = (el) => {
+  const priceStr = el.getAttribute("data-price");
+  return priceStr !== null ? Number(priceStr) : null;
+};
+
 const getSelectPrice = (field) => {
   const option = [...field.options].find((o) => o.selected);
-  if (!option) return null;
-  const priceStr = option.getAttribute("data-price");
-  return priceStr !== null ? Number(priceStr) : null;
+  return option ? parsePriceAttr(option) : null;
 };
 
 const getRadioPrice = (name) => {
   const checked = document.querySelector(
     `input[type="radio"][name="${name}"]:checked`,
   );
-  if (!checked) return null;
-  const priceStr = checked.getAttribute("data-price");
-  return priceStr !== null ? Number(priceStr) : null;
+  return checked ? parsePriceAttr(checked) : null;
 };
 
 const getFieldPrice = (field) => {
@@ -197,7 +198,7 @@ const updateQuotePrice = (days = 1) => {
   if (container) renderQuotePrice(container, days);
 };
 
-const setupDetailsBlurHandlers = (getDays = () => 1) => {
+const setupDetailsBlurHandlers = (getDays = () => 1, onFieldChange = null) => {
   const formContainer = getFormContainer();
   if (formContainer === null) return;
   const handleBlur = (event) => {
@@ -213,6 +214,7 @@ const setupDetailsBlurHandlers = (getDays = () => 1) => {
   formContainer.addEventListener("change", (event) => {
     if (event.target.matches('input[type="radio"], select')) {
       updateQuotePrice(getDays());
+      if (onFieldChange) onFieldChange(getDays());
     }
   });
 };

--- a/src/_lib/public/utils/quote-price-utils.js
+++ b/src/_lib/public/utils/quote-price-utils.js
@@ -28,12 +28,12 @@ const formatItemName = (item) =>
 const formatItemPrice = (price) =>
   price === null ? "TBC" : formatPrice(price);
 
-const calculateTotal = (cart, days) => {
+const calculateTotal = (cart, days, answerPricesTotal = 0) => {
   const prices = map(getPriceForDays(days))(cart);
   if (prices.includes(null)) {
     return { total: 0, canCalculate: false };
   }
-  return { total: sum(prices), canCalculate: true };
+  return { total: sum(prices) + answerPricesTotal, canCalculate: true };
 };
 
 const formatHireLength = pluralize("day");
@@ -61,6 +61,28 @@ const getFieldValue = (field) => {
   return field.value;
 };
 
+const getSelectPrice = (field) => {
+  const option = [...field.options].find((o) => o.selected);
+  if (!option) return null;
+  const priceStr = option.getAttribute("data-price");
+  return priceStr !== null ? Number(priceStr) : null;
+};
+
+const getRadioPrice = (name) => {
+  const checked = document.querySelector(
+    `input[type="radio"][name="${name}"]:checked`,
+  );
+  if (!checked) return null;
+  const priceStr = checked.getAttribute("data-price");
+  return priceStr !== null ? Number(priceStr) : null;
+};
+
+const getFieldPrice = (field) => {
+  if (isRadio(field)) return getRadioPrice(field.name);
+  if (isSelect(field)) return getSelectPrice(field);
+  return null;
+};
+
 const fieldLabel = (field) => getFieldLabels()[field.name || field.id];
 
 const getFieldId = (field) => (isRadio(field) ? field.name : field.id);
@@ -68,6 +90,7 @@ const getFieldId = (field) => (isRadio(field) ? field.name : field.id);
 const fieldToDetail = (field) => ({
   key: fieldLabel(field),
   value: getFieldValue(field),
+  price: getFieldPrice(field),
 });
 
 const collectFieldDetails = (container) => {
@@ -79,6 +102,11 @@ const collectFieldDetails = (container) => {
     map(fieldToDetail),
   )(fields);
 };
+
+const sumAnswerPrices = reduce(
+  (acc, d) => acc + (d.price !== null ? d.price : 0),
+  0,
+);
 
 const createItemElement = (item, days) => {
   const template = getTemplate(IDS.QUOTE_PRICE_ITEM, document);
@@ -101,6 +129,14 @@ const createDetailElement = (detail) => {
   const template = getTemplate(IDS.QUOTE_PRICE_DETAIL);
   template.querySelector('[data-field="key"]').textContent = detail.key;
   template.querySelector('[data-field="value"]').textContent = detail.value;
+  const priceEl = template.querySelector('[data-field="price"]');
+  if (priceEl) {
+    if (detail.price !== null) {
+      priceEl.textContent = `+${formatPrice(detail.price)}`;
+    } else {
+      priceEl.remove();
+    }
+  }
   return template;
 };
 
@@ -124,7 +160,13 @@ const renderQuotePrice = (container, days = 1) => {
   }
 
   const template = getTemplate(IDS.QUOTE_PRICE, document);
-  const { total, canCalculate } = calculateTotal(cart, days);
+
+  const details = collectFieldDetails(getFormContainer());
+  const { total, canCalculate } = calculateTotal(
+    cart,
+    days,
+    sumAnswerPrices(details),
+  );
   const itemCount = countItems(cart);
 
   template.querySelector('[data-field="item-count"]').textContent =
@@ -141,7 +183,6 @@ const renderQuotePrice = (container, days = 1) => {
   populateItems(itemsContainer, cart, days);
 
   const detailsContainer = template.querySelector('[data-field="details"]');
-  const details = collectFieldDetails(getFormContainer());
   populateDetails(detailsContainer, details);
   detailsContainer.parentElement.style.display =
     details.length === 0 ? "none" : "";
@@ -176,4 +217,9 @@ const setupDetailsBlurHandlers = (getDays = () => 1) => {
   });
 };
 
-export { setupDetailsBlurHandlers, updateQuotePrice };
+export {
+  collectFieldDetails,
+  getFormContainer,
+  setupDetailsBlurHandlers,
+  updateQuotePrice,
+};

--- a/src/_lib/public/utils/quote-price-utils.js
+++ b/src/_lib/public/utils/quote-price-utils.js
@@ -63,9 +63,7 @@ const getFieldValue = (field) => {
 
 const parsePriceAttr = (el) => {
   const priceStr = el.getAttribute("data-price");
-  if (priceStr === null) return null;
-  const price = Number(priceStr);
-  return Number.isNaN(price) ? null : price;
+  return priceStr !== null ? Number(priceStr) : null;
 };
 
 const getSelectPrice = (field) => {

--- a/test/unit/frontend/quote-price-utils.test.js
+++ b/test/unit/frontend/quote-price-utils.test.js
@@ -398,6 +398,105 @@ describe("quote-price-utils", () => {
       ).parentElement;
       expect(detailsParent.style.display).toBe("none");
     });
+
+    // ----------------------------------------
+    // Option answer price tests
+    // ----------------------------------------
+    describe("option answer prices", () => {
+      const getDetailPrice = (detail) =>
+        detail.querySelector('[data-field="price"]')?.textContent ?? "";
+
+      test("shows price for selected option with data-price", async () => {
+        await setupDOM(
+          [buyItem()],
+          `<select id="event_type" name="event_type">
+             <option value="">Choose...</option>
+             <option value="Wedding" data-price="200" selected>Wedding</option>
+           </select>`,
+        );
+        updateQuotePrice(1);
+        const details = getDetails();
+        expect(details).toHaveLength(1);
+        expect(getDetailPrice(details[0])).toBe("+£200");
+      });
+
+      test("adds select option price to the total", async () => {
+        await setupDOM(
+          [buyItem({ unit_price: 50 })],
+          `<select id="event_type" name="event_type">
+             <option value="Wedding" data-price="100" selected>Wedding</option>
+           </select>`,
+        );
+        updateQuotePrice(1);
+        expect(document.querySelector('[data-field="total"]').textContent).toBe(
+          "£150",
+        );
+      });
+
+      test("shows price for checked radio with data-price", async () => {
+        await setupDOM(
+          [buyItem()],
+          `<input type="radio" name="contact" value="Email" data-price="25" checked />
+           <input type="radio" name="contact" value="Phone" data-price="50" />`,
+        );
+        updateQuotePrice(1);
+        const details = getDetails();
+        expect(details).toHaveLength(1);
+        expect(getDetailPrice(details[0])).toBe("+£25");
+      });
+
+      test("adds radio option price to the total", async () => {
+        await setupDOM(
+          [buyItem({ unit_price: 100 })],
+          `<input type="radio" name="contact" value="Email" data-price="30" checked />
+           <input type="radio" name="contact" value="Phone" data-price="60" />`,
+        );
+        updateQuotePrice(1);
+        expect(document.querySelector('[data-field="total"]').textContent).toBe(
+          "£130",
+        );
+      });
+
+      test("omits price display for options without data-price", async () => {
+        await setupDOM(
+          [buyItem()],
+          `<select id="event_type" name="event_type">
+             <option value="Wedding" selected>Wedding</option>
+           </select>`,
+        );
+        updateQuotePrice(1);
+        const details = getDetails();
+        expect(details).toHaveLength(1);
+        expect(getDetailPrice(details[0])).toBe("");
+      });
+
+      test("sums multiple priced answers into the total", async () => {
+        await setupDOM(
+          [buyItem({ unit_price: 50 })],
+          `<select id="event_type" name="event_type">
+             <option value="Wedding" data-price="200" selected>Wedding</option>
+           </select>
+           <input type="radio" name="contact" value="Zone B" data-price="25" checked />`,
+        );
+        updateQuotePrice(1);
+        expect(document.querySelector('[data-field="total"]').textContent).toBe(
+          "£275",
+        );
+      });
+
+      test("total is TBC when cart item price unknown even with answer prices", async () => {
+        await setupDOM(
+          [cartItem({ hire_prices: { 2: "£50" } })],
+          `<select id="event_type" name="event_type">
+             <option value="Wedding" data-price="100" selected>Wedding</option>
+           </select>`,
+        );
+        updateQuotePrice(1); // No price for 1 day — cart item is TBC
+        expect(document.querySelector('[data-field="total"]').textContent).toBe(
+          "TBC",
+        );
+      });
+    });
   });
 
   // ----------------------------------------

--- a/test/unit/frontend/quote-price-utils.test.js
+++ b/test/unit/frontend/quote-price-utils.test.js
@@ -406,6 +406,13 @@ describe("quote-price-utils", () => {
       const getDetailPrice = (detail) =>
         detail.querySelector('[data-field="price"]')?.textContent ?? "";
 
+      const assertSingleDetailPrice = (expectedPrice) => {
+        updateQuotePrice(1);
+        const details = getDetails();
+        expect(details).toHaveLength(1);
+        expect(getDetailPrice(details[0])).toBe(expectedPrice);
+      };
+
       test("shows price for selected option with data-price", async () => {
         await setupDOM(
           [buyItem()],
@@ -414,10 +421,7 @@ describe("quote-price-utils", () => {
              <option value="Wedding" data-price="200" selected>Wedding</option>
            </select>`,
         );
-        updateQuotePrice(1);
-        const details = getDetails();
-        expect(details).toHaveLength(1);
-        expect(getDetailPrice(details[0])).toBe("+£200");
+        assertSingleDetailPrice("+£200");
       });
 
       test("adds select option price to the total", async () => {
@@ -439,10 +443,7 @@ describe("quote-price-utils", () => {
           `<input type="radio" name="contact" value="Email" data-price="25" checked />
            <input type="radio" name="contact" value="Phone" data-price="50" />`,
         );
-        updateQuotePrice(1);
-        const details = getDetails();
-        expect(details).toHaveLength(1);
-        expect(getDetailPrice(details[0])).toBe("+£25");
+        assertSingleDetailPrice("+£25");
       });
 
       test("adds radio option price to the total", async () => {
@@ -464,10 +465,7 @@ describe("quote-price-utils", () => {
              <option value="Wedding" selected>Wedding</option>
            </select>`,
         );
-        updateQuotePrice(1);
-        const details = getDetails();
-        expect(details).toHaveLength(1);
-        expect(getDetailPrice(details[0])).toBe("");
+        assertSingleDetailPrice("");
       });
 
       test("sums multiple priced answers into the total", async () => {


### PR DESCRIPTION
## Summary

- Select and radio options in `quote-fields.json` can now include a `price` field by using object syntax instead of plain strings
- When a priced option is selected, the price appears alongside the answer in the quote summary sidebar (e.g. `+£50`)
- Priced answers are added to the estimated total in the summary
- Priced answers are appended to the `cart_items` hidden field so they appear in the Formspark email (e.g. `Delivery Zone: Zone B (+£25)`)
- The `cart_items` hidden field is now re-populated whenever a select or radio field changes, keeping the email in sync

## How to use

Change an option from a plain string to an object with `label` and `price`:

```json
{
  "name": "delivery_zone",
  "type": "radio",
  "label": "Delivery Zone",
  "options": [
    { "label": "Zone A (0-10 miles)", "value": "Zone A", "price": 0 },
    { "label": "Zone B (10-20 miles)", "value": "Zone B", "price": 25 },
    { "label": "Zone C (20-30 miles)", "value": "Zone C", "price": 50 }
  ]
}
```

Plain string options (no price) continue to work unchanged — the feature is fully backwards-compatible.

## Files changed

- `src/_data/quote-fields.json` — added example delivery zone radio with prices
- `src/_includes/form-field-select.html` — renders `data-price` attribute on priced options
- `src/_includes/form-field-radio.html` — renders `data-price` attribute on priced radio inputs
- `src/_includes/templates/quote-price.html` — added `[data-field="price"]` span to the detail template
- `src/_lib/public/utils/quote-price-utils.js` — extracts prices from selected options, adds them to the total, shows them in details; exports `collectFieldDetails` and `getFormContainer`
- `src/_lib/public/cart/quote-checkout.js` — appends priced answers to `cart_items` email field; re-populates on field change
- `test/unit/frontend/quote-price-utils.test.js` — 7 new tests covering priced select/radio options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KU5YEa6RXD4fmmP6DQv5KZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KU5YEa6RXD4fmmP6DQv5KZ)_