### PR TITLE
Consolidate button rendering into design-system/button.html

### DIFF
--- a/src/_includes/design-system/blocks/link-button.html
+++ b/src/_includes/design-system/blocks/link-button.html
@@ -9,21 +9,17 @@ Parameters (via block object):
   - block.reveal: If set, adds data-reveal animation
 
 Embeddable form:
-  - text, href, variant, size, reveal: pass directly when sugar blocks need
-    to render a button without constructing a `block` object.
+  - text, href, variant, btn_size, reveal: pass directly when sugar blocks
+    need to render a button without constructing a `block` object.
 {%- endcomment -%}
 
 {%- assign _text = text | default: block.text -%}
 {%- assign _href = href | default: block.href -%}
-{%- assign _variant = variant | default: block.variant | default: "primary" -%}
-{%- assign _size = size | default: block.size -%}
+{%- assign _variant = variant | default: block.variant -%}
+{%- assign _size = btn_size | default: block.size -%}
 {%- assign _reveal = reveal | default: block.reveal -%}
 {%- if _text and _href -%}
-  {%- assign btnClass = "btn btn--" | append: _variant -%}
-  {%- if _size -%}
-    {%- assign btnClass = btnClass | append: " btn--" | append: _size -%}
-  {%- endif -%}
   <div class="link-button"{% if _reveal %} data-reveal="{{ _reveal }}"{% endif %}>
-    <a href="{{ _href }}" class="{{ btnClass }}">{{ _text }}</a>
+    {%- include "design-system/button.html", text: _text, href: _href, variant: _variant, btn_size: _size -%}
   </div>
 {%- endif -%}

--- a/src/_includes/design-system/blocks/menu-pdf-download.html
+++ b/src/_includes/design-system/blocks/menu-pdf-download.html
@@ -5,9 +5,7 @@ auto-derived from the menu page's computed `pdfFilename` data.
 
 {%- if pdfFilename -%}
   {%- assign menu_pdf_text = block.text | default: "Download PDF" -%}
-  {%- assign menu_pdf_variant = block.variant | default: "primary" -%}
-  {%- capture menu_pdf_class -%}btn btn--{{ menu_pdf_variant }}{%- if block.size %} btn--{{ block.size }}{%- endif -%}{%- endcapture -%}
   <div class="link-button"{% if block.reveal %} data-reveal="{{ block.reveal }}"{% endif %}>
-    <a href="{{ pdfFilename }}" class="{{ menu_pdf_class }}" download>{{ menu_pdf_text }}</a>
+    {%- include "design-system/button.html", text: menu_pdf_text, href: pdfFilename, variant: block.variant, btn_size: block.size, download: true -%}
   </div>
 {%- endif -%}

--- a/src/_includes/design-system/button.html
+++ b/src/_includes/design-system/button.html
@@ -1,0 +1,28 @@
+{%- comment -%}
+Button - the canonical `<a class="btn">` used across the design system.
+Every button-rendering block delegates here, so overriding this single file
+in a client template restyles (or re-markups) every button at once.
+
+Parameters (pass directly via include, or nest under a `button` object):
+  - text / button.text: Button label (required)
+  - href / button.href: Link URL or anchor (required)
+  - variant / button.variant: "primary", "secondary", or "ghost" (default: "primary")
+  - btn_size / button.size: "sm", "lg", or omit for default
+  - download / button.download: If truthy, adds the `download` attribute
+
+The direct size parameter is `btn_size`, not `size`: a bare Liquid variable
+named `size` collides with the magic `.size` (collection length) property and
+resolves to a number. For the same reason `.size` falls back to an object's
+key count when it has no `size` key, so only the known size values ("sm"/"lg")
+emit a size class.
+{%- endcomment -%}
+
+{%- assign _text = text | default: button.text -%}
+{%- assign _href = href | default: button.href -%}
+{%- assign _variant = variant | default: button.variant | default: "primary" -%}
+{%- assign _size = btn_size | default: button.size -%}
+{%- assign _download = download | default: button.download -%}
+{%- if _text and _href -%}
+  {%- capture _class -%}btn btn--{{ _variant }}{%- if _size == "sm" or _size == "lg" %} btn--{{ _size }}{%- endif -%}{%- endcapture -%}
+  <a href="{{ _href }}" class="{{ _class }}"{% if _download %} download{% endif %}>{{ _text }}</a>
+{%- endif -%}

--- a/src/_includes/design-system/hero-content.html
+++ b/src/_includes/design-system/hero-content.html
@@ -26,16 +26,7 @@ Usage:
 {%- if block.buttons.size > 0 -%}
   <div class="actions">
     {%- for button in block.buttons -%}
-      {%- assign variant = button.variant | default: "primary" -%}
-      {%- assign btnClass = "btn btn--" | append: variant -%}
-      {%- comment -%}
-        Liquid's `.size` falls back to the object's key count when the button
-        has no `size` key, so only append the class for known size values.
-      {%- endcomment -%}
-      {%- if button.size == "sm" or button.size == "lg" -%}
-        {%- assign btnClass = btnClass | append: " btn--" | append: button.size -%}
-      {%- endif -%}
-      <a href="{{ button.href }}" class="{{ btnClass }}">{{ button.text }}</a>
+      {%- include "design-system/button.html", button: button -%}
     {%- endfor -%}
   </div>
 {%- endif -%}


### PR DESCRIPTION
## What

Merges the duplicated `<a class="btn">` button markup that previously lived in both `link-button.html` and `hero-content.html` into a single, easily overrideable partial: **`src/_includes/design-system/button.html`**.

Every button-rendering block now delegates to it:

- `blocks/link-button.html` — wraps `button.html` in its `.link-button` div + reveal animation
- `hero-content.html` — renders each `block.buttons` entry via `button.html` (covers the hero block and the image/video background overlays)
- `blocks/menu-pdf-download.html` — delegates too, passing `download: true`

A client template can now restyle or re-markup **every** button by overriding one file, instead of editing each block individually.

## Notes

- The direct size parameter is named `btn_size`, not `size`. A bare Liquid variable named `size` collides with LiquidJS's magic `.size` (collection-length) property and resolves to a number, which silently dropped the size class. The object form still reads `button.size`, which is safe when the key is present.
- This also fixes a latent bug: `menu-pdf-download` previously emitted a bogus `btn--0` class when no size was set (it used `{% if block.size %}`, where `.size` falls back to the object's key count). The new shared guard only emits a class for the known `"sm"`/`"lg"` values.

## Testing

- `test/integration/eleventy/hero-content.test.js` — passes (asserts exact `btn btn--ghost btn--lg` classes and render order)
- `block-schema`, `unused-classes`, `html-in-js`, `block-docs` code-quality/unit tests — pass
- Verified all callers (`link-button` block form, embeddable form, `menu-pdf-download` with/without size) render identical markup to before, minus the `btn--0` fix
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nc3kWy2XNeYXdXJdjW46wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nc3kWy2XNeYXdXJdjW46wd)_