### PR TITLE
Fix button partial scope leak and route remaining blocks through it

### DIFF
--- a/src/_includes/design-system/blocks/cta.html
+++ b/src/_includes/design-system/blocks/cta.html
@@ -14,8 +14,11 @@ Parameters (via block object):
 <aside class="cta"{% if block.reveal %} data-reveal="{{ block.reveal }}"{% endif %}>
   <div class="prose">{{ block.content | renderContent: "md" }}</div>
   {%- if block.button -%}
-    {%- assign variant = block.button.variant | default: "secondary" -%}
-    {%- assign size = block.button.size | default: "lg" -%}
-    <a href="{{ block.button.href }}" class="btn btn--{{ variant }} btn--{{ size }}">{{ block.button.text }}</a>
+    {%- assign cta_variant = block.button.variant | default: "secondary" -%}
+    {%- assign cta_size = "lg" -%}
+    {%- if block.button.size == "sm" -%}
+      {%- assign cta_size = "sm" -%}
+    {%- endif -%}
+    {%- include "design-system/button.html", text: block.button.text, href: block.button.href, variant: cta_variant, btn_size: cta_size -%}
   {%- endif -%}
 </aside>

--- a/src/_includes/design-system/blocks/split-full.html
+++ b/src/_includes/design-system/blocks/split-full.html
@@ -16,8 +16,8 @@ Parameters (via block object):
     <div class="stack"{% if block.reveal_left %} data-reveal="{{ block.reveal_left }}"{% endif %}>
       <div class="prose">{{ block.left_content | renderContent: "md" }}</div>
       {%- if block.left_button -%}
-        {%- assign variant = block.left_button.variant | default: "secondary" -%}
-        <a href="{{ block.left_button.href }}" class="btn btn--{{ variant }}">{{ block.left_button.text }}</a>
+        {%- assign left_variant = block.left_button.variant | default: "secondary" -%}
+        {%- include "design-system/button.html", text: block.left_button.text, href: block.left_button.href, variant: left_variant -%}
       {%- endif -%}
     </div>
   </div>
@@ -25,8 +25,8 @@ Parameters (via block object):
     <div class="stack"{% if block.reveal_right %} data-reveal="{{ block.reveal_right }}"{% endif %}>
       <div class="prose">{{ block.right_content | renderContent: "md" }}</div>
       {%- if block.right_button -%}
-        {%- assign variant = block.right_button.variant | default: "secondary" -%}
-        <a href="{{ block.right_button.href }}" class="btn btn--{{ variant }}">{{ block.right_button.text }}</a>
+        {%- assign right_variant = block.right_button.variant | default: "secondary" -%}
+        {%- include "design-system/button.html", text: block.right_button.text, href: block.right_button.href, variant: right_variant -%}
       {%- endif -%}
     </div>
   </div>

--- a/src/_includes/design-system/button.html
+++ b/src/_includes/design-system/button.html
@@ -1,28 +1,26 @@
 {%- comment -%}
 Button - the canonical `<a class="btn">` used across the design system.
-Every button-rendering block delegates here, so overriding this single file
-in a client template restyles (or re-markups) every button at once.
+Button-rendering blocks delegate here, so overriding this single file in a
+client template restyles (or re-markups) every design-system button at once.
 
-Parameters (pass directly via include, or nest under a `button` object):
-  - text / button.text: Button label (required)
-  - href / button.href: Link URL or anchor (required)
-  - variant / button.variant: "primary", "secondary", or "ghost" (default: "primary")
-  - btn_size / button.size: "sm", "lg", or omit for default
-  - download / button.download: If truthy, adds the `download` attribute
+Parameters (pass as direct include arguments):
+  - text: Button label (required)
+  - href: Link URL or anchor (required)
+  - variant: "primary", "secondary", or "ghost" (default: "primary")
+  - btn_size: "sm", "lg", or omit for default
+  - download: If truthy, adds the `download` attribute
 
-The direct size parameter is `btn_size`, not `size`: a bare Liquid variable
-named `size` collides with the magic `.size` (collection length) property and
-resolves to a number. For the same reason `.size` falls back to an object's
-key count when it has no `size` key, so only the known size values ("sm"/"lg")
-emit a size class.
+Callers pass every field as an explicit argument so the include's own scope
+shadows any same-named variable leaking from the page/parent context.
+
+The size parameter is `btn_size`, not `size`: a bare Liquid variable named
+`size` collides with the magic `.size` (collection length) property and
+resolves to a number. Only the known size values ("sm"/"lg") emit a class, so
+an object's `.size` key-count fallback can never produce a bogus size class.
 {%- endcomment -%}
 
-{%- assign _text = text | default: button.text -%}
-{%- assign _href = href | default: button.href -%}
-{%- assign _variant = variant | default: button.variant | default: "primary" -%}
-{%- assign _size = btn_size | default: button.size -%}
-{%- assign _download = download | default: button.download -%}
-{%- if _text and _href -%}
-  {%- capture _class -%}btn btn--{{ _variant }}{%- if _size == "sm" or _size == "lg" %} btn--{{ _size }}{%- endif -%}{%- endcapture -%}
-  <a href="{{ _href }}" class="{{ _class }}"{% if _download %} download{% endif %}>{{ _text }}</a>
+{%- assign _variant = variant | default: "primary" -%}
+{%- if text and href -%}
+  {%- capture _class -%}btn btn--{{ _variant }}{%- if btn_size == "sm" or btn_size == "lg" %} btn--{{ btn_size }}{%- endif -%}{%- endcapture -%}
+  <a href="{{ href }}" class="{{ _class }}"{% if download %} download{% endif %}>{{ text }}</a>
 {%- endif -%}

--- a/src/_includes/design-system/hero-content.html
+++ b/src/_includes/design-system/hero-content.html
@@ -26,7 +26,7 @@ Usage:
 {%- if block.buttons.size > 0 -%}
   <div class="actions">
     {%- for button in block.buttons -%}
-      {%- include "design-system/button.html", button: button -%}
+      {%- include "design-system/button.html", text: button.text, href: button.href, variant: button.variant, btn_size: button.size -%}
     {%- endfor -%}
   </div>
 {%- endif -%}

--- a/src/_includes/design-system/split-article.html
+++ b/src/_includes/design-system/split-article.html
@@ -18,6 +18,6 @@ Parameters (direct):
   <div class="prose">{{ block.content | renderContent: "md" }}</div>
   {%- if block.button -%}
     {%- assign btn_variant = block.button.variant | default: "secondary" -%}
-    <a href="{{ block.button.href }}" class="btn btn--{{ btn_variant }}">{{ block.button.text }}</a>
+    {%- include "design-system/button.html", text: block.button.text, href: block.button.href, variant: btn_variant -%}
   {%- endif -%}
 </article>

--- a/test/integration/eleventy/hero-content.test.js
+++ b/test/integration/eleventy/hero-content.test.js
@@ -46,6 +46,19 @@ const getSite = useSharedSite({
       }),
     ),
     pageWithBlock("overlay-media-only", imageBackground({})),
+    {
+      // Page-level `text`/`href`/`variant` data must not leak into the
+      // button partial and override each hero button's own fields.
+      path: "pages/hero-leak.md",
+      frontmatter: {
+        name: "hero-leak",
+        permalink: "/hero-leak/",
+        text: "LEAKED",
+        href: "/leaked/",
+        variant: "danger",
+        blocks: [{ type: "hero", content: "# Heading", buttons: BUTTONS }],
+      },
+    },
   ],
 });
 
@@ -67,6 +80,19 @@ describe("hero block", () => {
     expect(buttons.length).toBe(2);
     expect(buttons[0].className).toBe("btn btn--primary");
     expect(buttons[0].getAttribute("href")).toBe("/go/");
+    expect(buttons[1].className).toBe("btn btn--ghost btn--lg");
+  });
+
+  test("hero buttons ignore page-level text/href/variant data", async () => {
+    const doc = await getSite().getDoc("hero-leak/index.html");
+    const buttons = doc.querySelectorAll("header.hero .actions a.btn");
+    expect(buttons.length).toBe(2);
+    // Each button keeps its own fields despite the page exposing top-level
+    // `text` ("LEAKED"), `href` ("/leaked/"), and `variant` ("danger").
+    expect(buttons[0].textContent).toBe("Primary Action");
+    expect(buttons[0].getAttribute("href")).toBe("/go/");
+    expect(buttons[0].className).toBe("btn btn--primary");
+    expect(buttons[1].textContent).toBe("Ghost Action");
     expect(buttons[1].className).toBe("btn btn--ghost btn--lg");
   });
 });


### PR DESCRIPTION
Follow-up to #1460 (button consolidation), addressing two valid review findings.

## 1. Fix scope-leak in hero buttons (correctness bug)

`hero-content.html` passed `button: button` to `button.html`, and the partial read the direct `text`/`href`/`variant` variables *before* the object fields. Because Liquid includes inherit the parent/page scope, any page exposing a top-level `text`, `href`, or `variant` value (e.g. from front matter) leaked in and overrode **every** hero button.

Reproduced before the fix:

```
ctx: { text: "LEAKED", variant: "danger", buttons: [{ text: "Real", href: "/r/", variant: "ghost" }] }
→ <a href="/r/" class="btn btn--danger">LEAKED</a>   ❌
```

`button.html` is now **direct-argument-only** (no object-form fallback), and every caller passes explicit field arguments, so the include's own scope shadows any same-named page/parent variable. Verified the same input now renders the button's own `text`/`variant`.

## 2. Route cta / split-article / split-full through the partial (coverage)

These three blocks still hand-rolled their own `<a class="btn ...">` markup, so overriding `button.html` would not have restyled them — the "override one file" contract was overstated. They now delegate to the partial too, **preserving their existing defaults** (cta: `secondary` + `lg`; splits: `secondary`, no size). Output is byte-for-byte identical to before for all valid inputs.

## Testing

- Added a regression test in `hero-content.test.js` asserting hero buttons ignore page-level `text`/`href`/`variant` data.
- `hero-content` integration suite, `block-schema`, `unused-classes`, `html-in-js`, `block-docs` — all pass.
- Verified cta/split-article/split-full render identical markup to the pre-change templates (default + size/variant overrides).
- `bun run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nc3kWy2XNeYXdXJdjW46wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nc3kWy2XNeYXdXJdjW46wd)_