### PR TITLE
Wrap guide feature block text in prose wrapper

### DIFF
--- a/src/_includes/design-system/blocks/property-guides.html
+++ b/src/_includes/design-system/blocks/property-guides.html
@@ -19,7 +19,7 @@ Property-only block. No block-level parameters.
         {%- endif -%}
         <h3><a href="{{ category.url }}">{{ category.data.name }}</a></h3>
         {%- if category.data.subtitle -%}
-          <p>{{ category.data.subtitle }}</p>
+          <div class="prose"><p>{{ category.data.subtitle }}</p></div>
         {%- endif -%}
       </article>
     </li>


### PR DESCRIPTION
## Summary

The `property-guides` block is styled as a feature grid (`ul.features` / `article.feature`), mirroring `features.html`. However, it rendered its subtitle text in a bare `<p>` element, whereas the standard features block wraps text content in a `<div class="prose">`.

This change wraps the guide category subtitle in a `div.prose` element so the guide feature block matches the typography of other feature blocks.

## Changes

- `src/_includes/design-system/blocks/property-guides.html` — wrap the category subtitle in `<div class="prose">`.

## Testing

- `bun test test/unit/code-quality/block-markdown-rendering.test.js` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrEEpNoNANs1qHdBoTRBqA)_