### PR TITLE
Restore product/property page headings via markdown blocks

### DIFF
--- a/src/products/classic-wotzit-wrapper.md
+++ b/src/products/classic-wotzit-wrapper.md
@@ -31,6 +31,11 @@ features:
   - "Available in azure, obsidian, and silver"
 
 blocks:
+  - type: markdown
+    content: |
+      # Classic Wotzit Wrapper
+
+      ## Timeless structured wrapper for formal occasions
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/doggy-day-care.md
+++ b/src/products/doggy-day-care.md
@@ -42,6 +42,11 @@ categories:
   - compact-doodahs
 
 blocks:
+  - type: markdown
+    content: |
+      # Doggy Day Care
+
+      ## Professional pet care while you're away
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/doodah-pro-enterprise.md
+++ b/src/products/doodah-pro-enterprise.md
@@ -27,6 +27,11 @@ features:
 stripe_url: 'https://buy.stripe.com/example'
 
 blocks:
+  - type: markdown
+    content: |
+      # Doodah Pro Enterprise Edition
+
+      ## Industrial-grade doodah for commercial applications
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/eleventy.md
+++ b/src/products/eleventy.md
@@ -22,6 +22,11 @@ features:
   - Low resource hosting requirements
 
 blocks:
+  - type: markdown
+    content: |
+      # Eleventy
+
+      ## The Chobble Template is built with the Eleventy static site generator
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/heritage-thingy-deluxe.md
+++ b/src/products/heritage-thingy-deluxe.md
@@ -33,6 +33,11 @@ features:
   - Includes presentation box
 
 blocks:
+  - type: markdown
+    content: |
+      # Heritage Thingy Deluxe
+
+      ## Handcrafted classic thingy with timeless appeal
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/mini-gizmo.md
+++ b/src/products/mini-gizmo.md
@@ -36,6 +36,11 @@ categories:
   - src/categories/compact-doodahs.md
 
 blocks:
+  - type: markdown
+    content: |
+      # Mini Gizmo with Local Image
+
+      ## This gizmo uses a local image file path
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/pagescms-integration.md
+++ b/src/products/pagescms-integration.md
@@ -13,6 +13,11 @@ features:
   - Support for all content types (pages, products, categories, etc.)
 
 blocks:
+  - type: markdown
+    content: |
+      # PagesCMS Integration
+
+      ## Integrates with the free and customisable PagesCMS editor
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/pocket-doodah-mini.md
+++ b/src/products/pocket-doodah-mini.md
@@ -32,6 +32,11 @@ features:
   - IPX4 water resistance
 
 blocks:
+  - type: markdown
+    content: |
+      # Pocket Doodah Mini
+
+      ## Ultra-portable doodah for everyday carry
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/pocketgizmo-x1.md
+++ b/src/products/pocketgizmo-x1.md
@@ -26,6 +26,11 @@ features:
   - Identity recognition
 
 blocks:
+  - type: markdown
+    content: |
+      # PocketGizmo X1
+
+      ## Premium pocket gizmo with advanced vision system
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/smarthingy-ai-plus.md
+++ b/src/products/smarthingy-ai-plus.md
@@ -42,6 +42,11 @@ features:
   - Automatic software updates
 
 blocks:
+  - type: markdown
+    content: |
+      # SmarThingy AI Plus
+
+      ## Next-generation AI-powered thingy with cloud connectivity
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/smarthingy-home-hub.md
+++ b/src/products/smarthingy-home-hub.md
@@ -35,6 +35,11 @@ features:
 stripe_url: 'https://buy.stripe.com/example'
 
 blocks:
+  - type: markdown
+    content: |
+      # SmarThingy Home Hub
+
+      ## Central command center for your smart thingy ecosystem
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/thingy-classic-original.md
+++ b/src/products/thingy-classic-original.md
@@ -26,6 +26,11 @@ features:
   - Collector's manual included
 
 blocks:
+  - type: markdown
+    content: |
+      # Thingy Classic Original
+
+      ## The original thingy design that started it all
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/ultra-compact-doodah.md
+++ b/src/products/ultra-compact-doodah.md
@@ -32,6 +32,11 @@ features:
   - Multi-function indicator lights
 
 blocks:
+  - type: markdown
+    content: |
+      # Ultra Compact Doodah X5
+
+      ## Pocket-sized doodah with maximum efficiency
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/products/ultrawidget-pro.md
+++ b/src/products/ultrawidget-pro.md
@@ -49,6 +49,11 @@ add_ons:
     - name: Wireless Charging Pad
       price: 49.99
 blocks:
+  - type: markdown
+    content: |
+      # UltraWidget Pro
+
+      ## Lightweight, powerful widget for professionals
   - type: snippet
     reference: product-intro
   - type: markdown

--- a/src/properties/city-apartment.md
+++ b/src/properties/city-apartment.md
@@ -34,6 +34,13 @@ faqs:
     order: 2
 
 blocks:
+  - type: markdown
+    content: |
+      # City Centre Apartment
+
+      ## Modern 1-bedroom apartment in the heart of town
+
+      From £95 per night
   - type: freetobook
   - type: property-gallery
   - type: property-content

--- a/src/properties/mountain-lodge.md
+++ b/src/properties/mountain-lodge.md
@@ -35,6 +35,13 @@ faqs:
     order: 2
 
 blocks:
+  - type: markdown
+    content: |
+      # Mountain Lodge
+
+      ## Spacious 4-bedroom lodge with stunning mountain views
+
+      From £280 per night
   - type: freetobook
   - type: property-gallery
   - type: property-content

--- a/src/properties/seaside-cottage.md
+++ b/src/properties/seaside-cottage.md
@@ -35,6 +35,13 @@ faqs:
     order: 2
 
 blocks:
+  - type: markdown
+    content: |
+      # Seaside Cottage
+
+      ## Charming 2-bedroom retreat with ocean views
+
+      From £150 per night
   - type: freetobook
   - type: property-gallery
   - type: property-content


### PR DESCRIPTION
## Summary

Follow-up to #1465, which removed the `product-header` and `property-header` blocks. That change left the starter product and property detail pages with no on-page `<h1>` title (and properties also lost the nightly-price line), as flagged in the automated review.

This restores those headings using **static `markdown` blocks**, per the requested approach.

## Why markdown blocks (and why per-page)

The deleted header blocks read `name` / `subtitle` / `price_per_night` directly from each page's data. The `markdown` block renders its content through `renderContent: "md"`, which runs with `accessGlobalData: false` — so `{{ name }}` inside a markdown block can't resolve page data. The shared `product-intro` snippet therefore can't produce per-product titles, so each page gets its own markdown block with the title written in.

## Changes

- **Products** (14 files): a `# name` / `## subtitle` markdown block is now the first block on each product page
- **Properties** (3 files): same, plus a `From <price> per night` line (e.g. `From £280 per night`, matching the previous `to_price` formatting for whole GBP amounts)

## Verification

- `bun run build` succeeds; every product/property detail page now renders exactly one `<h1>` plus the `<h2>` subtitle, and property pages show the nightly price
- Full test suite passes (3238 tests, 0 failures)
- `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0154J6QL9XbX8oCdTjmqvWSg)_