### PR TITLE
Fix gallery current image sizing by keeping max-width constraint

### DIFF
--- a/src/_includes/gallery-current-image.html
+++ b/src/_includes/gallery-current-image.html
@@ -8,6 +8,6 @@
     data-index="1"
     aria-label="Open image gallery"
   >
-    {% image image, alt_text, "", "", "", "", "", false, true %}
+    {% image image, alt_text %}
   </a>
 </div>

--- a/src/_includes/gallery-full-size-images.html
+++ b/src/_includes/gallery-full-size-images.html
@@ -2,7 +2,7 @@
   {%- for image in gallery -%}
     {%- capture alt_text -%}{%- include "get-alt-text.html" -%}{%- endcapture -%}
     <div class="full-image-{{ forloop.index }}">
-      {% image image, alt_text, "", "fade-in", "", "", "", false, true %}
+      {% image image, alt_text, "", "fade-in" %}
     </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Problem

Since the fullscreen image popup gallery was added (#1464), the `.design-system` gallery hero image sometimes rendered small and did not recalculate its size until a thumbnail was clicked.

## Cause

The gallery current image was rendered with `skipMaxWidth=true`:

```liquid
{% image image, alt_text, "", "", "", "", "", false, true %}
```

That drops the wrapper's `max-width: min(<intrinsicWidth>px, 100%)` style (`buildImageWrapperStyles`, `image-utils.js:122`). Every image also gets `sizes="auto"` + `loading="lazy"` by default. `sizes="auto"` resolves the srcset candidate from the element's rendered layout width **once, at lazy-load time**, and never recomputes on later reflows. With no width constraint and a collapsed container at load time, the browser picked the smallest srcset candidate and stayed small until a thumbnail click forced a reflow/`src` swap.

`skipMaxWidth` is intended for background images, not the gallery hero.

## Fix

Drop the `skipMaxWidth` argument (all trailing args were defaults) so the hero image keeps its `max-width` constraint and sizes correctly on first paint:

```liquid
{% image image, alt_text %}
```

This addresses the root cause rather than pinning the container to a fixed `width: 800px`.

## Testing

- `bun run build` succeeds
- `bun test test/unit/ui/gallery.test.js test/unit/ui/image-popup.test.js` — 52 pass
- `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016nYYLBJbpb9NdVjWJkkHR8)_