### PR TITLE
[codex] fix mobile nav scrolling

### DIFF
--- a/src/css/_nav-mixins.scss
+++ b/src/css/_nav-mixins.scss
@@ -214,23 +214,31 @@
   position: fixed;
   top: 3rem;
   right: -100%;
+  bottom: 0;
 
-  overflow-y: scroll;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
   display: flex;
   flex-direction: column;
   gap: $gap;
 
+  box-sizing: border-box;
   width: 70%;
   max-width: 300px;
-  height: calc(100vh - 3rem);
+  height: auto;
+  max-height: calc(100vh - 3rem);
+  max-height: calc(100dvh - 3rem);
   margin: 0;
   padding: $gap;
+  padding-bottom: calc(#{$gap} + env(safe-area-inset-bottom));
 
   list-style: none;
 
   background: var(--color-bg);
 
   transition: right $transition;
+
+  -webkit-overflow-scrolling: touch;
 
   .toggle-label {
     display: block;

--- a/test/unit/build/scss.test.js
+++ b/test/unit/build/scss.test.js
@@ -274,6 +274,22 @@ describe("scss", () => {
     expect(tableRule).toContain("margin: 0");
   });
 
+  test("Design-system mobile navigation panel supports scrolling overflow", async () => {
+    const result = await compileDesignSystemBundle();
+    const menuRule =
+      result.match(
+        /\.design-system\.sticky-mobile-nav nav > ul\s*\{[^}]*\}/,
+      )?.[0] ?? "";
+
+    expect(menuRule).toContain("bottom: 0");
+    expect(menuRule).toContain("overflow-y: auto");
+    expect(menuRule).toContain("overscroll-behavior-y: contain");
+    expect(menuRule).toContain("box-sizing: border-box");
+    expect(menuRule).toContain("height: auto");
+    expect(menuRule).toContain("max-height: calc(100dvh - 3rem)");
+    expect(menuRule).toContain("-webkit-overflow-scrolling: touch");
+  });
+
   test("Design-system bundle defines default link decoration tokens", async () => {
     const result = await compileDesignSystemBundle();
     const linkRule =


### PR DESCRIPTION
## Summary

Fixes the mobile sticky navigation panel so long menus can be scrolled all the way to the bottom on mobile browsers.

The panel now anchors to the viewport bottom, uses dynamic viewport height as a fallback-aware maximum, keeps padding inside the scroll container, and enables touch momentum scrolling. This addresses mobile browser viewport chrome and safe-area cases where `100vh` could leave lower navigation items unreachable.

## Validation

- `bun test test/unit/build/scss.test.js`
- `bunx stylelint src/css/_nav-mixins.scss`
- `bun scripts/biome.js check test/unit/build/scss.test.js`
- `bun test/precommit.js` via commit hook