### PR TITLE
Improve generated SEO metadata

### DIFF
--- a/.forgejo/workflows/build-and-deploy.yaml
+++ b/.forgejo/workflows/build-and-deploy.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Build with Bun
         run: |
           bun install
-          bun ./node_modules/@11ty/eleventy/cmd.cjs
+          bun run build
 
       - name: Deploy to neocities
         # uses: bcomnes/deploy-to-neocities@v3

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"#toolkit/*": "./packages/js-toolkit/*"
 	},
 	"scripts": {
-		"build": "rm -rf _site && bun scripts/eleventy-build.js",
+		"build": "rm -rf _site && bun scripts/eleventy-build.js && bun run check:links",
 		"serve": "rm -rf _site && bun scripts/eleventy-build.js --serve --incremental",
 		"test": "bun ./test/run-tests.js",
 		"test:unit": "bun test test/unit",
@@ -46,7 +46,8 @@
 		"generate-cms-types": "bun scripts/generate-pages-cms-types.js",
 		"generate-blocks-reference": "bun scripts/generate-blocks-reference.js",
 		"screenshot": "bun scripts/screenshot.js",
-		"lighthouse": "bun scripts/lighthouse.js"
+		"lighthouse": "bun scripts/lighthouse.js",
+		"check:links": "bun scripts/check-internal-links.js _site"
 	},
 	"devDependencies": {
 		"11ty.ts": "^0.0.7",

--- a/scripts/check-internal-links.js
+++ b/scripts/check-internal-links.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env bun
+
+import path from "node:path";
+import { runInternalLinkCheck } from "#scripts/internal-links.js";
+
+const outputDir = path.resolve(process.argv[2] || "_site");
+process.exit(runInternalLinkCheck(outputDir));

--- a/scripts/internal-links.js
+++ b/scripts/internal-links.js
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { tokenize } from "@nfrasser/simple-html-tokenizer";
+
+const INTERNAL_ORIGIN = "https://internal.invalid";
+const URI_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+const listFiles = (rootDir) => [
+  ...new Bun.Glob("**/*").scanSync({ cwd: rootDir, onlyFiles: true }),
+];
+
+const getAttribute = (token, name) =>
+  token.attributes.find(([attribute]) => attribute.toLowerCase() === name)?.[1];
+
+const isRedirectDocument = (tokens) =>
+  tokens.some(
+    (token) =>
+      token.type === "StartTag" &&
+      token.tagName === "meta" &&
+      getAttribute(token, "http-equiv")?.toLowerCase() === "refresh",
+  );
+
+const shouldSkipHref = (href) =>
+  !href ||
+  href.includes("?") ||
+  href.includes("#") ||
+  href.startsWith("//") ||
+  URI_SCHEME.test(href);
+
+const getInternalHrefs = (tokens) => {
+  return tokens.flatMap((token) => {
+    if (token.type !== "StartTag") return [];
+    const href = getAttribute(token, "href");
+    return shouldSkipHref(href) ? [] : [href];
+  });
+};
+
+const resolveTarget = (source, href) => {
+  const url = new URL(href, `${INTERNAL_ORIGIN}/${source}`);
+  return decodeURIComponent(url.pathname).replace(/^\/+/, "");
+};
+
+const targetExists = (files, target) =>
+  files.has(target) || files.has(path.posix.join(target, "index.html"));
+
+const checkHtmlFile = (outputDir, files, source) => {
+  const html = readFileSync(path.join(outputDir, source), "utf8");
+  const tokens = tokenize(html);
+  if (isRedirectDocument(tokens)) return [];
+  return getInternalHrefs(tokens)
+    .map((href) => ({ source, href, target: resolveTarget(source, href) }))
+    .filter(({ target }) => !targetExists(files, target));
+};
+
+export const findBrokenInternalLinks = (outputDir) => {
+  if (!existsSync(outputDir)) {
+    throw new Error(`Generated site directory does not exist: ${outputDir}`);
+  }
+  const files = new Set(listFiles(outputDir));
+  return [...files]
+    .filter((file) => file.endsWith(".html"))
+    .flatMap((source) => checkHtmlFile(outputDir, files, source))
+    .sort(
+      (first, second) =>
+        first.source.localeCompare(second.source) ||
+        first.href.localeCompare(second.href),
+    );
+};
+
+export const formatBrokenInternalLink = ({ source, href, target }) =>
+  `${source}: ${href} -> ${target || "index.html"}`;
+
+export const runInternalLinkCheck = (outputDir, output = console) => {
+  const failures = findBrokenInternalLinks(outputDir);
+  if (failures.length === 0) {
+    output.log("Internal link check passed");
+    return 0;
+  }
+  output.error(
+    `Broken internal links:\n${failures.map(formatBrokenInternalLink).join("\n")}`,
+  );
+  return 1;
+};

--- a/scripts/internal-links.js
+++ b/scripts/internal-links.js
@@ -21,11 +21,7 @@ const isRedirectDocument = (tokens) =>
   );
 
 const shouldSkipHref = (href) =>
-  !href ||
-  href.includes("?") ||
-  href.includes("#") ||
-  href.startsWith("//") ||
-  URI_SCHEME.test(href);
+  !href || href.startsWith("//") || URI_SCHEME.test(href);
 
 const getInternalHrefs = (tokens) => {
   return tokens.flatMap((token) => {
@@ -37,7 +33,7 @@ const getInternalHrefs = (tokens) => {
 
 const resolveTarget = (source, href) => {
   const url = new URL(href, `${INTERNAL_ORIGIN}/${source}`);
-  return decodeURIComponent(url.pathname).replace(/^\/+/, "");
+  return url.pathname.replace(/^\/+/, "");
 };
 
 const targetExists = (files, target) =>
@@ -56,10 +52,13 @@ export const findBrokenInternalLinks = (outputDir) => {
   if (!existsSync(outputDir)) {
     throw new Error(`Generated site directory does not exist: ${outputDir}`);
   }
-  const files = new Set(listFiles(outputDir));
-  return [...files]
+  const outputFiles = listFiles(outputDir);
+  const targets = new Set(
+    outputFiles.flatMap((file) => [file, encodeURI(file)]),
+  );
+  return outputFiles
     .filter((file) => file.endsWith(".html"))
-    .flatMap((source) => checkHtmlFile(outputDir, files, source))
+    .flatMap((source) => checkHtmlFile(outputDir, targets, source))
     .sort(
       (first, second) =>
         first.source.localeCompare(second.source) ||

--- a/scripts/strict-typecheck-ratchet.js
+++ b/scripts/strict-typecheck-ratchet.js
@@ -14,7 +14,7 @@ import { spawnSync } from "node:child_process";
 import { ROOT_DIR } from "#lib/paths.js";
 
 // Current baseline - lower this as you fix errors
-const CURRENT_ERROR_COUNT = 367;
+const CURRENT_ERROR_COUNT = 366;
 
 // Files that currently pass strict mode (must not regress)
 const STRICT_CLEAN_FILES = [

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -12,6 +12,7 @@ import {
   buildOrganizationMeta,
   buildPostMeta,
   buildProductMeta,
+  buildSocialMeta,
 } from "#utils/schema-helper.js";
 import { collectItemErrors } from "#utils/validate-item.js";
 import { getVideoThumbnailUrl } from "#utils/video.js";
@@ -190,6 +191,12 @@ export default {
     if (data.no_index) return {};
     return data.metaComputed ?? {};
   },
+
+  /**
+   * @param {import("#lib/types").EleventyComputedData} data - Page data
+   * @returns {Record<string, unknown>} Open Graph and Twitter metadata
+   */
+  socialMeta: (data) => buildSocialMeta(data),
 
   /**
    * @param {import("#lib/types").EleventyComputedData} data - Page data

--- a/src/_includes/head-meta.html
+++ b/src/_includes/head-meta.html
@@ -6,13 +6,13 @@
 >
 
 <title>
-  {{- meta_title | default: name | default: title | escape -}}
+  {{- socialMeta.title | escape -}}
 </title>
 
-{%- if meta_description -%}
+{%- if socialMeta.description -%}
   <meta
     name="description"
-    content="{{ meta_description }}"
+    content="{{ socialMeta.description | escape }}"
   >
 {%- endif -%}
 
@@ -24,11 +24,33 @@
 {%- if no_index -%}
   <meta
     name="robots"
-    value="noindex,nofollow"
+    content="noindex,nofollow"
   >
 {%- else -%}
   <link
     rel="canonical"
-    href="{{ page.url | canonicalUrl }}"
+    href="{{ socialMeta.url | escape }}"
   >
+{%- endif -%}
+
+<meta property="og:type" content="{{ socialMeta.type | escape }}">
+<meta property="og:title" content="{{ socialMeta.title | escape }}">
+{%- if socialMeta.description -%}
+  <meta property="og:description" content="{{ socialMeta.description | escape }}">
+{%- endif -%}
+<meta property="og:url" content="{{ socialMeta.url | escape }}">
+{%- if socialMeta.image -%}
+  <meta property="og:image" content="{{ socialMeta.image | escape }}">
+{%- endif -%}
+
+<meta
+  name="twitter:card"
+  content="{% if socialMeta.image %}summary_large_image{% else %}summary{% endif %}"
+>
+<meta name="twitter:title" content="{{ socialMeta.title | escape }}">
+{%- if socialMeta.description -%}
+  <meta name="twitter:description" content="{{ socialMeta.description | escape }}">
+{%- endif -%}
+{%- if socialMeta.image -%}
+  <meta name="twitter:image" content="{{ socialMeta.image | escape }}">
 {%- endif -%}

--- a/src/_includes/head-schema.html
+++ b/src/_includes/head-schema.html
@@ -12,5 +12,9 @@
 {%- endif -%}
 
 {%- unless no_index -%}
-  {% jsonLdScript metaComputed, schemaType, tags %}
+  {%- assign schemaMeta = meta | withSchemaBreadcrumbs: config.show_breadcrumbs, page, name, navigationParent, parent, categories, collections, property, parentGuideCategory -%}
+  {%- if schemaType == "post" and author -%}
+    {%- assign schemaMeta = schemaMeta | withSchemaAuthor: author, collections.team -%}
+  {%- endif -%}
+  {% jsonLdScript schemaMeta, schemaType, tags %}
 {%- endunless -%}

--- a/src/_lib/eleventy/breadcrumbs.js
+++ b/src/_lib/eleventy/breadcrumbs.js
@@ -11,6 +11,7 @@
 
 import strings from "#data/strings.js";
 import { getBySlug } from "#eleventy/collection-lookup.js";
+import { canonicalUrl } from "#utils/canonical-url.js";
 
 /** Mapping from navigation parent names to their index URLs */
 const PARENT_URL_MAP = {
@@ -224,14 +225,37 @@ const breadcrumbsFilter = (
 };
 
 /**
+ * @param {Record<string, unknown>} meta
+ * @param {boolean} showBreadcrumbs
+ * @param {...any} breadcrumbArgs - Arguments forwarded to breadcrumbsFilter
+ * @returns {Record<string, unknown>}
+ */
+const withSchemaBreadcrumbs = (meta, showBreadcrumbs, ...breadcrumbArgs) => {
+  if (!showBreadcrumbs) return meta;
+  const page = breadcrumbArgs[0];
+  const breadcrumbs = Reflect.apply(
+    breadcrumbsFilter,
+    null,
+    breadcrumbArgs,
+  ).map((crumb, index) => ({
+    name: crumb.label,
+    url: canonicalUrl(crumb.url ? crumb.url : page.url),
+    position: index + 1,
+  }));
+  return breadcrumbs.length > 0 ? { ...meta, breadcrumbs } : meta;
+};
+
+/**
  * Configure breadcrumbs in Eleventy
  * @param {import('@11ty/eleventy').UserConfig} eleventyConfig
  */
 const configureBreadcrumbs = (eleventyConfig) => {
   eleventyConfig.addFilter("breadcrumbsFilter", breadcrumbsFilter);
+  eleventyConfig.addFilter("withSchemaBreadcrumbs", withSchemaBreadcrumbs);
 };
 
 export {
+  breadcrumbsFilter,
   buildCategoryCrumbs,
   buildParentCrumbs,
   buildPropertyCrumbs,
@@ -240,4 +264,5 @@ export {
   findParent,
   getIndexUrl,
   resolvePropertySlug,
+  withSchemaBreadcrumbs,
 };

--- a/src/_lib/eleventy/collection-lookup.js
+++ b/src/_lib/eleventy/collection-lookup.js
@@ -70,6 +70,18 @@ export const getBySlug = (collection, slug) => {
 };
 
 /**
+ * @param {Record<string, unknown>} meta
+ * @param {string | null | undefined} authorReference
+ * @param {EleventyCollectionItem[]} team
+ * @returns {Record<string, unknown>}
+ */
+export const withSchemaAuthor = (meta, authorReference, team) => {
+  if (!authorReference) return meta;
+  const author = getBySlug(team, authorReference);
+  return { ...meta, author: { name: author.data.name } };
+};
+
+/**
  * Resolve an array of file or directory paths to collection items.
  * Skips paths that don't match any item (e.g. deleted content).
  * Preserves the order of the input paths array; directory paths are
@@ -133,4 +145,5 @@ export const getItemsByPath = (collection, paths) => {
 export const configureCollectionLookup = (eleventyConfig) => {
   eleventyConfig.addFilter("getBySlug", getBySlug);
   eleventyConfig.addFilter("getItemsByPath", getItemsByPath);
+  eleventyConfig.addFilter("withSchemaAuthor", withSchemaAuthor);
 };

--- a/src/_lib/types/schema.d.ts
+++ b/src/_lib/types/schema.d.ts
@@ -15,13 +15,13 @@ export type SchemaOrgMeta = {
   description?: string;
   image?: { src: string };
   faq?: Faq[];
+  breadcrumbs?: Array<{ name: string; url: string; position: number }>;
   name?: string;
   brand?: string;
   offers?: Record<string, unknown>;
   reviews?: Record<string, unknown>[];
   rating?: Record<string, unknown>;
-  datePublished?: string;
+  published?: string;
   author?: Record<string, unknown>;
-  publisher?: Record<string, unknown>;
   organization?: Record<string, unknown>;
 };

--- a/src/_lib/utils/schema-helper.js
+++ b/src/_lib/utils/schema-helper.js
@@ -1,6 +1,8 @@
 import { getReviewsFor } from "#collections/reviews.js";
+import getConfig from "#data/config.js";
+import { normalizeImageUrl } from "#media/image-utils.js";
 import { canonicalUrl } from "#utils/canonical-url.js";
-import { isExternalUrl } from "#utils/url-utils.js";
+import { isAmbiguousPrice } from "#utils/price-utils.js";
 
 /**
  * @typedef {Object} SiteInfo
@@ -24,13 +26,21 @@ import { isExternalUrl } from "#utils/url-utils.js";
 
 /**
  * @typedef {Object} BasePageData
- * @property {string} [image] - Image path
+ * @property {string | {src: string}} [image] - Image path
+ * @property {string} [thumbnail] - Computed thumbnail path
+ * @property {string[]} [gallery] - Gallery image paths
  * @property {SiteInfo} site - Site information
  * @property {PageInfo} page - Page information
  * @property {string} name - Page name (required - computed for pages, explicit for collections)
+ * @property {string} [title] - Legacy page title
+ * @property {string} [meta_title] - Search/social title
+ * @property {string} [description] - Page description
  * @property {string} [meta_description] - Meta description
  * @property {string} [subtitle] - Page subtitle
  * @property {FAQ[]} [faqs] - FAQ items
+ * @property {string[]} [tags] - Collection tags
+ * @property {Array<{type: string, image?: string, items?: FAQ[]}>} [blocks] - Content blocks
+ * @property {Record<string, import("#lib/types").EleventyCollectionItem[]>} [collections] - Collections data
  * @property {Record<string, unknown>} [metaComputed] - Computed metadata
  */
 
@@ -41,7 +51,7 @@ import { isExternalUrl } from "#utils/url-utils.js";
  * @property {SiteInfo} site - Site information
  * @property {PageInfo} page - Page information
  * @property {string[]} [tags] - Item tags (used to derive reviews field)
- * @property {{ reviews: import("#lib/types").EleventyCollectionItem[] }} [collections] - Collections data
+ * @property {Array<{unit_price: string | number}>} [options] - Product options
  */
 
 /**
@@ -69,9 +79,8 @@ import { isExternalUrl } from "#utils/url-utils.js";
  * @property {Record<string, unknown>} [offers] - Offer data
  * @property {Record<string, unknown>[]} [reviews] - Review data
  * @property {Record<string, unknown>} [rating] - Rating data
- * @property {string} [datePublished] - Published date
+ * @property {string} [published] - Published date
  * @property {Record<string, unknown>} [author] - Author info
- * @property {Record<string, unknown>} [publisher] - Publisher info
  * @property {Record<string, unknown>} [organization] - Organization info
  */
 
@@ -82,23 +91,47 @@ import { isExternalUrl } from "#utils/url-utils.js";
  */
 const toDateString = (date) => date.toISOString().split("T")[0];
 
+/** @param {BasePageData} data */
+const getPageImageUrl = (data) => {
+  const getHeroImage = () => {
+    if (!Array.isArray(data.blocks)) return null;
+    const hero = data.blocks.find(
+      (block) =>
+        ["hero", "image-background"].includes(block.type) && block.image,
+    );
+    return hero ? hero.image : null;
+  };
+  const image =
+    data.image || data.thumbnail || data.gallery?.[0] || getHeroImage();
+  if (!image) return null;
+  const src = typeof image === "string" ? image : image.src;
+  if (src.startsWith("data:")) return null;
+  return new URL(normalizeImageUrl(src), `${data.site.url}/`).href;
+};
+
+/** @param {BasePageData} data */
+const getDescription = (data) =>
+  data.meta_description || data.subtitle || data.description;
+
 /**
- * Build a full image URL from a path
- * @param {string} imageInput - Image path or URL
- * @param {{ url: string }} site - Site object with url property
- * @returns {string} Full image URL
+ * Build metadata used by the shared HTML head.
+ * @param {BasePageData & {tags?: string[]}} data - Page data
+ * @returns {{title: string|undefined, description?: string, url: string, image?: string, type: string}}
  */
-function buildImageUrl(imageInput, { url }) {
-  if (isExternalUrl(imageInput)) {
-    return imageInput;
-  }
-
-  if (imageInput.startsWith("/")) {
-    return `${url}${imageInput}`;
-  }
-
-  return `${url}/images/${imageInput}`;
-}
+const buildSocialMeta = (data) => {
+  const image = getPageImageUrl(data);
+  return {
+    title: data.meta_title || data.name || data.title,
+    description: getDescription(data),
+    url: canonicalUrl(data.page.url),
+    ...(image && { image }),
+    type: data.tags?.includes("news")
+      ? "article"
+      : data.tags?.includes("products")
+        ? "product"
+        : "website",
+  };
+};
 
 /**
  * Builds base schema.org metadata from page data.
@@ -106,17 +139,48 @@ function buildImageUrl(imageInput, { url }) {
  * @returns {SchemaOrgMeta} Schema.org metadata object
  */
 function buildBaseMeta(data) {
-  const imageUrl = data.image ? buildImageUrl(data.image, data.site) : null;
+  const getFaqs = () => {
+    const pageFaqs = Array.isArray(data.faqs) ? data.faqs : [];
+    if (!Array.isArray(data.blocks)) return pageFaqs;
+    const faqBlocks = data.blocks.filter((block) => block.type === "faqs");
+    if (faqBlocks.length === 0) return pageFaqs;
+    const faqs = faqBlocks.flatMap((block) =>
+      Array.isArray(block.items) && block.items.length > 0
+        ? block.items
+        : pageFaqs,
+    );
+    return [
+      ...new Map(
+        faqs.map((faq) => [`${faq.question}\0${faq.answer}`, faq]),
+      ).values(),
+    ];
+  };
+  const imageUrl = getPageImageUrl(data);
+  const faqs = getFaqs();
 
   return {
     ...data.metaComputed,
     url: canonicalUrl(data.page.url),
-    title: data.name,
-    description: data.meta_description || data.subtitle,
+    title: data.name || data.title || data.meta_title,
+    description: getDescription(data),
     ...(imageUrl && { image: { src: imageUrl } }),
-    ...(data.faqs?.length > 0 && { faq: data.faqs }),
+    ...(faqs.length > 0 && { faq: faqs }),
   };
 }
+
+/** @param {number} price */
+const positiveFinitePrice = (price) =>
+  Number.isFinite(price) && price > 0 ? price : null;
+
+/** @param {string | number | null | undefined} price */
+const parseOfferPrice = (price) => {
+  const normalized =
+    typeof price === "string" ? price.replaceAll(",", "") : price;
+  if (isAmbiguousPrice(normalized)) return null;
+  if (typeof price === "number") return positiveFinitePrice(price);
+  const match = price ? String(normalized).match(/\d+(?:\.\d+)?/) : null;
+  return positiveFinitePrice(match ? Number(match[0]) : Number.NaN);
+};
 
 /**
  * Build schema.org metadata for a product page
@@ -124,6 +188,15 @@ function buildBaseMeta(data) {
  * @returns {SchemaOrgMeta} Schema.org product metadata
  */
 const buildProductMeta = (data) => {
+  const getOfferPrice = () => {
+    if (data.price !== undefined && data.price !== null && data.price !== "")
+      return parseOfferPrice(data.price);
+    if (!Array.isArray(data.options)) return null;
+    const prices = data.options
+      .map((option) => parseOfferPrice(option.unit_price))
+      .filter((price) => price !== null);
+    return prices.length > 0 ? Math.min(...prices) : null;
+  };
   const buildPriceValidUntil = () => {
     const date = new Date();
     date.setFullYear(date.getFullYear() + 1);
@@ -131,8 +204,8 @@ const buildProductMeta = (data) => {
   };
 
   const buildOffers = (price) => ({
-    price: price.toString().replace(/[£€$,]/g, ""),
-    priceCurrency: "GBP",
+    price,
+    priceCurrency: getConfig().currency,
     availability: "https://schema.org/InStock",
     priceValidUntil: buildPriceValidUntil(),
   });
@@ -171,11 +244,12 @@ const buildProductMeta = (data) => {
     };
   };
 
+  const price = getOfferPrice();
   return {
     ...buildBaseMeta(data),
     name: data.name,
     brand: data.site.name,
-    ...(data.price && { offers: buildOffers(data.price) }),
+    ...(price !== null && { offers: buildOffers(price) }),
     ...buildReviewsMeta(),
   };
 };
@@ -186,20 +260,10 @@ const buildProductMeta = (data) => {
  * @returns {SchemaOrgMeta} Schema.org post metadata
  */
 const buildPostMeta = (data) => {
-  const buildPublisher = (site) => ({
-    name: site.name,
-    logo: {
-      src: buildImageUrl(site.logo || "/images/logo.png", site),
-      width: 512,
-      height: 512,
-    },
-  });
-
   return {
     ...buildBaseMeta(data),
-    ...(data.page.date && { datePublished: toDateString(data.page.date) }),
+    ...(data.page.date && { published: toDateString(data.page.date) }),
     author: { name: data.author || data.site.name },
-    publisher: buildPublisher(data.site),
   };
 };
 
@@ -220,4 +284,5 @@ export {
   buildOrganizationMeta,
   buildPostMeta,
   buildProductMeta,
+  buildSocialMeta,
 };

--- a/src/_lib/utils/schema-helper.js
+++ b/src/_lib/utils/schema-helper.js
@@ -178,6 +178,11 @@ const parseOfferPrice = (price) => {
     typeof price === "string" ? price.replaceAll(",", "") : price;
   if (isAmbiguousPrice(normalized)) return null;
   if (typeof price === "number") return positiveFinitePrice(price);
+  if (
+    typeof normalized === "string" &&
+    /[-−]\s*(?:[A-Z]{3}\s*)?[£€$]?\s*\d/i.test(normalized)
+  )
+    return null;
   const match = price ? String(normalized).match(/\d+(?:\.\d+)?/) : null;
   return positiveFinitePrice(match ? Number(match[0]) : Number.NaN);
 };

--- a/src/snippets/contact-cta.md
+++ b/src/snippets/contact-cta.md
@@ -8,7 +8,7 @@ blocks:
       Get in touch for a fast, free quote. We cover discos, roller derbies and dog agility contests across the UK.
     button:
       text: Get In Touch
-      href: /contact-us/
+      href: /contact/
       variant: secondary
       size: lg
 ---

--- a/test/integration/eleventy/news.test.js
+++ b/test/integration/eleventy/news.test.js
@@ -220,8 +220,10 @@ describe("news", () => {
 
       // Test 2: no_index post has noindex meta tag
       const hiddenOutput = site.getOutput("/news/hidden-post/index.html");
-      expect(hiddenOutput.includes('name="robots"')).toBe(true);
-      expect(hiddenOutput.includes("noindex")).toBe(true);
+      expect(hiddenOutput).toContain(
+        '<meta name="robots" content="noindex,nofollow">',
+      );
+      expect(hiddenOutput).not.toContain('name="robots" value=');
 
       // Test 3: no_index post does not appear in news list
       const newsListHtml = site.getOutput("/news/index.html");

--- a/test/integration/eleventy/seo-metadata.test.js
+++ b/test/integration/eleventy/seo-metadata.test.js
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import { useSharedSite } from "#test/test-site-factory.js";
+
+const SITE_URL = "https://example.chobble.com";
+
+const getSchema = async (site, outputPath) => {
+  const doc = await site.getDoc(outputPath);
+  const script = doc.querySelector('script[type="application/ld+json"]');
+  expect(script).not.toBeNull();
+  return JSON.parse(script.textContent);
+};
+
+const getGraphItem = (schema, type) =>
+  schema["@graph"].find((item) => item["@type"] === type);
+
+describe("generated SEO metadata", () => {
+  const getSite = useSharedSite({
+    config: { placeholder_images: false },
+    files: [
+      {
+        path: "pages/normal.md",
+        frontmatter: {
+          name: "Normal Page",
+          meta_title: 'Normal & "Social"',
+          meta_description: 'Normal & "description"',
+          permalink: "/normal/",
+          blocks: [
+            {
+              type: "image-background",
+              image: "src/images/placeholders/purple.svg",
+              image_alt: "Purple background",
+              content: "# Normal Page",
+            },
+          ],
+        },
+      },
+      {
+        path: "products/schema-widget.md",
+        frontmatter: {
+          name: "Schema Widget",
+          subtitle: "A structured widget",
+          price: "From £495",
+          thumbnail: "src/images/placeholders/blue.svg",
+          blocks: [
+            { type: "markdown", content: "# Schema Widget" },
+            {
+              type: "faqs",
+              items: [
+                {
+                  question: "Does it have schema?",
+                  answer: "Yes, automatically.",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        path: "products/poa-widget.md",
+        frontmatter: {
+          name: "POA Widget",
+          subtitle: "Ask for a price",
+          price: "POA",
+          thumbnail: "src/images/placeholders/orange.svg",
+          blocks: [{ type: "markdown", content: "# POA Widget" }],
+        },
+      },
+      {
+        path: "news/2024-02-03-schema-news.md",
+        frontmatter: {
+          name: "Schema News",
+          meta_description: "Structured news description",
+          author: "src/team/jane-seo.md",
+          thumbnail: "src/images/placeholders/green.svg",
+          blocks: [
+            { type: "markdown", content: "# Schema News" },
+            { type: "news-meta" },
+          ],
+        },
+      },
+      {
+        path: "team/jane-seo.md",
+        frontmatter: {
+          name: "Jane SEO",
+          blocks: [{ type: "markdown", content: "Jane's biography." }],
+        },
+      },
+      {
+        path: "pages/private.md",
+        frontmatter: {
+          name: "Private Page",
+          permalink: "/private/",
+          no_index: true,
+          blocks: [{ type: "markdown", content: "Private." }],
+        },
+      },
+    ],
+  });
+
+  test("renders complete product, breadcrumb, FAQ, and global JSON-LD", async () => {
+    const site = getSite();
+    const outputPath = "/products/schema-widget/index.html";
+    const schema = await getSchema(site, outputPath);
+    const product = getGraphItem(schema, "Product");
+
+    expect(product).toMatchObject({
+      name: "Schema Widget",
+      url: `${SITE_URL}/products/schema-widget/`,
+      description: "A structured widget",
+      image: `${SITE_URL}/images/placeholders/blue.svg`,
+      brand: { "@type": "Brand", name: "The Chobble Template" },
+      offers: { "@type": "Offer", price: 495, priceCurrency: "GBP" },
+    });
+    expect(getGraphItem(schema, "Organization")).toBeDefined();
+    expect(getGraphItem(schema, "WebSite")).toBeDefined();
+
+    const breadcrumbs = getGraphItem(schema, "BreadcrumbList");
+    expect(breadcrumbs.itemListElement.map((item) => item.item.name)).toEqual([
+      "Home",
+      "Products",
+      "Schema Widget",
+    ]);
+    expect(breadcrumbs.itemListElement.at(-1).item["@id"]).toBe(
+      `${SITE_URL}/products/schema-widget/`,
+    );
+
+    const faq = getGraphItem(schema, "FAQPage");
+    expect(faq.mainEntity[0]).toMatchObject({
+      name: "Does it have schema?",
+      acceptedAnswer: { text: "Yes, automatically." },
+    });
+    expect(site.getOutput(outputPath)).toContain(
+      '<meta property="og:type" content="product">',
+    );
+  });
+
+  test("omits product offers for unparseable prices", async () => {
+    const schema = await getSchema(
+      getSite(),
+      "/products/poa-widget/index.html",
+    );
+    expect(getGraphItem(schema, "Product").offers).toBeUndefined();
+  });
+
+  test("renders complete news JSON-LD from authored content", async () => {
+    const schema = await getSchema(getSite(), "/news/schema-news/index.html");
+    expect(getGraphItem(schema, "BlogPosting")).toMatchObject({
+      headline: "Schema News",
+      url: `${SITE_URL}/news/schema-news/`,
+      description: "Structured news description",
+      image: `${SITE_URL}/images/placeholders/green.svg`,
+      author: { "@type": "Person", name: "Jane SEO" },
+      publisher: { "@type": "Organization", name: "The Chobble Template" },
+      datePublished: "2024-02-03",
+    });
+  });
+
+  test("renders normal page JSON-LD and escaped social cards", async () => {
+    const site = getSite();
+    const schema = await getSchema(site, "/normal/index.html");
+    expect(getGraphItem(schema, "WebPage")).toMatchObject({
+      headline: "Normal Page",
+      url: `${SITE_URL}/normal/`,
+      description: 'Normal & "description"',
+      image: `${SITE_URL}/images/placeholders/purple.svg`,
+    });
+
+    const output = site.getOutput("/normal/index.html");
+    expect(output).toContain(
+      '<meta property="og:title" content="Normal & &quot;Social&quot;">',
+    );
+    expect(output).toContain(
+      '<meta property="og:description" content="Normal & &quot;description&quot;">',
+    );
+    expect(output).toContain(
+      `<meta property="og:url" content="${SITE_URL}/normal/">`,
+    );
+    expect(output).toContain(
+      `<meta property="og:image" content="${SITE_URL}/images/placeholders/purple.svg">`,
+    );
+    expect(output).toContain('<meta property="og:type" content="website">');
+    expect(output).toContain(
+      '<meta name="twitter:card" content="summary_large_image">',
+    );
+    expect(output).toContain(
+      `<link rel="canonical" href="${SITE_URL}/normal/">`,
+    );
+  });
+
+  test("uses article social type for news", () => {
+    const output = getSite().getOutput("/news/schema-news/index.html");
+    expect(output).toContain('<meta property="og:type" content="article">');
+    expect(output).toContain(
+      `<meta name="twitter:image" content="${SITE_URL}/images/placeholders/green.svg">`,
+    );
+  });
+
+  test("renders valid noindex robots metadata without JSON-LD", () => {
+    const output = getSite().getOutput("/private/index.html");
+    expect(output).toContain('<meta name="robots" content="noindex,nofollow">');
+    expect(output).not.toContain('name="robots" value=');
+    expect(output).not.toContain('type="application/ld+json"');
+  });
+});

--- a/test/test-runner-utils.js
+++ b/test/test-runner-utils.js
@@ -256,7 +256,7 @@ export const COMMON_STEPS = {
   build: {
     name: "build",
     cmd: "bun",
-    args: ["./node_modules/@11ty/eleventy/cmd.cjs", "--quiet"],
+    args: ["run", "build"],
   },
 };
 

--- a/test/unit/data/eleventy-computed/meta.test.js
+++ b/test/unit/data/eleventy-computed/meta.test.js
@@ -23,8 +23,7 @@ describe("eleventyComputed.meta", () => {
       page: { url: "/news/test-post/", date: new Date("2024-01-15") },
     });
     expect(result.author.name).toBe("Test Site");
-    expect(result.publisher.name).toBe("Test Site");
-    expect(result.datePublished).toBe("2024-01-15");
+    expect(result.published).toBe("2024-01-15");
   });
 
   test("returns organization-shaped meta when schema_type is 'organization'", () => {
@@ -79,5 +78,24 @@ describe("eleventyComputed.metaComputed", () => {
         metaComputed: { customField: "leaky" },
       }),
     ).toEqual({});
+  });
+});
+
+describe("eleventyComputed.socialMeta", () => {
+  test("returns shared head metadata", () => {
+    expect(
+      eleventyComputed.socialMeta({
+        name: "News item",
+        meta_title: "SEO news title",
+        meta_description: "News description",
+        tags: ["news"],
+        site,
+        page: { url: "/news/item/" },
+      }),
+    ).toMatchObject({
+      title: "SEO news title",
+      description: "News description",
+      type: "article",
+    });
   });
 });

--- a/test/unit/eleventy/breadcrumbs.test.js
+++ b/test/unit/eleventy/breadcrumbs.test.js
@@ -3,11 +3,57 @@ import { configureBreadcrumbs } from "#eleventy/breadcrumbs.js";
 import { createMockEleventyConfig } from "#test/test-utils.js";
 
 describe("configureBreadcrumbs", () => {
-  test("registers breadcrumbsFilter", () => {
+  test("registers breadcrumb filters", () => {
     const mockConfig = createMockEleventyConfig();
     configureBreadcrumbs(mockConfig);
 
     expect(typeof mockConfig.filters.breadcrumbsFilter).toBe("function");
+    expect(typeof mockConfig.filters.withSchemaBreadcrumbs).toBe("function");
+  });
+});
+
+describe("withSchemaBreadcrumbs", () => {
+  const setupFilter = () => {
+    const mockConfig = createMockEleventyConfig();
+    configureBreadcrumbs(mockConfig);
+    return mockConfig.filters.withSchemaBreadcrumbs;
+  };
+
+  test("returns metadata unchanged when breadcrumbs are hidden or empty", () => {
+    const filter = setupFilter();
+    const meta = { title: "Home" };
+    expect(filter(meta, false, { url: "/page/" })).toBe(meta);
+    expect(
+      filter(meta, true, { url: "/" }, "Home", "Home", null, null, {}),
+    ).toBe(meta);
+  });
+
+  test("maps rendered crumbs to absolute schema URLs", () => {
+    const filter = setupFilter();
+    expect(
+      filter(
+        { title: "Widget" },
+        true,
+        { url: "/products/widget/" },
+        "Widget",
+        "Products",
+        undefined,
+        undefined,
+        {},
+      ).breadcrumbs,
+    ).toEqual([
+      { name: "Home", url: "https://example.chobble.com", position: 1 },
+      {
+        name: "Products",
+        url: "https://example.chobble.com/products/",
+        position: 2,
+      },
+      {
+        name: "Widget",
+        url: "https://example.chobble.com/products/widget/",
+        position: 3,
+      },
+    ]);
   });
 });
 

--- a/test/unit/eleventy/collection-lookup.test.js
+++ b/test/unit/eleventy/collection-lookup.test.js
@@ -4,6 +4,7 @@ import {
   getBySlug,
   getItemsByPath,
   indexBySlug,
+  withSchemaAuthor,
 } from "#eleventy/collection-lookup.js";
 import { createMockEleventyConfig } from "#test/test-utils.js";
 
@@ -25,6 +26,21 @@ describe("collection-lookup", () => {
       configureCollectionLookup(mockConfig);
 
       expect(typeof mockConfig.filters.getBySlug).toBe("function");
+      expect(typeof mockConfig.filters.withSchemaAuthor).toBe("function");
+    });
+  });
+
+  describe("withSchemaAuthor", () => {
+    test("uses the same team lookup as the rendered news byline", () => {
+      const team = slugItems([["jane-doe", "Jane Doe", "/team/jane-doe/"]]);
+      expect(
+        withSchemaAuthor({ title: "News" }, "src/team/jane-doe.md", team),
+      ).toEqual({ title: "News", author: { name: "Jane Doe" } });
+    });
+
+    test("returns metadata unchanged without an author reference", () => {
+      const meta = { title: "News" };
+      expect(withSchemaAuthor(meta, null, [])).toBe(meta);
     });
   });
 

--- a/test/unit/scripts/internal-links.test.js
+++ b/test/unit/scripts/internal-links.test.js
@@ -35,12 +35,18 @@ describe("internal link validation", () => {
           <a href="mailto:test@example.com">Email</a>
           <a href="tel:+44123456789">Phone</a>
           <a href="data:text/plain,test">Data</a>
-          <a href="/missing?preview=true">Preview</a>
-          <a href="/missing#section">Section</a>
+          <a href="/about/?preview=true">Preview</a>
+          <a href="/about/#section">Section</a>
+          <a href="?preview=true">Current query</a>
+          <a href="#section">Current section</a>
+          <a href="/encoded%20page/">Encoded path</a>
+          <a href="/literal%20path/">Literal encoded path</a>
           <a>No href</a>
         `,
       );
       writeOutput(outputDir, "about/index.html");
+      writeOutput(outputDir, "encoded page/index.html");
+      writeOutput(outputDir, "literal%20path/index.html");
       writeOutput(outputDir, "products/index.html");
       writeOutput(outputDir, "feed.xml");
       writeOutput(outputDir, "legacy/index.html");
@@ -67,12 +73,42 @@ describe("internal link validation", () => {
         "a/index.html",
         '<link rel="stylesheet" href="/missing.css">',
       );
+      writeOutput(
+        outputDir,
+        "b/index.html",
+        '<a href="/bad%ZZ">Malformed path</a>',
+      );
+      writeOutput(
+        outputDir,
+        "f/index.html",
+        '<a href="/missing-fragment/#section">Missing fragment path</a>',
+      );
+      writeOutput(
+        outputDir,
+        "q/index.html",
+        '<a href="/missing-query/?preview=true">Missing query path</a>',
+      );
 
       expect(findBrokenInternalLinks(outputDir)).toEqual([
         {
           source: "a/index.html",
           href: "/missing.css",
           target: "missing.css",
+        },
+        {
+          source: "b/index.html",
+          href: "/bad%ZZ",
+          target: "bad%ZZ",
+        },
+        {
+          source: "f/index.html",
+          href: "/missing-fragment/#section",
+          target: "missing-fragment/",
+        },
+        {
+          source: "q/index.html",
+          href: "/missing-query/?preview=true",
+          target: "missing-query/",
         },
         {
           source: "z/index.html",

--- a/test/unit/scripts/internal-links.test.js
+++ b/test/unit/scripts/internal-links.test.js
@@ -1,0 +1,134 @@
+import { describe, expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  findBrokenInternalLinks,
+  formatBrokenInternalLink,
+  runInternalLinkCheck,
+} from "#scripts/internal-links.js";
+import { withTempDir } from "#test/test-utils.js";
+
+const writeOutput = (outputDir, relativePath, content = "") => {
+  const filePath = path.join(outputDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+};
+
+const runCheck = (outputDir) => {
+  const output = { log: mock(), error: mock() };
+  return { status: runInternalLinkCheck(outputDir, output), output };
+};
+
+describe("internal link validation", () => {
+  test("accepts generated pages, assets, relative paths, and redirects", () => {
+    withTempDir("internal-links-valid", (outputDir) => {
+      writeOutput(
+        outputDir,
+        "index.html",
+        `
+          <a href="/about/">About</a>
+          <a href="/products">Products</a>
+          <a href="/legacy/">Redirect</a>
+          <a href="/feed.xml">Feed</a>
+          <a href="https://example.com/missing">External</a>
+          <a href="//cdn.example.com/missing">CDN</a>
+          <a href="mailto:test@example.com">Email</a>
+          <a href="tel:+44123456789">Phone</a>
+          <a href="data:text/plain,test">Data</a>
+          <a href="/missing?preview=true">Preview</a>
+          <a href="/missing#section">Section</a>
+          <a>No href</a>
+        `,
+      );
+      writeOutput(outputDir, "about/index.html");
+      writeOutput(outputDir, "products/index.html");
+      writeOutput(outputDir, "feed.xml");
+      writeOutput(outputDir, "legacy/index.html");
+      writeOutput(
+        outputDir,
+        "docs/index.html",
+        '<a href="manual.pdf">Manual</a>',
+      );
+      writeOutput(outputDir, "docs/manual.pdf");
+
+      expect(findBrokenInternalLinks(outputDir)).toEqual([]);
+    });
+  });
+
+  test("reports missing pages and assets in stable source order", () => {
+    withTempDir("internal-links-missing", (outputDir) => {
+      writeOutput(
+        outputDir,
+        "z/index.html",
+        '<a href="/missing-page/">Missing page</a>',
+      );
+      writeOutput(
+        outputDir,
+        "a/index.html",
+        '<link rel="stylesheet" href="/missing.css">',
+      );
+
+      expect(findBrokenInternalLinks(outputDir)).toEqual([
+        {
+          source: "a/index.html",
+          href: "/missing.css",
+          target: "missing.css",
+        },
+        {
+          source: "z/index.html",
+          href: "/missing-page/",
+          target: "missing-page/",
+        },
+      ]);
+    });
+  });
+
+  test("does not validate links emitted by redirect documents", () => {
+    withTempDir("internal-links-redirect", (outputDir) => {
+      writeOutput(
+        outputDir,
+        "legacy/index.html",
+        `
+          <meta http-equiv="refresh" content="0; url=/not-generated/">
+          <a href="/not-generated/">Continue</a>
+        `,
+      );
+      expect(findBrokenInternalLinks(outputDir)).toEqual([]);
+    });
+  });
+
+  test("throws when the generated site directory is missing", () => {
+    withTempDir("internal-links-no-output", (tempDir) => {
+      expect(() =>
+        findBrokenInternalLinks(path.join(tempDir, "missing")),
+      ).toThrow("Generated site directory does not exist");
+    });
+  });
+
+  test("formats failures and returns a non-zero status", () => {
+    withTempDir("internal-links-status-fail", (outputDir) => {
+      writeOutput(outputDir, "index.html", '<a href="/missing/">Missing</a>');
+      const { status, output } = runCheck(outputDir);
+      expect(status).toBe(1);
+      expect(output.error).toHaveBeenCalledWith(
+        "Broken internal links:\nindex.html: /missing/ -> missing/",
+      );
+      expect(
+        formatBrokenInternalLink({
+          source: "index.html",
+          href: "/",
+          target: "",
+        }),
+      ).toBe("index.html: / -> index.html");
+    });
+  });
+
+  test("returns success when all links resolve", () => {
+    withTempDir("internal-links-status-pass", (outputDir) => {
+      writeOutput(outputDir, "index.html");
+      const { status, output } = runCheck(outputDir);
+      expect(status).toBe(0);
+      expect(output.log).toHaveBeenCalledWith("Internal link check passed");
+    });
+  });
+});

--- a/test/unit/utils/schema-helper.test.js
+++ b/test/unit/utils/schema-helper.test.js
@@ -212,6 +212,12 @@ describe("buildProductMeta", () => {
     expect(productMeta({ price: 0 }).offers).toBeUndefined();
   });
 
+  test("does not turn negative string prices into positive offers", () => {
+    expect(productMeta({ price: "-10" }).offers).toBeUndefined();
+    expect(productMeta({ price: "From -£10" }).offers).toBeUndefined();
+    expect(productMeta({ price: "GBP -10" }).offers).toBeUndefined();
+  });
+
   test("uses the lowest product option when no page-level price exists", () => {
     expect(
       productMeta({

--- a/test/unit/utils/schema-helper.test.js
+++ b/test/unit/utils/schema-helper.test.js
@@ -11,6 +11,7 @@ import {
   buildOrganizationMeta,
   buildPostMeta,
   buildProductMeta,
+  buildSocialMeta,
 } from "#utils/schema-helper.js";
 
 // ----------------------------------------
@@ -34,7 +35,7 @@ const orgMeta = (overrides = {}) =>
     createSchemaData({ pageUrl: "/", name: "Home", ...overrides }),
   );
 
-/** Curried: (price input) => stripped price string from offers */
+/** Curried: (price input) => numeric price from offers */
 const strippedPrice = (price) => productMeta({ price }).offers.price;
 
 /** Build productMeta with mock reviews from specs */
@@ -69,6 +70,27 @@ describe("buildBaseMeta", () => {
     const result = baseMeta({ image: "fallback-image.jpg" });
     expect(result.image).toBeTruthy();
     expect(result.image.src.includes("fallback-image.jpg")).toBe(true);
+  });
+
+  test("uses computed thumbnail before a hero image", () => {
+    const result = baseMeta({
+      thumbnail: "thumbnail.jpg",
+      blocks: [{ type: "image-background", image: "hero.jpg" }],
+    });
+    expect(result.image.src).toBe("https://example.com/images/thumbnail.jpg");
+  });
+
+  test("uses a hero image when the page has no image or thumbnail", () => {
+    const result = baseMeta({
+      blocks: [{ type: "hero", image: "hero.jpg" }],
+    });
+    expect(result.image.src).toBe("https://example.com/images/hero.jpg");
+  });
+
+  test("ignores data images in metadata", () => {
+    expect(
+      baseMeta({ image: "data:image/png;base64,abc" }).image,
+    ).toBeUndefined();
   });
 
   test("handles absolute URL images (http://)", () => {
@@ -107,6 +129,26 @@ describe("buildBaseMeta", () => {
     expect(baseMeta({ faqs }).faq).toEqual(faqs);
   });
 
+  test("uses FAQ block items instead of page-level fallback content", () => {
+    const blockFaqs = [{ question: "Block question", answer: "Block answer" }];
+    expect(
+      baseMeta({
+        faqs: [{ question: "Page question", answer: "Page answer" }],
+        blocks: [{ type: "faqs", items: blockFaqs }],
+      }).faq,
+    ).toEqual(blockFaqs);
+  });
+
+  test("uses and deduplicates page FAQs for FAQ blocks without items", () => {
+    const faqs = [{ question: "Question", answer: "Answer" }];
+    expect(
+      baseMeta({
+        faqs,
+        blocks: [{ type: "faqs" }, { type: "faqs" }],
+      }).faq,
+    ).toEqual(faqs);
+  });
+
   test("does not include empty FAQs array", () => {
     expect(baseMeta({ faqs: [] }).faq).toBeUndefined();
   });
@@ -134,30 +176,48 @@ describe("buildProductMeta", () => {
   test("includes offers when price is provided", () => {
     const result = productMeta({ price: "29.99" });
     expect(result.offers).toBeTruthy();
-    expect(result.offers.price).toBe("29.99");
+    expect(result.offers.price).toBe(29.99);
     expect(result.offers.priceCurrency).toBe("GBP");
     expect(result.offers.availability).toBe("https://schema.org/InStock");
     expect(result.offers.priceValidUntil).toBeTruthy();
   });
 
   test("strips currency symbols from price", () => {
-    expect(strippedPrice("£29.99")).toBe("29.99");
+    expect(strippedPrice("£29.99")).toBe(29.99);
   });
 
   test("strips dollar sign from price", () => {
-    expect(strippedPrice("$49.99")).toBe("49.99");
+    expect(strippedPrice("$49.99")).toBe(49.99);
   });
 
   test("strips euro sign from price", () => {
-    expect(strippedPrice("€39.99")).toBe("39.99");
+    expect(strippedPrice("€39.99")).toBe(39.99);
   });
 
   test("strips commas from price", () => {
-    expect(strippedPrice("1,299.99")).toBe("1299.99");
+    expect(strippedPrice("1,299.99")).toBe(1299.99);
+  });
+
+  test("parses a prefixed price", () => {
+    expect(strippedPrice("From £495")).toBe(495);
   });
 
   test("does not include offers when price is not provided", () => {
     expect(productMeta().offers).toBeUndefined();
+  });
+
+  test("does not include offers for POA, ambiguous, or non-positive prices", () => {
+    expect(productMeta({ price: "POA" }).offers).toBeUndefined();
+    expect(productMeta({ price: "£10 / £12" }).offers).toBeUndefined();
+    expect(productMeta({ price: 0 }).offers).toBeUndefined();
+  });
+
+  test("uses the lowest product option when no page-level price exists", () => {
+    expect(
+      productMeta({
+        options: [{ unit_price: 20 }, { unit_price: 15 }],
+      }).offers.price,
+    ).toBe(15);
   });
 
   test("includes reviews and rating when tags and collections.reviews are provided", () => {
@@ -226,28 +286,53 @@ describe("buildPostMeta", () => {
     expect(postMeta().author.name).toBe("Test Site");
   });
 
-  test("includes datePublished from page.date", () => {
-    expect(postMeta().datePublished).toBe("2024-03-15");
+  test("includes published from page.date", () => {
+    expect(postMeta().published).toBe("2024-03-15");
   });
 
-  test("includes publisher with name and logo", () => {
-    const result = postMeta({ siteLogo: "/custom-logo.png" });
-    expect(result.publisher).toBeTruthy();
-    expect(result.publisher.name).toBe("Test Site");
-    expect(result.publisher.logo).toBeTruthy();
-    expect(result.publisher.logo.src.includes("custom-logo.png")).toBe(true);
-    expect(result.publisher.logo.width).toBe(512);
-    expect(result.publisher.logo.height).toBe(512);
+  test("does not include published when page.date is not provided", () => {
+    expect(postMeta({ date: null }).published).toBeUndefined();
+  });
+});
+
+describe("buildSocialMeta", () => {
+  test("uses SEO title, canonical URL, description, image, and news type", () => {
+    expect(
+      buildSocialMeta(
+        createSchemaData({
+          name: "Page name",
+          meta_title: "SEO title",
+          meta_description: "Description",
+          thumbnail: "/images/social.jpg",
+          tags: ["news"],
+        }),
+      ),
+    ).toEqual({
+      title: "SEO title",
+      description: "Description",
+      url: "https://example.chobble.com/page/",
+      image: "https://example.com/images/social.jpg",
+      type: "article",
+    });
   });
 
-  test("uses default logo path when site.logo not provided", () => {
-    expect(postMeta().publisher.logo.src.includes("/images/logo.png")).toBe(
-      true,
+  test("falls back to page title and ordinary website type", () => {
+    expect(
+      buildSocialMeta(
+        createSchemaData({ name: undefined, title: "Legacy title" }),
+      ),
+    ).toEqual({
+      title: "Legacy title",
+      description: undefined,
+      url: "https://example.chobble.com/page/",
+      type: "website",
+    });
+  });
+
+  test("uses product type for product pages", () => {
+    expect(buildSocialMeta(createSchemaData({ tags: ["products"] })).type).toBe(
+      "product",
     );
-  });
-
-  test("does not include datePublished when page.date is not provided", () => {
-    expect(postMeta({ date: null }).datePublished).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- render page-specific Product, BlogPosting, WebPage, breadcrumb, and FAQ JSON-LD while preserving Organization and WebSite data
- add escaped Open Graph and Twitter metadata with article, product, and website types, and fix noindex robots output
- validate generated internal links during builds and add focused unit/integration coverage

## Testing
- `bun run test`
- pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic internal-link validation after the static site build to help catch broken links early.
  * Enhanced SEO/social and structured data generation (social meta, schema breadcrumbs, schema author, FAQ aggregation, images, and product pricing handling).
* **Bug Fixes**
  * Updated the Contact CTA link to the correct `/contact/` path.
  * Improved handling of invalid/ambiguous product prices by omitting unavailable offers.
  * Refined robots meta rendering for `no_index` pages.
* **Build & Deployment**
  * Updated build steps to run the standard `bun run build` flow and include the link-check step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->