### PR TITLE
Make mobile menu full-height robust against containing-block ancestors

### DIFF
--- a/src/css/_nav-mixins.scss
+++ b/src/css/_nav-mixins.scss
@@ -214,7 +214,6 @@
   position: fixed;
   top: 3rem;
   right: -100%;
-  bottom: 0;
 
   overflow-y: auto;
   overscroll-behavior-y: contain;
@@ -225,9 +224,14 @@
   box-sizing: border-box;
   width: 70%;
   max-width: 300px;
-  height: auto;
-  max-height: calc(100vh - 3rem);
-  max-height: calc(100dvh - 3rem);
+  // Fill the viewport below the 3rem bar with an explicit height rather than
+  // `bottom: 0`. If an ancestor (e.g. a nav with `backdrop-filter`, `filter`,
+  // `transform`, `perspective`, or `will-change`) becomes the containing block
+  // for this `position: fixed` element, `bottom: 0` would resolve against the
+  // 3rem bar and collapse the menu to a sliver. A definite height renders
+  // identically in the normal case and stays full-height regardless.
+  height: calc(100vh - 3rem);
+  height: calc(100dvh - 3rem);
   margin: 0;
   padding: $gap;
   padding-bottom: calc(#{$gap} + env(safe-area-inset-bottom));

--- a/test/unit/build/scss.test.js
+++ b/test/unit/build/scss.test.js
@@ -281,12 +281,11 @@ describe("scss", () => {
         /\.design-system\.sticky-mobile-nav nav > ul\s*\{[^}]*\}/,
       )?.[0] ?? "";
 
-    expect(menuRule).toContain("bottom: 0");
     expect(menuRule).toContain("overflow-y: auto");
     expect(menuRule).toContain("overscroll-behavior-y: contain");
     expect(menuRule).toContain("box-sizing: border-box");
-    expect(menuRule).toContain("height: auto");
-    expect(menuRule).toContain("max-height: calc(100dvh - 3rem)");
+    expect(menuRule).toContain("height: calc(100vh - 3rem)");
+    expect(menuRule).toContain("height: calc(100dvh - 3rem)");
     expect(menuRule).toContain("-webkit-overflow-scrolling: touch");
   });
 


### PR DESCRIPTION
## Background

Several client sites that layer their own theme on top of this template had a mobile nav that opened as a thin sliver at the top of the screen instead of filling it. The trigger in every case was the client adding `backdrop-filter` (frosted-glass bar) to `<nav>`.

## Root cause

The mobile menu panel (`nav > ul`, via the `nav-mobile-menu` mixin) filled the viewport using:

```scss
position: fixed;
top: 3rem;
bottom: 0;
height: auto;
max-height: calc(100dvh - 3rem);
```

Its height comes from `top: 3rem` + `bottom: 0` resolving **against the viewport**. But `backdrop-filter` — like `filter`, `transform`, `perspective`, and `will-change` — makes an element the **containing block for its `position: fixed` descendants**. When a client puts any of those on `<nav>` (the panel's parent), `top`/`bottom` resolve against the `3rem`-tall bar instead of the viewport, so `bottom: 0` collapses the menu. The `max-height` doesn't help because it's only an upper bound.

The clients fixed this on their side by scoping their `backdrop-filter` to desktop widths, but it's an easy footgun to hit and worth hardening here so no future client runs into it.

## Change

Give the panel a **definite height** instead of relying on `bottom: 0`:

```scss
position: fixed;
top: 3rem;
right: -100%;
height: calc(100vh - 3rem);
height: calc(100dvh - 3rem);   // dvh with vh fallback, same idiom as before
```

- Renders **identically** in the normal case (no containing-block ancestor).
- Stays full-height even when an ancestor establishes a containing block, because the height is defined in viewport units rather than derived from `bottom: 0`.
- `bottom: 0` and the now-redundant `height: auto` / `max-height` pair are removed (an explicit height plus `top` fully constrains the box).

Scoped to a single mixin (`src/css/_nav-mixins.scss`), no markup or JS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014S4zTuDPBEokPPWMHBgM3t

---
_Generated by [Claude Code](https://claude.ai/code/session_014S4zTuDPBEokPPWMHBgM3t)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mobile navigation slide-out panel sizing to reliably fill the viewport area beneath the 3rem sticky header.
  * Updated height handling to use explicit `calc(100vh - 3rem)` / `calc(100dvh - 3rem)` sizing for more consistent layout across viewport and browser scenarios.
* **Tests**
  * Updated the SCSS unit test to reflect the new expected navigation panel CSS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->