### PR TITLE
Use names for Pages CMS collections

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -515,11 +515,12 @@ components:
       - name: reference
         label: Snippet
         type: reference
-        list: true
         options:
-          search: primary
+          collection: snippets
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
+        required: true
   block_socials:
     label: Socials
     type: object
@@ -909,9 +910,9 @@ components:
         type: reference
         options:
           collection: products
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
   block_event_contact_section:
     label: Event Contact Section
     type: object
@@ -1031,7 +1032,7 @@ content:
     path: src/pages
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     view:
       fields:
         - permalink
@@ -1040,6 +1041,7 @@ content:
       sort:
         - meta_title
     fields:
+      - { name: name, type: string, label: Name, required: true }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: body, type: rich-text, label: Body }
       - { name: meta_title, component: meta_title }
@@ -1112,9 +1114,9 @@ content:
     path: src/products
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: thumbnail, type: image, label: Thumbnail }
       - { name: order, type: number, label: Order }
@@ -1124,18 +1126,18 @@ content:
         list: true
         options:
           collection: categories
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - name: events
         label: Events
         type: reference
         list: true
         options:
           collection: events
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - name: options
         label: Product Options
         type: object
@@ -1241,18 +1243,18 @@ content:
     path: src/categories
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: thumbnail, type: image, label: Thumbnail }
       - name: parent
         label: Parent Category
         type: reference
         options:
           collection: categories
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - { name: featured, type: boolean, label: Featured }
       - { name: keywords, type: string, label: Search Keywords, list: true }
       - { name: meta_title, component: meta_title }
@@ -1317,6 +1319,7 @@ content:
     path: src/news
     type: collection
     subfolders: false
+    filename: "{year}-{month}-{day}-{name}.md"
     view:
       fields:
         - name
@@ -1325,16 +1328,16 @@ content:
       sort:
         - date
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: date, label: Date, type: date }
       - name: author
         label: Author
         type: reference
         options:
           collection: team
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - { name: subtitle, type: string, label: Subtitle }
       - { name: body, type: rich-text, label: Body }
       - { name: meta_title, component: meta_title }
@@ -1398,7 +1401,7 @@ content:
     path: src/events
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     view:
       fields:
         - thumbnail
@@ -1410,7 +1413,7 @@ content:
       sort:
         - name
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: thumbnail, type: image, label: Thumbnail }
       - { name: order, type: number, label: Order }
@@ -1497,9 +1500,9 @@ content:
     path: src/team
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: thumbnail, type: image, label: Thumbnail }
       - { name: order, type: number, label: Order }
       - { name: subtitle, type: string, label: Subtitle }
@@ -1561,9 +1564,9 @@ content:
     path: src/reviews
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: url, type: string, label: URL }
       - { name: rating, type: number, label: Rating }
       - { name: thumbnail, type: image, label: Reviewer Photo }
@@ -1574,9 +1577,9 @@ content:
         list: true
         options:
           collection: products
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - { name: permalink, type: string, label: Permalink }
       - { name: redirect_from, type: string, label: Redirect From, list: true }
       - { name: faqs, component: faqs }
@@ -1633,7 +1636,7 @@ content:
     path: src/properties
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     view:
       fields:
         - thumbnail
@@ -1645,20 +1648,12 @@ content:
       sort:
         - name
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: thumbnail, type: image, label: Thumbnail }
       - { name: order, type: number, label: Order }
       - { name: featured, type: boolean, label: Featured }
-      - name: locations
-        label: Locations
-        type: reference
-        list: true
-        options:
-          collection: locations
-          search: primary
-          value: "{path}"
-          label: "{primary}"
+      - { name: locations, type: string, label: Locations, list: true }
       - { name: bedrooms, type: number, label: Bedrooms }
       - { name: bathrooms, type: number, label: Bathrooms }
       - { name: sleeps, type: number, label: Sleeps }
@@ -1733,9 +1728,9 @@ content:
     path: src/guide-categories
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: order, type: number, label: Order }
       - { name: icon, type: image, label: Icon }
@@ -1744,9 +1739,9 @@ content:
         type: reference
         options:
           collection: properties
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - { name: body, type: rich-text, label: Body }
       - { name: permalink, type: string, label: Permalink }
       - { name: redirect_from, type: string, label: Redirect From, list: true }
@@ -1807,18 +1802,18 @@ content:
     path: src/guide-pages
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: subtitle, type: string, label: Subtitle }
       - name: guide-category
         label: Guide Category
         type: reference
         options:
           collection: guide-categories
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - { name: order, type: number, label: Order }
       - { name: body, type: rich-text, label: Body }
       - { name: permalink, type: string, label: Permalink }
@@ -1880,9 +1875,9 @@ content:
     path: src/menus
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: subtitle, type: string, label: Subtitle }
       - { name: thumbnail, type: image, label: Thumbnail }
       - { name: order, type: number, label: Order }
@@ -1948,9 +1943,9 @@ content:
     path: src/menu-categories
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: thumbnail, type: image, label: Thumbnail }
       - { name: order, type: number, label: Order }
       - name: menus
@@ -1959,9 +1954,9 @@ content:
         list: true
         options:
           collection: menus
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - { name: body, type: rich-text, label: Body }
       - { name: permalink, type: string, label: Permalink }
       - { name: redirect_from, type: string, label: Redirect From, list: true }
@@ -2020,9 +2015,9 @@ content:
     path: src/menu-items
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: thumbnail, type: image, label: Thumbnail }
       - { name: price, type: string, label: Price }
       - { name: sku, type: string, label: SKU }
@@ -2034,9 +2029,9 @@ content:
         list: true
         options:
           collection: menu-categories
-          search: primary
+          search: fields.name
           value: "{path}"
-          label: "{primary}"
+          label: "{fields.name}"
       - { name: description, type: string, label: Description }
       - { name: body, type: rich-text, label: Body }
       - { name: permalink, type: string, label: Permalink }
@@ -2096,9 +2091,11 @@ content:
     path: src/snippets
     type: collection
     subfolders: false
-    filename: "{primary}.md"
+    filename: "{name}.md"
+    exclude:
+      - README.md
     fields:
-      - { name: name, type: string, label: Name }
+      - { name: name, type: string, label: Name, required: true }
       - { name: body, type: rich-text, label: Body }
   - name: homepage
     label: Homepage Settings

--- a/scripts/customise-cms/blocks.js
+++ b/scripts/customise-cms/blocks.js
@@ -56,12 +56,15 @@ const schemaFieldToCmsField = (name, fieldSchema, useVisualEditor) => {
   }
 
   if (fieldSchema.type === "reference") {
-    return createReferenceField(
-      name,
-      fieldSchema.label || name,
-      fieldSchema.collection,
-      fieldSchema.multiple !== false,
-    );
+    return {
+      ...createReferenceField(
+        name,
+        fieldSchema.label || name,
+        fieldSchema.options.collection,
+        fieldSchema.options.multiple === true,
+      ),
+      ...(fieldSchema.required && { required: true }),
+    };
   }
 
   return buildGenericCmsField(name, fieldSchema, useVisualEditor);

--- a/scripts/customise-cms/collection-config.js
+++ b/scripts/customise-cms/collection-config.js
@@ -215,13 +215,6 @@ const getValidatedViewConfig = (collectionName, config, fieldContext) => {
 const DATE_FILENAME_COLLECTIONS = ["news"];
 
 /**
- * Check if a collection uses filename-based primary key (all except date-based ones)
- * @param {string} name - Collection name
- * @returns {boolean}
- */
-const hasFilenameConfig = (name) => !memberOf(DATE_FILENAME_COLLECTIONS)(name);
-
-/**
  * Generate configuration for a single collection
  * @param {string} collectionName - Name of the collection (must exist in COLLECTIONS)
  * @param {CmsConfig} config - CMS configuration
@@ -241,11 +234,11 @@ export const generateCollectionConfig = (
     path: collection.path,
     type: "collection",
     subfolders: false,
+    filename: memberOf(DATE_FILENAME_COLLECTIONS)(collectionName)
+      ? "{year}-{month}-{day}-{name}.md"
+      : "{name}.md",
+    ...(collectionName === "snippets" && { exclude: ["README.md"] }),
   };
-
-  if (hasFilenameConfig(collectionName)) {
-    collectionConfig.filename = "{primary}.md";
-  }
 
   const viewConfig = getValidatedViewConfig(
     collectionName,

--- a/scripts/customise-cms/config.js
+++ b/scripts/customise-cms/config.js
@@ -107,7 +107,6 @@ export const createDefaultConfig = () => ({
     "events",
     "team",
     "reviews",
-    "locations",
     "properties",
     "guide-categories",
     "guide-pages",

--- a/scripts/customise-cms/field-builders.js
+++ b/scripts/customise-cms/field-builders.js
@@ -63,6 +63,7 @@ export const productsRefList = (enabled) =>
 export const getCollectionFieldBuilders = (config, fields) => ({
   pages: () =>
     compact([
+      COMMON_FIELDS.name,
       COMMON_FIELDS.subtitle,
       fields.body,
       COMMON_FIELDS.meta_title,

--- a/scripts/customise-cms/fields.js
+++ b/scripts/customise-cms/fields.js
@@ -32,7 +32,7 @@
  * @type {Record<string, CmsField>}
  */
 export const COMMON_FIELDS = {
-  name: { name: "name", type: "string", label: "Name" },
+  name: { name: "name", type: "string", label: "Name", required: true },
   thumbnail: { name: "thumbnail", type: "image", label: "Thumbnail" },
   subtitle: { name: "subtitle", type: "string", label: "Subtitle" },
   body: {
@@ -196,9 +196,9 @@ export const createReferenceField = (
   ...(multiple && { list: true }),
   options: {
     collection,
-    search: "primary",
+    search: "fields.name",
     value: "{path}",
-    label: "{primary}",
+    label: "{fields.name}",
   },
 });
 

--- a/scripts/customise-cms/generator.js
+++ b/scripts/customise-cms/generator.js
@@ -80,7 +80,7 @@ const generateCustomBlocksCollectionConfig = (name, config, fieldContext) => {
     label: slugToLabel(name),
     path,
     type: "collection",
-    filename: "{primary}.md",
+    filename: "{name}.md",
     fields: compact([
       COMMON_FIELDS.name,
       COMMON_FIELDS.subtitle,

--- a/scripts/customise-cms/item-builders.js
+++ b/scripts/customise-cms/item-builders.js
@@ -134,10 +134,9 @@ export const buildEventsFields = (config, fields) =>
  * @returns {CmsField[]} Properties collection fields
  */
 export const buildPropertiesFields = (config, fields) =>
-  buildItem((enabled) => [
+  buildItem(() => [
     COMMON_FIELDS.featured,
-    enabled("locations") &&
-      createReferenceField("locations", "Locations", "locations"),
+    { name: "locations", type: "string", label: "Locations", list: true },
     { name: "bedrooms", type: "number", label: "Bedrooms" },
     { name: "bathrooms", type: "number", label: "Bathrooms" },
     { name: "sleeps", type: "number", label: "Sleeps" },

--- a/src/_lib/eleventy/file-utils.js
+++ b/src/_lib/eleventy/file-utils.js
@@ -146,7 +146,8 @@ const readFileContent = memoize(
  * @param {string} [baseDir]
  */
 const loadSnippet = (name, baseDir = process.cwd()) => {
-  const snippetPath = path.join(baseDir, "src/snippets", `${name}.md`);
+  const snippetName = path.basename(name, path.extname(name));
+  const snippetPath = path.join(baseDir, "src/snippets", `${snippetName}.md`);
   return fs.existsSync(snippetPath) ? matter.read(snippetPath) : null;
 };
 

--- a/src/snippets/footer-content.md
+++ b/src/snippets/footer-content.md
@@ -1,1 +1,5 @@
+---
+name: Footer Content
+---
+
 Example Web Design in Prestwich

--- a/src/snippets/right-content.md
+++ b/src/snippets/right-content.md
@@ -1,3 +1,7 @@
+---
+name: Right Content
+---
+
 ### Opening Hours
 
 {% opening_times %}

--- a/test/precommit/environment.js
+++ b/test/precommit/environment.js
@@ -1,0 +1,26 @@
+const GIT_LOCAL_ENV_VARS = [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_SHALLOW_FILE",
+  "GIT_WORK_TREE",
+];
+
+export const getStepEnvironment = (environment, verbose) => ({
+  ...Object.fromEntries(
+    Object.entries(environment).filter(
+      ([name]) => !GIT_LOCAL_ENV_VARS.includes(name),
+    ),
+  ),
+  VERBOSE: verbose ? "1" : "0",
+});

--- a/test/precommit/runner.js
+++ b/test/precommit/runner.js
@@ -33,7 +33,34 @@ import {
   reportCoverageFailures,
 } from "#test/test-runner-utils.js";
 
+const GIT_LOCAL_ENV_VARS = [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_SHALLOW_FILE",
+  "GIT_WORK_TREE",
+];
+
 const isVerbose = () => process.argv.includes("--verbose");
+
+export const getStepEnvironment = (environment, verbose) => ({
+  ...Object.fromEntries(
+    Object.entries(environment).filter(
+      ([name]) => !GIT_LOCAL_ENV_VARS.includes(name),
+    ),
+  ),
+  VERBOSE: verbose ? "1" : "0",
+});
 
 const finishStep = ({ step, stdout, stderr, status, elapsed }) => {
   const mark = status === 0 ? green("✓") : red("✗");
@@ -82,7 +109,7 @@ const runStep = async (step, showProgress) => {
   const child = spawn(command, args, {
     cwd: ROOT_DIR,
     stdio: ["ignore", "pipe", "pipe"],
-    env: { ...process.env, VERBOSE: isVerbose() ? "1" : "0" },
+    env: getStepEnvironment(process.env, isVerbose()),
   });
 
   const progress = { value: "" };

--- a/test/precommit/runner.js
+++ b/test/precommit/runner.js
@@ -19,6 +19,7 @@ import {
   write,
   yellow,
 } from "#test/precommit/colors.js";
+import { getStepEnvironment } from "#test/precommit/environment.js";
 import { getMergeConflictWarning } from "#test/precommit/merge-warning.js";
 import { promptToPushCheckedInChanges } from "#test/precommit/push.js";
 import { getSteps } from "#test/precommit/steps.js";
@@ -33,34 +34,7 @@ import {
   reportCoverageFailures,
 } from "#test/test-runner-utils.js";
 
-const GIT_LOCAL_ENV_VARS = [
-  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-  "GIT_COMMON_DIR",
-  "GIT_CONFIG",
-  "GIT_CONFIG_COUNT",
-  "GIT_CONFIG_PARAMETERS",
-  "GIT_DIR",
-  "GIT_GRAFT_FILE",
-  "GIT_IMPLICIT_WORK_TREE",
-  "GIT_INDEX_FILE",
-  "GIT_NO_REPLACE_OBJECTS",
-  "GIT_OBJECT_DIRECTORY",
-  "GIT_PREFIX",
-  "GIT_REPLACE_REF_BASE",
-  "GIT_SHALLOW_FILE",
-  "GIT_WORK_TREE",
-];
-
 const isVerbose = () => process.argv.includes("--verbose");
-
-export const getStepEnvironment = (environment, verbose) => ({
-  ...Object.fromEntries(
-    Object.entries(environment).filter(
-      ([name]) => !GIT_LOCAL_ENV_VARS.includes(name),
-    ),
-  ),
-  VERBOSE: verbose ? "1" : "0",
-});
 
 const finishStep = ({ step, stdout, stderr, status, elapsed }) => {
   const mark = status === 0 ? green("✓") : red("✗");

--- a/test/unit/code-quality/pages-yml-reference-names.test.js
+++ b/test/unit/code-quality/pages-yml-reference-names.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+import YAML from "yaml";
+import { rootDir } from "#test/test-utils.js";
+import {
+  collectReferenceFields,
+  getCollectionMap,
+} from "#test/unit/utils/pages-yml-helpers.js";
+import { unique } from "#toolkit/fp/array.js";
+
+const pagesConfig = YAML.parse(
+  readFileSync(join(rootDir, ".pages.yml"), "utf-8"),
+);
+const collections = getCollectionMap(pagesConfig);
+const referenceTargets = unique(
+  collectReferenceFields(pagesConfig).map(
+    (reference) => reference.options.collection,
+  ),
+);
+
+describe("Pages CMS reference names", () => {
+  test("every referenced collection entry has name frontmatter", () => {
+    for (const targetName of referenceTargets) {
+      const target = collections.get(targetName);
+      expect(target).toBeDefined();
+      const entries = readdirSync(join(rootDir, target.path), {
+        withFileTypes: true,
+      }).filter(
+        (entry) =>
+          entry.isFile() &&
+          entry.name.endsWith(".md") &&
+          !target.exclude?.includes(entry.name),
+      );
+
+      for (const entry of entries) {
+        const source = readFileSync(
+          join(rootDir, target.path, entry.name),
+          "utf-8",
+        );
+        expect(matter(source).data.name).toBeTruthy();
+      }
+    }
+  });
+});

--- a/test/unit/precommit.test.js
+++ b/test/unit/precommit.test.js
@@ -1,10 +1,27 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { getStepEnvironment } from "#test/precommit/runner.js";
 import { extractErrorsFromOutput } from "#test/test-runner-utils.js";
 import { expectErrorsInclude, rootDir } from "#test/test-utils.js";
 
 const precommitPath = join(rootDir, "test", "precommit.js");
 const testRunnerUtilsPath = join(rootDir, "test", "test-runner-utils.js");
+
+describe("precommit step environment", () => {
+  test("removes parent repository state from child processes", () => {
+    const environment = getStepEnvironment(
+      {
+        PATH: "/bin",
+        GIT_CONFIG_PARAMETERS: "'user.name=Test'",
+        GIT_DIR: "/repo/.git",
+        GIT_INDEX_FILE: "/repo/.git/worktrees/feature/index",
+      },
+      true,
+    );
+
+    expect(environment).toEqual({ PATH: "/bin", VERBOSE: "1" });
+  });
+});
 
 /** Read the test-runner-utils.js file content */
 const readTestRunnerUtils = () =>

--- a/test/unit/precommit.test.js
+++ b/test/unit/precommit.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { getStepEnvironment } from "#test/precommit/runner.js";
+import { getStepEnvironment } from "#test/precommit/environment.js";
 import { extractErrorsFromOutput } from "#test/test-runner-utils.js";
 import { expectErrorsInclude, rootDir } from "#test/test-utils.js";
 

--- a/test/unit/scripts/customise-cms/blocks.test.js
+++ b/test/unit/scripts/customise-cms/blocks.test.js
@@ -86,6 +86,22 @@ describe("generateBlocksField list field conversion", () => {
   });
 });
 
+describe("generateBlocksField reference conversion", () => {
+  test("preserves the snippet target and required scalar shape", () => {
+    const field = generateBlocksField(["snippet"], false);
+    const reference = field.blocks[0].fields.find(
+      (candidate) => candidate.name === "reference",
+    );
+
+    expect(reference).toMatchObject({
+      type: "reference",
+      required: true,
+      options: { collection: "snippets", label: "{fields.name}" },
+    });
+    expect(reference.list).toBeUndefined();
+  });
+});
+
 describe("generateBlocksField generic field conversion", () => {
   test("passes primitive type strings through verbatim", () => {
     // split-image covers string, boolean, and image in one block.

--- a/test/unit/scripts/customise-cms/config.test.js
+++ b/test/unit/scripts/customise-cms/config.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { getRequiredCollections } from "#scripts/customise-cms/collections.js";
+import {
+  getCollection,
+  getRequiredCollections,
+} from "#scripts/customise-cms/collections.js";
 import {
   createDefaultConfig,
   loadCmsConfig,
@@ -42,6 +45,10 @@ describe("createDefaultConfig", () => {
     expect(config.collections).toContain("news");
     expect(config.collections).toContain("snippets");
     expect(config.collections.length).toBeGreaterThan(10);
+  });
+
+  test("only includes registered collections", () => {
+    expect(config.collections.every((name) => getCollection(name))).toBe(true);
   });
 
   test("enables most features but not visual editor", () => {

--- a/test/unit/scripts/customise-cms/fields.test.js
+++ b/test/unit/scripts/customise-cms/fields.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  COMMON_FIELDS,
   createAddOnsField,
   createBodyField,
   createMarkdownField,
@@ -75,13 +76,24 @@ describe("createReferenceField", () => {
 
     expect(field.type).toBe("reference");
     expect(field.list).toBe(true);
-    expect(field.options.collection).toBe("categories");
+    expect(field.options).toEqual({
+      collection: "categories",
+      search: "fields.name",
+      value: "{path}",
+      label: "{fields.name}",
+    });
   });
 
   test("creates single reference when multiple is false", () => {
     const field = createReferenceField("author", "Author", "team", false);
 
     expect(field.list).toBeUndefined();
+  });
+});
+
+describe("COMMON_FIELDS", () => {
+  test("requires collection names", () => {
+    expect(COMMON_FIELDS.name.required).toBe(true);
   });
 });
 

--- a/test/unit/scripts/customise-cms/generator.test.js
+++ b/test/unit/scripts/customise-cms/generator.test.js
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 import YAML from "yaml";
 import { createDefaultConfig } from "#scripts/customise-cms/config.js";
 import { generatePagesYaml } from "#scripts/customise-cms/generator.js";
+import {
+  collectReferenceFields,
+  getCollectionMap,
+} from "#test/unit/utils/pages-yml-helpers.js";
 
 /**
  * @type {import('#scripts/customise-cms/config.js').CmsFeatures}
@@ -72,6 +76,41 @@ describe("generatePagesYaml output validity", () => {
     expect(collectionNames).toContain("homepage");
     expect(collectionNames).toContain("site");
   });
+
+  test("uses required names in every collection filename", () => {
+    const config = createDefaultConfig();
+    config.customBlocksCollections = ["clients"];
+    const parsed = YAML.parse(generatePagesYaml(config));
+    const collections = parsed.content.filter(
+      (entry) => entry.type === "collection",
+    );
+
+    for (const collection of collections) {
+      expect(collection.filename).toContain("{name}");
+      expect(collection.fields).toContainEqual(
+        expect.objectContaining({ name: "name", required: true }),
+      );
+    }
+  });
+
+  test("does not generate primary placeholders", () => {
+    expect(generatePagesYaml(createDefaultConfig())).not.toContain("{primary}");
+  });
+
+  test("references existing collections by required frontmatter name", () => {
+    const parsed = YAML.parse(generatePagesYaml(createDefaultConfig()));
+    const collections = getCollectionMap(parsed);
+
+    for (const reference of collectReferenceFields(parsed)) {
+      const target = collections.get(reference.options.collection);
+      expect(target).toBeDefined();
+      expect(target.fields).toContainEqual(
+        expect.objectContaining({ name: "name", required: true }),
+      );
+      expect(reference.options.search).toBe("fields.name");
+      expect(reference.options.label).toBe("{fields.name}");
+    }
+  });
 });
 
 describe("generatePagesYaml collections", () => {
@@ -89,6 +128,7 @@ describe("generatePagesYaml collections", () => {
 
     expect(yaml).toContain("name: snippets");
     expect(yaml).toContain("path: src/snippets");
+    expect(getSection("snippets")(yaml)).toContain("- README.md");
   });
 
   test("excludes snippets when not in collections list", () => {
@@ -207,6 +247,22 @@ describe("generatePagesYaml reference fields", () => {
     const section = getSection("guide-categories")(yaml);
 
     expect(section).not.toContain("collection: properties");
+  });
+
+  test("keeps property location slugs editable without a dangling reference", () => {
+    const parsed = YAML.parse(
+      generatePagesYaml(
+        createTestConfig({ collections: ["pages", "properties"] }),
+      ),
+    );
+    const properties = parsed.content.find(
+      (entry) => entry.name === "properties",
+    );
+    const locations = properties.fields.find(
+      (field) => field.name === "locations",
+    );
+
+    expect(locations).toMatchObject({ type: "string", list: true });
   });
 });
 

--- a/test/unit/utils/file-utils.test.js
+++ b/test/unit/utils/file-utils.test.js
@@ -376,6 +376,32 @@ Unicode: café résumé naïve`;
       );
     });
 
+    test("Resolves a snippet path saved by Pages CMS", async () => {
+      const content = `---
+name: CMS Snippet
+blocks:
+  - type: markdown
+    content: CMS content
+---`;
+
+      await withSnippetSetup(
+        "ctx-cms-path",
+        "cms-snippet",
+        content,
+        async (mockConfig) => {
+          const filter = mockConfig.asyncFilters.snippet_blocks;
+          const result = await filter.call(
+            { context: { environments: {} } },
+            "src/snippets/cms-snippet.md",
+          );
+
+          expect(result).toEqual([
+            { type: "markdown", content: "CMS content" },
+          ]);
+        },
+      );
+    });
+
     test("Resolves Liquid expressions in block strings with page context", async () => {
       const content = `---
 name: Test CTA

--- a/test/unit/utils/pages-yml-helpers.js
+++ b/test/unit/utils/pages-yml-helpers.js
@@ -24,3 +24,31 @@ export const collectBlockReferences = (node, acc = []) => {
   }
   return acc;
 };
+
+/**
+ * @param {unknown} node
+ * @param {object[]} [acc]
+ * @returns {object[]}
+ */
+export const collectReferenceFields = (node, acc = []) => {
+  if (Array.isArray(node)) {
+    for (const entry of node) collectReferenceFields(entry, acc);
+    return acc;
+  }
+  if (node && typeof node === "object") {
+    if (node.type === "reference") acc.push(node);
+    for (const value of Object.values(node)) collectReferenceFields(value, acc);
+  }
+  return acc;
+};
+
+/**
+ * @param {{content: object[]}} pagesConfig
+ * @returns {Map<string, object>}
+ */
+export const getCollectionMap = (pagesConfig) =>
+  new Map(
+    pagesConfig.content
+      .filter((entry) => entry.type === "collection")
+      .map((entry) => [entry.name, entry]),
+  );


### PR DESCRIPTION
## Summary

- generate collection filenames from required `name` fields and display reference labels from `{fields.name}`
- verify every reference target exists, requires `name`, and has named content while fixing snippet and stale location references
- prevent precommit child processes from inheriting linked-worktree Git state

## Testing

- `bun run precommit`
- `bun test test/unit/precommit.test.js test/unit/code-quality/pages-yml-reference-names.test.js test/unit/scripts/customise-cms/generator.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * CMS reference fields now search and display using the referenced content’s “name”.
  * Generated page/collection filenames now consistently use `{name}` and all supported collections require a `name` field.
  * Product/category/news/team/reviews/properties/guide/menu references are validated end-to-end.
  * Properties “Locations” are now an editable string list.
  * Snippets exclude `README.md`, and snippet markdown now includes standardized front-matter (including new footer/right-content names).
* **Bug Fixes**
  * Precommit step environments are now sanitized to avoid local Git state.
* **Tests**
  * Added/expanded unit coverage for reference conversion, YAML consistency, environment behavior, and snippet filter resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->