### PR TITLE
Use native auto sizes in Firefox 150+

### DIFF
--- a/src/_lib/public/ui/autosizes.js
+++ b/src/_lib/public/ui/autosizes.js
@@ -24,7 +24,7 @@
  * SOFTWARE.
  *
  * Algorithm:
- * 1. polyfillAutoSizes(): Uses UA sniffing to detect Chrome < 126 (no native support).
+ * 1. polyfillAutoSizes(): Uses UA sniffing to detect browsers without native support.
  *    Avoids polyfilling if browser is too old (no PerformanceObserver/paint timing).
  * 2. Before FCP: Store src/srcset in data attributes and remove originals to prevent loading.
  *    Also strips srcset from <source> elements inside <picture> to prevent bypass.
@@ -43,12 +43,19 @@
 
     const chromeMatch = navigator.userAgent.match(/Chrome\/(\d+)/);
 
-    if (!chromeMatch) {
+    if (chromeMatch) {
+      const chromeVersion = Number.parseInt(chromeMatch[1], 10);
+      return chromeVersion < 126;
+    }
+
+    const firefoxMatch = navigator.userAgent.match(/Firefox\/(\d+)/);
+
+    if (!firefoxMatch) {
       return true;
     }
 
-    const chromeVersion = Number.parseInt(chromeMatch[1], 10);
-    return chromeVersion < 126;
+    const firefoxVersion = Number.parseInt(firefoxMatch[1], 10);
+    return firefoxVersion < 150;
   };
 
   if (!polyfillAutoSizes()) {

--- a/test/code-quality/code-quality-exceptions.js
+++ b/test/code-quality/code-quality-exceptions.js
@@ -298,7 +298,7 @@ const ALLOWED_NULLISH_COALESCING = frozenSet([
   // src/_lib/public - frontend JavaScript (browser-side, no collections)
   "src/_lib/public/cart/cart.js:86",
   "src/_lib/public/cart/cart.js:87",
-  "src/_lib/public/ui/autosizes.js:76",
+  "src/_lib/public/ui/autosizes.js:83",
 
   // src/_lib/utils - utility functions
   "src/_lib/utils/collection-utils.js:71", // indexer may not contain the lookup slug

--- a/test/unit/build/autosizes.test.js
+++ b/test/unit/build/autosizes.test.js
@@ -195,9 +195,23 @@ describe("autosizes", () => {
       expect(img.hasAttribute("data-auto-sizes-src")).toBe(true);
     });
 
-    test("Runs polyfill for non-Chrome browsers (Firefox, Safari)", async () => {
+    test("Does not run polyfill for Firefox 150+", async () => {
       const { window, img } = await createAutosizesTestEnv({
-        userAgent: "Mozilla/5.0 Firefox/120",
+        userAgent: "Mozilla/5.0 Firefox/150",
+      });
+      runAndExpectSrc(window, img, true);
+    });
+
+    test("Runs polyfill for Firefox 149 (older than 150)", async () => {
+      const { window, img } = await createAutosizesTestEnv({
+        userAgent: "Mozilla/5.0 Firefox/149",
+      });
+      runAndExpectSrc(window, img, false);
+    });
+
+    test("Runs polyfill for Safari", async () => {
+      const { window, img } = await createAutosizesTestEnv({
+        userAgent: "Mozilla/5.0 Version/18.5 Safari/605.1.15",
       });
       runAndExpectSrc(window, img, false);
     });
@@ -236,7 +250,11 @@ describe("autosizes", () => {
 
     test("Processes local images with relative paths", async () => {
       const { window, img } = await createAutosizesTestEnv({
-        imgAttrs: { src: "/images/photo.jpg", sizes: "auto", loading: "lazy" },
+        imgAttrs: {
+          src: "/images/photo.jpg",
+          sizes: "auto",
+          loading: "lazy",
+        },
       });
       runAndCheckDeferred(window, img, "/images/photo.jpg");
     });


### PR DESCRIPTION
## Summary

- skip the autosizes shim in Firefox 150 and newer
- retain the shim for Safari and older Firefox releases
- cover the Firefox support boundary and Safari behavior

## Testing

- `bun test`
- `bun run build`
- pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autosizing support detection across Chrome and Firefox versions.
  * Ensured the autosizing polyfill runs appropriately in Safari and older Firefox releases.

* **Tests**
  * Expanded browser compatibility coverage for autosizing behavior.
  * Maintained image filtering coverage for local images with relative paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->