### PR TITLE
Style split figure captions

### DIFF
--- a/src/css/design-system/_split.scss
+++ b/src/css/design-system/_split.scss
@@ -42,7 +42,7 @@
         padding: $space-xs $space-sm;
         font-size: $font-size-sm;
         font-style: italic;
-        background: var(--body-background);
+        background: var(--color-card-bg);
       }
 
       @include video-media;

--- a/src/css/design-system/_split.scss
+++ b/src/css/design-system/_split.scss
@@ -38,6 +38,13 @@
         height: auto;
       }
 
+      figcaption {
+        padding: $space-xs $space-sm;
+        font-size: $font-size-sm;
+        font-style: italic;
+        background: var(--body-background);
+      }
+
       @include video-media;
     }
   }


### PR DESCRIPTION
## Summary
- add compact padding to split figure captions
- use small italic text with a section-aware card background
- preserve caption contrast in dark sections

## Testing
- `bun test test/unit/build/scss.test.js`
- `bun test/precommit.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved split-layout figure captions with added padding, smaller italic text, and a card-style background for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->