### PR TITLE
Handle missing contact form item tag labels

### DIFF
--- a/src/_lib/config/form-helpers.js
+++ b/src/_lib/config/form-helpers.js
@@ -27,7 +27,7 @@
 /**
  * @typedef {object} ContactFormData
  * @property {ContactFormField[]} fields
- * @property {Record<string, string>} itemTagLabels
+ * @property {Record<string, string>} [itemTagLabels]
  */
 
 /**
@@ -45,8 +45,9 @@
  * @returns {ContactFormField[]}
  */
 export function resolveFormFields(contactForm, tags, skipShowOn = false) {
+  const { fields, itemTagLabels = {} } = contactForm;
   const tagList = Array.isArray(tags) ? tags : [];
-  const matchEntry = Object.entries(contactForm.itemTagLabels).find(([tag]) =>
+  const matchEntry = Object.entries(itemTagLabels).find(([tag]) =>
     tagList.includes(tag),
   );
   const match = matchEntry
@@ -83,7 +84,7 @@ export function resolveFormFields(contactForm, tags, skipShowOn = false) {
     return [field];
   };
 
-  return contactForm.fields.flatMap(resolveField);
+  return fields.flatMap(resolveField);
 }
 
 /**

--- a/test/unit/contact-form-fields.test.js
+++ b/test/unit/contact-form-fields.test.js
@@ -93,4 +93,10 @@ describe("resolveFormFields", () => {
     // showForItemTag field is dropped (no match), plain fields pass through
     expect(out.map((f) => f.name)).toEqual(["name", "message"]);
   });
+
+  test("treats missing item tag labels as an empty mapping", () => {
+    const contactForm = { fields: baseContactForm.fields };
+    const out = resolveFormFields(contactForm, ["products"]);
+    expect(out.map((f) => f.name)).toEqual(["name", "message"]);
+  });
 });


### PR DESCRIPTION
## Summary
- treat omitted `itemTagLabels` as an empty mapping when resolving contact form fields
- keep ordinary fields while dropping unmatched item-tag fields
- document the mapping as optional and add regression coverage

## Context
Client repositories overlay their own `_data/contact-form.json` onto the template. Older client configurations can omit `itemTagLabels`, causing `Object.entries(undefined)` when a configured form target activates field rendering.

## Testing
- `nix develop -c bun run precommit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact form field handling when optional item tag labels are not provided.
  * Forms now retain their standard fields without errors or unintended item-tag-based fields.

* **Tests**
  * Added coverage to verify correct behavior when item tag labels are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->