### PR TITLE
Upgrade Eleventy image processing and report CPU usage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "chobble-template",
       "dependencies": {
-        "@11ty/eleventy": "^3.1.5",
-        "@11ty/eleventy-img": "7.0.0-alpha.4",
+        "@11ty/eleventy": "4.0.0-alpha.9",
+        "@11ty/eleventy-img": "7.0.0",
         "@11ty/eleventy-navigation": "^1.0.5",
         "@11ty/eleventy-plugin-rss": "^2.0.4",
         "@botpoison/browser": "^0.1.30",
@@ -59,27 +59,37 @@
 
     "@11ty/dependency-tree-esm": ["@11ty/dependency-tree-esm@2.0.4", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.7", "acorn": "^8.15.0", "dependency-graph": "^1.0.0", "normalize-path": "^3.0.0" } }, "sha512-MYKC0Ac77ILr1HnRJalzKDlb9Z8To3kXQCltx299pUXXUFtJ1RIONtULlknknqW8cLe19DLVgmxVCtjEFm7h0A=="],
 
-    "@11ty/eleventy": ["@11ty/eleventy@3.1.5", "", { "dependencies": { "@11ty/dependency-tree": "^4.0.2", "@11ty/dependency-tree-esm": "^2.0.4", "@11ty/eleventy-dev-server": "^2.0.8", "@11ty/eleventy-plugin-bundle": "^3.0.7", "@11ty/eleventy-utils": "^2.0.7", "@11ty/lodash-custom": "^4.17.21", "@11ty/posthtml-urls": "^1.0.2", "@11ty/recursive-copy": "^4.0.4", "@sindresorhus/slugify": "^2.2.1", "bcp-47-normalize": "^2.3.0", "chokidar": "^3.6.0", "debug": "^4.4.3", "dependency-graph": "^1.0.0", "entities": "^6.0.1", "filesize": "^10.1.6", "gray-matter": "^4.0.3", "iso-639-1": "^3.1.5", "js-yaml": "^4.1.1", "kleur": "^4.1.5", "liquidjs": "^10.25.0", "luxon": "^3.7.2", "markdown-it": "^14.1.1", "minimist": "^1.2.8", "moo": "0.5.2", "node-retrieve-globals": "^6.0.1", "nunjucks": "^3.2.4", "picomatch": "^4.0.3", "please-upgrade-node": "^3.2.0", "posthtml": "^0.16.7", "posthtml-match-helper": "^2.0.3", "semver": "^7.7.4", "slugify": "^1.6.8", "tinyglobby": "^0.2.15" }, "bin": { "eleventy": "cmd.cjs" } }, "sha512-hZ0g6MwZyRxCqXsPm82gIM304LraKbUz3ZmezOSjsqxttZG6cHTib3Qq8QkESJoKwnr+yX1eyfOkPC5/mEgZnQ=="],
+    "@11ty/dependency-tree-typescript": ["@11ty/dependency-tree-typescript@1.0.0", "", { "dependencies": { "@11ty/dependency-tree-esm": "^2.0.4", "@sveltejs/acorn-typescript": "^1.0.8", "acorn": "^8.15.0" } }, "sha512-eQcxtNbMs4LlWV1VeyjPajxO9XMB9ciikqQYnR9oXD6d5o7Fy5jjLyaRCYX0BV5znaDabH1LG4YQZuKGVzHzCg=="],
 
-    "@11ty/eleventy-dev-server": ["@11ty/eleventy-dev-server@2.0.8", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.1", "chokidar": "^3.6.0", "debug": "^4.4.0", "finalhandler": "^1.3.1", "mime": "^3.0.0", "minimist": "^1.2.8", "morphdom": "^2.7.4", "please-upgrade-node": "^3.2.0", "send": "^1.1.0", "ssri": "^11.0.0", "urlpattern-polyfill": "^10.0.0", "ws": "^8.18.1" }, "bin": { "eleventy-dev-server": "cmd.js" } }, "sha512-15oC5M1DQlCaOMUq4limKRYmWiGecDaGwryr7fTE/oM9Ix8siqMvWi+I8VjsfrGr+iViDvWcH/TVI6D12d93mA=="],
+    "@11ty/eleventy": ["@11ty/eleventy@4.0.0-alpha.9", "", { "dependencies": { "@11ty/dependency-tree": "^4.0.2", "@11ty/dependency-tree-esm": "^2.0.4", "@11ty/dependency-tree-typescript": "^1.0.0", "@11ty/eleventy-dev-server": "^3.0.0-alpha.10", "@11ty/eleventy-plugin-bundle": "^4.0.2", "@11ty/eleventy-utils": "^2.0.7", "@11ty/gray-matter": "^2.1.0", "@11ty/lodash-custom": "^4.17.21", "@11ty/node-version-check": "^1.0.1", "@11ty/nunjucks": "^4.0.0-alpha.3", "@11ty/parse-date-strings": "^2.0.6", "@11ty/posthtml-urls": "^1.0.3", "@11ty/recursive-copy": "^5.0.2", "@sindresorhus/slugify": "^3.0.0", "bcp-47-normalize": "^2.3.0", "chokidar": "^5.0.0", "dependency-graph": "^1.0.0", "entities": "^8.0.0", "import-module-string": "^2.0.3", "iso-639-1": "^3.1.5", "kleur": "^4.1.5", "liquidjs": "^10.27.1", "markdown-it": "^14.2.0", "minimist": "^1.2.8", "moo": "0.5.2", "node-retrieve-globals": "^6.0.1", "obug": "^2.1.3", "picomatch": "^4.0.4", "posthtml": "^0.16.7", "posthtml-match-helper": "^2.0.3", "semver": "^7.8.5", "tinyglobby": "^0.2.17" }, "bin": { "eleventy": "cmd.cjs" } }, "sha512-SSgoavzxnngcrOBbOtqJLwsOTZypkwShpmqFTF6EPcrbh4x7Jz5xFFrj/gJRyo9yk+pUgM56e3JsSPnzgcSz1g=="],
 
-    "@11ty/eleventy-fetch": ["@11ty/eleventy-fetch@5.1.1", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.7", "@rgrove/parse-xml": "^4.2.0", "debug": "^4.4.3", "flatted": "^3.3.3", "p-queue": "6.6.2" } }, "sha512-/xFJLCrqKlcnRKIfO9Qjd1QOs4IpvypljXET955+EgdRPFA+h8Or6bDnZBbcwr6KS7yeUuzp5k1DhXgbentSTA=="],
+    "@11ty/eleventy-dev-server": ["@11ty/eleventy-dev-server@3.0.0-alpha.10", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.7", "@11ty/node-version-check": "^1.0.1", "chokidar": "^5.0.0", "debug": "^4.4.3", "finalhandler": "^2.1.1", "mime": "^4.1.0", "minimist": "^1.2.8", "morphdom": "^2.7.8", "send": "^1.2.1", "urlpattern-polyfill": "^10.1.0", "ws": "^8.21.0" }, "bin": { "eleventy-dev-server": "cmd.cjs" } }, "sha512-/3bR71s1Wgavp6wmTWPSEmVbNIawnaZiushHIPMuq9vVUKwJtegmY9C1TTPD2Z/Z1IHzuft/QNlZxEnKzXJttw=="],
 
-    "@11ty/eleventy-img": ["@11ty/eleventy-img@7.0.0-alpha.4", "", { "dependencies": { "@11ty/eleventy-fetch": "^5.1.2", "@11ty/eleventy-utils": "^2.0.7", "brotli-size": "^4.0.0", "debug": "^4.4.3", "entities": "^6.0.1", "image-size": "^1.2.1", "p-queue": "^8.1.0", "sharp": "^0.34.5" } }, "sha512-7FJD1+ShuWK+rvLNvSpWyWmGKnOzDqPfMYcXyBH5cAMZcsjWAsPhzX1ERjvOROz41D6hLu/Ss6YE77yOmRGQSA=="],
+    "@11ty/eleventy-fetch": ["@11ty/eleventy-fetch@5.1.3", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.7", "@rgrove/parse-xml": "^4.2.1", "debug": "^4.4.3", "flatted": "^3.4.2", "p-queue": "6.6.2" } }, "sha512-4HS6QB/mVWTVlE6kjCKPkjkC1Z0YOqizJaHR05zK+E7a2b4EUC3T+wLktIy7wEl76ZoarkY45EKLmTw1XuR8fQ=="],
+
+    "@11ty/eleventy-img": ["@11ty/eleventy-img@7.0.0", "", { "dependencies": { "@11ty/eleventy-fetch": "^5.1.3", "@11ty/eleventy-utils": "^2.0.7", "brotli-size": "^4.0.0", "entities": "^8.0.0", "obug": "^2.1.4", "p-queue": "^9.3.3", "sharp": "^0.35.3" } }, "sha512-4b8BSTd1XZSax3hFg1Iyv3B3Vc2DmuTenbFr7M0+x4H3fNJDYq3Bctc9rDxiD021hzO7v6MPXXCb5HsQT6//Aw=="],
 
     "@11ty/eleventy-navigation": ["@11ty/eleventy-navigation@1.0.5", "", { "dependencies": { "dependency-graph": "^1.0.0" } }, "sha512-zb6xe29cM9viSdYtZywKIkJw2HIROyBINdBcFWC9uD0c/jYOTAex5nwy3HNEuh5t6/Ld/S9V4gEizfmeYuYpCQ=="],
 
-    "@11ty/eleventy-plugin-bundle": ["@11ty/eleventy-plugin-bundle@3.0.7", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.2", "debug": "^4.4.0", "posthtml-match-helper": "^2.0.3" } }, "sha512-QK1tRFBhQdZASnYU8GMzpTdsMMFLVAkuU0gVVILqNyp09xJJZb81kAS3AFrNrwBCsgLxTdWHJ8N64+OTTsoKkA=="],
+    "@11ty/eleventy-plugin-bundle": ["@11ty/eleventy-plugin-bundle@4.0.2", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.7", "obug": "^2.1.3", "posthtml-match-helper": "^2.0.3" } }, "sha512-eIrfJ3x1B8HtpNKQItCWgzYqgJiPYyAbkxAvhLkabhA4adkAEMvM2m5yM/5Hgj9M1tG7CZ1q9dR9eqw1mLAy1A=="],
 
     "@11ty/eleventy-plugin-rss": ["@11ty/eleventy-plugin-rss@2.0.4", "", { "dependencies": { "@11ty/eleventy-utils": "^2.0.0", "@11ty/posthtml-urls": "^1.0.1", "debug": "^4.4.0", "posthtml": "^0.16.6" } }, "sha512-LF60sGVlxGTryQe3hTifuzrwF8R7XbrNsM2xfcDcNMSliLN4kmB+7zvoLRySRx0AQDjqhPTAeeeT0ra6/9zHUQ=="],
 
     "@11ty/eleventy-utils": ["@11ty/eleventy-utils@2.0.7", "", {}, "sha512-6QE+duqSQ0GY9rENXYb4iPR4AYGdrFpqnmi59tFp9VrleOl0QSh8VlBr2yd6dlhkdtj7904poZW5PvGr9cMiJQ=="],
 
+    "@11ty/gray-matter": ["@11ty/gray-matter@2.1.0", "", { "dependencies": { "js-yaml": "^4.2.0", "section-matter": "^1.0.0" } }, "sha512-fNdBOb3MgDz/1UCIoeY4wDuGbp+/3s5y6UrsyfMabECbh/CVycj7Er33JXqSxRwxrRKXcGE1Jipuq/1mODInsQ=="],
+
     "@11ty/lodash-custom": ["@11ty/lodash-custom@4.17.21", "", {}, "sha512-Mqt6im1xpb1Ykn3nbcCovWXK3ggywRJa+IXIdoz4wIIK+cvozADH63lexcuPpGS/gJ6/m2JxyyXDyupkMr5DHw=="],
 
-    "@11ty/posthtml-urls": ["@11ty/posthtml-urls@1.0.2", "", { "dependencies": { "evaluate-value": "^2.0.0", "http-equiv-refresh": "^2.0.1", "list-to-array": "^1.1.0", "parse-srcset": "^1.0.2" } }, "sha512-0vaV3Wt0surZ+oS1VdKKe0axeeupuM+l7W/Z866WFQwF+dGg2Tc/nmhk/5l74/Y55P8KyImnLN9CdygNw2huHg=="],
+    "@11ty/node-version-check": ["@11ty/node-version-check@1.0.1", "", { "dependencies": { "semver": "^7.7.3" } }, "sha512-x8Lw7WwW0C5ornA5gh5YRFi51QO5NNeQ0+B1+RUj2ZFSVN6ptgtp28HLSkX7tcIGdVGOd8xLffEFtQ3idxHvVg=="],
 
-    "@11ty/recursive-copy": ["@11ty/recursive-copy@4.0.4", "", { "dependencies": { "errno": "^1.0.0", "junk": "^3.1.0", "minimatch": "^3.1.5", "slash": "^3.0.0" } }, "sha512-oI7m8pa7/IAU/3lqRU9vjBbs20iKFo7x+1K9kT3aVira6scc1X9MjBdgLCHzLJeJ7iB6wydioA+kr9/qPnvmlQ=="],
+    "@11ty/nunjucks": ["@11ty/nunjucks@4.0.0-alpha.3", "", {}, "sha512-oWDW+MtBq8dKrx/njAjCXxrThS5q0Fvaj632a9RwUqKhddeOAgqKN5odvev/PSpkSTGhrLRkaLkjAVrvqrdKsQ=="],
+
+    "@11ty/parse-date-strings": ["@11ty/parse-date-strings@2.0.6", "", {}, "sha512-UbN0jKuELYAVnjbFiRjrvHGQMLcxMThlJXsyqIA2f6gTbo9BqeBLbXLjx9/t8Wx1NutNaXVB3jRU76IrsOXDXQ=="],
+
+    "@11ty/posthtml-urls": ["@11ty/posthtml-urls@1.0.3", "", { "dependencies": { "evaluate-value": "^2.0.0", "http-equiv-refresh": "^2.0.1", "list-to-array": "^1.1.0", "parse-srcset": "^1.0.2" } }, "sha512-1YvhnkaNlFnnJic1rBMWmTC2adbuy+JQiBfl1Hecr1Wjjik1pQZmGyk/eC9zKX/FQv52s2Nht1Gi/UwhYqrBeg=="],
+
+    "@11ty/recursive-copy": ["@11ty/recursive-copy@5.0.2", "", { "dependencies": { "errno": "^1.0.0", "junk": "^3.1.0", "minimatch": "^10.2.4" } }, "sha512-3fzosXvQEyGl7vVXkJ+8ixlhu+BP0Gw9bGKtPuP8JPYJEfEgSc8w86pxjgMq/WNfAs0vPQWOO4lFdAZ7DEbN9g=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -145,6 +155,8 @@
 
     "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
 
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
+
     "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
 
     "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
@@ -182,6 +194,8 @@
     "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
 
     "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
     "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
 
@@ -409,7 +423,7 @@
 
     "@quasibit/eleventy-plugin-schema": ["@quasibit/eleventy-plugin-schema@1.13.0", "", { "peerDependencies": { "@11ty/eleventy": ">=0.11.0" } }, "sha512-e4Vu2nkwBrczh1h8ra02P/jOfaz7OnN6AvLm+NRQzGnm7ytusHWJgaH/UilzQRAr58QDYrZneIUJ9ijsbOA4NQ=="],
 
-    "@rgrove/parse-xml": ["@rgrove/parse-xml@4.2.0", "", {}, "sha512-UuBOt7BOsKVOkFXRe4Ypd/lADuNIfqJXv8GvHqtXaTYXPPKkj2nS2zPllVsrtRjcomDhIJVBnZwfmlI222WH8g=="],
+    "@rgrove/parse-xml": ["@rgrove/parse-xml@4.2.3", "", {}, "sha512-Jhlb+0zYez1T1yXUQs3F1qAtFuJljBVNdy9TKmLDauAXkxsOXopKYOyQ5Wm6SvP3fycav0GviX4Y15WWhGetMw=="],
 
     "@sentry/core": ["@sentry/core@9.47.1", "", {}, "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw=="],
 
@@ -424,6 +438,8 @@
     "@sindresorhus/slugify": ["@sindresorhus/slugify@3.0.0", "", { "dependencies": { "@sindresorhus/transliterate": "^2.0.0", "escape-string-regexp": "^5.0.0" } }, "sha512-SCrKh1zS96q+CuH5GumHcyQEVPsM4Ve8oE0E6tw7AAhGq50K8ojbTUOQnX/j9Mhcv/AXiIsbCfquovyGOo5fGw=="],
 
     "@sindresorhus/transliterate": ["@sindresorhus/transliterate@2.3.0", "", {}, "sha512-BBgw7tduDCoOKPSjuSxqfqeudXLvu7qCffDZHskdfaBWEFBtr9ecrMLevvGAYYk5fWA1I56wn1DgXWKz7D574g=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.11", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
@@ -453,8 +469,6 @@
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
-    "a-sync-waterfall": ["a-sync-waterfall@1.0.1", "", {}, "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="],
-
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
@@ -470,8 +484,6 @@
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -493,7 +505,7 @@
 
     "badgen": ["badgen@3.2.3", "", {}, "sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
 
@@ -517,11 +529,9 @@
 
     "bcp-47-normalize": ["bcp-47-normalize@2.3.0", "", { "dependencies": { "bcp-47": "^2.0.0", "bcp-47-match": "^2.0.0" } }, "sha512-8I/wfzqQvttUFz7HVJgIZ7+dj3vUaIyIxYXaTRP1YWoSDfzt6TUmxaKZeuXR62qBmYr+nvuWINFRl6pZ5DlN4Q=="],
 
-    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
-
     "blamer": ["blamer@1.0.7", "", { "dependencies": { "execa": "^4.0.0", "which": "^2.0.2" } }, "sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA=="],
 
-    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -547,7 +557,7 @@
 
     "character-parser": ["character-parser@2.2.0", "", { "dependencies": { "is-regex": "^1.0.3" } }, "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw=="],
 
-    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "chrome-launcher": ["chrome-launcher@1.2.1", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A=="],
 
@@ -570,8 +580,6 @@
     "colors": ["colors@1.4.0", "", {}, "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="],
 
     "commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
-
-    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "configstore": ["configstore@7.1.0", "", { "dependencies": { "atomically": "^2.0.3", "dot-prop": "^9.0.0", "graceful-fs": "^4.2.11", "xdg-basedir": "^5.1.0" } }, "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg=="],
 
@@ -707,15 +715,13 @@
 
     "file-entry-cache": ["file-entry-cache@11.1.2", "", { "dependencies": { "flat-cache": "^6.1.20" } }, "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log=="],
 
-    "filesize": ["filesize@10.1.6", "", {}, "sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w=="],
-
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "flat-cache": ["flat-cache@6.1.22", "", { "dependencies": { "cacheable": "^2.3.4", "flatted": "^3.4.2", "hookified": "^1.15.0" } }, "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug=="],
 
-    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
@@ -797,8 +803,6 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
-
     "image-ssim": ["image-ssim@0.2.0", "", {}, "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg=="],
 
     "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
@@ -808,6 +812,8 @@
     "import-in-the-middle": ["import-in-the-middle@1.15.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^1.2.2", "module-details-from-path": "^1.0.3" } }, "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "import-module-string": ["import-module-string@2.0.3", "", { "dependencies": { "acorn": "^8.15.0", "acorn-walk": "^8.3.4", "esm-import-transformer": "^3.0.5" } }, "sha512-r4YU95vbJbQ6ZI/8faM4EKJr8mw03nVJInEozgPIYFFDrYNtNgYu+WDBrWnIQnQUhP4/H9Ce91sgwsA4yEu25A=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -826,8 +832,6 @@
     "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
-
-    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
@@ -881,7 +885,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "jscpd": ["jscpd@4.0.9", "", { "dependencies": { "@jscpd/badge-reporter": "4.0.5", "@jscpd/core": "4.0.5", "@jscpd/finder": "4.0.5", "@jscpd/html-reporter": "4.0.5", "@jscpd/tokenizer": "4.0.5", "colors": "^1.4.0", "commander": "^5.0.0", "fs-extra": "^11.2.0", "jscpd-sarif-reporter": "4.0.7" }, "bin": { "jscpd": "bin/jscpd" } }, "sha512-fp6Sh42W3mIPoQgZmgYmKDLQzEDnnX2vaGlTN4haILkB2vsi+ewcCHEtWR/2CR/QbsBvAvsNo8U5Sa+p9aHiGw=="],
 
@@ -963,7 +967,7 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+    "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -971,11 +975,9 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
@@ -985,7 +987,7 @@
 
     "moo": ["moo@0.5.2", "", {}, "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="],
 
-    "morphdom": ["morphdom@2.7.7", "", {}, "sha512-04GmsiBcalrSCNmzfo+UjU8tt3PhZJKzcOy+r1FlGA7/zri8wre3I1WkYN9PT3sIeIKfW9bpyElA+VzOg2E24g=="],
+    "morphdom": ["morphdom@2.7.8", "", {}, "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1003,13 +1005,13 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
-    "nunjucks": ["nunjucks@3.2.4", "", { "dependencies": { "a-sync-waterfall": "^1.0.0", "asap": "^2.0.3", "commander": "^5.1.0" }, "peerDependencies": { "chokidar": "^3.3.0" }, "optionalPeers": ["chokidar"], "bin": { "nunjucks-precompile": "bin/precompile" } }, "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ=="],
-
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
@@ -1025,9 +1027,9 @@
 
     "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
 
-    "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
+    "p-queue": ["p-queue@9.3.3", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA=="],
 
-    "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+    "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
@@ -1070,8 +1072,6 @@
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
-
-    "please-upgrade-node": ["please-upgrade-node@3.2.0", "", { "dependencies": { "semver-compare": "^1.0.0" } }, "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg=="],
 
     "png-js": ["png-js@1.0.0", "", {}, "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="],
 
@@ -1149,13 +1149,11 @@
 
     "qified": ["qified@0.9.1", "", { "dependencies": { "hookified": "^2.1.1" } }, "sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg=="],
 
-    "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
-
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
-    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
@@ -1187,9 +1185,7 @@
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -1213,8 +1209,6 @@
 
     "slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
 
-    "slugify": ["slugify@1.6.9", "", {}, "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg=="],
-
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
@@ -1232,8 +1226,6 @@
     "speedline-core": ["speedline-core@1.4.3", "", { "dependencies": { "@types/node": "*", "image-ssim": "^0.2.0", "jpeg-js": "^0.4.1" } }, "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
-    "ssri": ["ssri@11.0.0", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-aZpUoMN/Jj2MqA4vMCeiKGnc/8SuSyHbGSBdgFbZxP8OJGF/lFkIuElzPxsN0q8TQQ+prw3P4EDfB3TBHHgfXw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1289,7 +1281,7 @@
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tldts-core": ["tldts-core@7.0.19", "", {}, "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A=="],
 
@@ -1322,8 +1314,6 @@
     "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
 
@@ -1371,19 +1361,31 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@11ty/eleventy/@sindresorhus/slugify": ["@sindresorhus/slugify@2.2.1", "", { "dependencies": { "@sindresorhus/transliterate": "^1.0.0", "escape-string-regexp": "^5.0.0" } }, "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw=="],
+    "@11ty/eleventy/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
-    "@11ty/eleventy/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "@11ty/eleventy/liquidjs": ["liquidjs@10.27.2", "", { "dependencies": { "commander": "^10.0.0" }, "bin": { "liquidjs": "bin/liquid.js", "liquid": "bin/liquid.js" } }, "sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w=="],
 
-    "@11ty/eleventy-dev-server/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "@11ty/eleventy/markdown-it": ["markdown-it@14.3.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.5.0", "linkify-it": "^5.0.2", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw=="],
+
+    "@11ty/eleventy/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "@11ty/eleventy-dev-server/ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "@11ty/eleventy-fetch/p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
 
-    "@11ty/eleventy-img/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "@11ty/eleventy-img/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
-    "@11ty/recursive-copy/slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+    "@11ty/eleventy-img/sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" } }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
+
+    "@11ty/eleventy-plugin-rss/@11ty/posthtml-urls": ["@11ty/posthtml-urls@1.0.2", "", { "dependencies": { "evaluate-value": "^2.0.0", "http-equiv-refresh": "^2.0.1", "list-to-array": "^1.1.0", "parse-srcset": "^1.0.2" } }, "sha512-0vaV3Wt0surZ+oS1VdKKe0axeeupuM+l7W/Z866WFQwF+dGg2Tc/nmhk/5l74/Y55P8KyImnLN9CdygNw2huHg=="],
+
+    "@11ty/gray-matter/js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+
+    "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
+
+    "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
     "@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
@@ -1407,10 +1409,6 @@
 
     "@sentry/node/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
     "chrome-launcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -1419,23 +1417,21 @@
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "cosmiconfig/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "flat-cache/flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
-
     "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
-
-    "gray-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "htmlparser2/entities": ["entities@3.0.1", "", {}, "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="],
 
     "is-expression/acorn": ["acorn@7.4.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="],
+
+    "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "knip/zod": ["zod@4.3.4", "", {}, "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A=="],
 
@@ -1447,11 +1443,11 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "p-queue/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "puppeteer-core/devtools-protocol": ["devtools-protocol@0.0.1534754", "", {}, "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ=="],
 
     "qified/hookified": ["hookified@2.2.0", "", {}, "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA=="],
-
-    "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "sass/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -1460,6 +1456,8 @@
     "table/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "table/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "tinyglobby/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1471,7 +1469,59 @@
 
     "@11ty/eleventy-fetch/p-queue/p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
-    "@11ty/eleventy/@sindresorhus/slugify/@sindresorhus/transliterate": ["@sindresorhus/transliterate@1.6.0", "", { "dependencies": { "escape-string-regexp": "^5.0.0" } }, "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ=="],
+    "@11ty/eleventy-img/sharp/@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@11ty/eleventy-img/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
+
+    "@11ty/eleventy/liquidjs/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
+    "@11ty/eleventy/markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "@11ty/eleventy/markdown-it/linkify-it": ["linkify-it@5.0.2", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 
@@ -1487,10 +1537,6 @@
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
     "sass/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "table/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -1500,6 +1546,8 @@
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@sentry/node/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
 		"zod": "^3.25.76"
 	},
 	"dependencies": {
-		"@11ty/eleventy": "^3.1.5",
-		"@11ty/eleventy-img": "7.0.0-alpha.4",
+		"@11ty/eleventy": "4.0.0-alpha.9",
+		"@11ty/eleventy-img": "7.0.0",
 		"@11ty/eleventy-navigation": "^1.0.5",
 		"@11ty/eleventy-plugin-rss": "^2.0.4",
 		"@botpoison/browser": "^0.1.30",

--- a/scripts/build-metrics.js
+++ b/scripts/build-metrics.js
@@ -1,0 +1,40 @@
+import os from "node:os";
+
+const sumTimes = (times) =>
+  times.user + times.nice + times.sys + times.idle + times.irq;
+
+const getCpuSnapshot = (cpus = os.cpus()) => {
+  if (cpus.length === 0) {
+    throw new Error("CPU usage is unavailable: no logical CPUs were reported");
+  }
+
+  return cpus.reduce(
+    (snapshot, cpu) => {
+      snapshot.idle += cpu.times.idle;
+      snapshot.total += sumTimes(cpu.times);
+      return snapshot;
+    },
+    { idle: 0, total: 0, logicalCpuCount: cpus.length },
+  );
+};
+
+const calculateAverageCpuUsage = (start, end) => {
+  const idle = end.idle - start.idle;
+  const total = end.total - start.total;
+  if (total <= 0 || idle < 0 || idle > total) {
+    throw new Error("CPU usage is unavailable: invalid CPU time delta");
+  }
+
+  const percentage = ((total - idle) / total) * 100;
+  return {
+    percentage,
+    busyCores: (percentage / 100) * end.logicalCpuCount,
+    logicalCpuCount: end.logicalCpuCount,
+  };
+};
+
+const formatAverageCpuUsage = ({ percentage, busyCores, logicalCpuCount }) =>
+  `Average system CPU usage: ${percentage.toFixed(1)}% ` +
+  `(${busyCores.toFixed(1)} of ${logicalCpuCount} logical CPUs)`;
+
+export { calculateAverageCpuUsage, formatAverageCpuUsage, getCpuSnapshot };

--- a/scripts/eleventy-build.js
+++ b/scripts/eleventy-build.js
@@ -11,6 +11,11 @@
  */
 import { spawn, spawnSync } from "node:child_process";
 import { parseArgs } from "node:util";
+import {
+  calculateAverageCpuUsage,
+  formatAverageCpuUsage,
+  getCpuSnapshot,
+} from "#scripts/build-metrics.js";
 
 const ERROR_PATTERNS = [
   "[11ty] Problem writing Eleventy templates:",
@@ -33,6 +38,8 @@ const args = [];
 if (values.serve) args.push("--serve");
 if (values.incremental) args.push("--incremental");
 args.push(...positionals);
+
+const cpuStart = getCpuSnapshot();
 
 const eleventy = spawn(
   "bun",
@@ -132,6 +139,8 @@ eleventy.on("close", (code) => {
     if (!runPagefind()) {
       process.exit(1);
     }
+    const cpuUsage = calculateAverageCpuUsage(cpuStart, getCpuSnapshot());
+    console.log(formatAverageCpuUsage(cpuUsage));
   }
   process.exit(0);
 });

--- a/scripts/strict-typecheck-ratchet.js
+++ b/scripts/strict-typecheck-ratchet.js
@@ -14,7 +14,7 @@ import { spawnSync } from "node:child_process";
 import { ROOT_DIR } from "#lib/paths.js";
 
 // Current baseline - lower this as you fix errors
-const CURRENT_ERROR_COUNT = 366;
+const CURRENT_ERROR_COUNT = 364;
 
 // Files that currently pass strict mode (must not regress)
 const STRICT_CLEAN_FILES = [
@@ -71,6 +71,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/eleventy/video.js",
   "src/_lib/filters/filter-core.js",
   "src/_lib/filters/spec-filters.js",
+  "src/_lib/media/image-crop.js",
   "src/_lib/media/image-frontmatter.js",
   "src/_lib/media/image-placeholder.js",
   "src/_lib/media/inline-asset.js",

--- a/src/_lib/media/image-crop.js
+++ b/src/_lib/media/image-crop.js
@@ -1,59 +1,76 @@
 /**
  * Image cropping utilities for aspect ratio manipulation.
- *
- * Caches cropped images in .image-cache/ using MD5 hash of source+ratio.
- * Handles EXIF orientation by swapping width/height for rotated images.
- *
- * cropImage uses dedupeAsync to prevent concurrent writes to the same file.
- * Without this, concurrent calls could both see fs.existsSync()=false and
- * race to write the same file, corrupting it ("Input Buffer is empty" error).
+ * Handles EXIF orientation, width clamping, and Eleventy Image transforms.
  */
-import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
-import { dedupeAsync, memoize } from "#toolkit/fp/memoize.js";
+import { memoize } from "#toolkit/fp/memoize.js";
 import { simplifyRatio } from "#utils/math-utils.js";
+
+/** @typedef {import("sharp").Metadata} Metadata */
+/** @typedef {import("sharp").Sharp} Sharp */
 
 const getSharp = async () => (await import("sharp")).default;
 
-const CROP_CACHE_DIR = ".image-cache";
-
+/**
+ * @param {string | null} aspectRatio
+ * @param {Metadata} metadata
+ */
 const getAspectRatio = (aspectRatio, metadata) =>
   aspectRatio || simplifyRatio(metadata);
 
-const cropImage = dedupeAsync(
-  async (aspectRatio, sourcePath, metadata) => {
-    if (!aspectRatio) return sourcePath;
+/** @param {string} aspectRatio */
+const parseCropAspectRatio = (aspectRatio) => {
+  const [ratioWidth, ratioHeight] = aspectRatio
+    .split("/")
+    .map(Number.parseFloat);
+  return ratioWidth / ratioHeight;
+};
 
-    const cacheHash = crypto
-      .createHash("md5")
-      .update(`${sourcePath}:${aspectRatio}`)
-      .digest("hex")
-      .slice(0, 8);
-    const basename = path.basename(sourcePath, path.extname(sourcePath));
-    const cachedPath = path.join(
-      CROP_CACHE_DIR,
-      `${basename}-crop-${cacheHash}.jpeg`,
-    );
-    if (fs.existsSync(cachedPath)) return cachedPath;
+/**
+ * @param {(number | string)[]} widths
+ * @param {string | null} aspectRatio
+ * @param {Metadata} metadata
+ * @returns {(number | string)[]}
+ */
+const sanitizeCropWidths = (widths, aspectRatio, metadata) => {
+  if (!aspectRatio) return widths;
 
-    const [ratioWidth, ratioHeight] = aspectRatio
-      .split("/")
-      .map(Number.parseFloat);
-    const cropHeight = Math.round(metadata.width / (ratioWidth / ratioHeight));
-    fs.mkdirSync(CROP_CACHE_DIR, { recursive: true });
+  const maxWidth = Math.min(
+    metadata.width,
+    Math.floor(metadata.height * parseCropAspectRatio(aspectRatio)),
+  );
+  return [
+    ...new Set(
+      widths.map((width) =>
+        Math.min(
+          width === "auto" ? maxWidth : Number.parseInt(String(width), 10),
+          maxWidth,
+        ),
+      ),
+    ),
+  ];
+};
 
-    const sharp = await getSharp();
-    await sharp(sourcePath)
-      .rotate()
-      .resize(metadata.width, cropHeight, { fit: "cover" })
-      .toFile(cachedPath);
+/**
+ * @param {string | null} aspectRatio
+ * @returns {{manualCacheKey?: string, transform?: (sharp: Sharp, stats: {width: number}) => Sharp}}
+ */
+const getCropImageOptions = (aspectRatio) => {
+  if (!aspectRatio) return {};
 
-    return cachedPath;
-  },
-  { cacheKey: (args) => `${args[0]}:${args[1]}` },
-);
+  const cropRatio = parseCropAspectRatio(aspectRatio);
+  return {
+    manualCacheKey: aspectRatio,
+    transform: (sharp, stats) =>
+      sharp.resize({
+        width: stats.width,
+        height: Math.floor(stats.width / cropRatio),
+        fit: "cover",
+        position: "centre",
+      }),
+  };
+};
 
+/** @param {string} imagePath */
 const getMetadata = memoize(async (imagePath) => {
   const sharp = await getSharp();
   const metadata = await sharp(imagePath).metadata();
@@ -66,4 +83,10 @@ const getMetadata = memoize(async (imagePath) => {
   return metadata;
 });
 
-export { cropImage, getAspectRatio, getMetadata, getSharp };
+export {
+  getAspectRatio,
+  getCropImageOptions,
+  getMetadata,
+  getSharp,
+  sanitizeCropWidths,
+};

--- a/src/_lib/media/image-crop.js
+++ b/src/_lib/media/image-crop.js
@@ -26,6 +26,19 @@ const parseCropAspectRatio = (aspectRatio) => {
 };
 
 /**
+ * @param {string | null} aspectRatio
+ * @param {Metadata} metadata
+ * @returns {number}
+ */
+const getCropMaxWidth = (aspectRatio, metadata) =>
+  aspectRatio
+    ? Math.min(
+        metadata.width,
+        Math.floor(metadata.height * parseCropAspectRatio(aspectRatio)),
+      )
+    : metadata.width;
+
+/**
  * @param {(number | string)[]} widths
  * @param {string | null} aspectRatio
  * @param {Metadata} metadata
@@ -34,10 +47,7 @@ const parseCropAspectRatio = (aspectRatio) => {
 const sanitizeCropWidths = (widths, aspectRatio, metadata) => {
   if (!aspectRatio) return widths;
 
-  const maxWidth = Math.min(
-    metadata.width,
-    Math.floor(metadata.height * parseCropAspectRatio(aspectRatio)),
-  );
+  const maxWidth = getCropMaxWidth(aspectRatio, metadata);
   return [
     ...new Set(
       widths.map((width) =>
@@ -86,6 +96,7 @@ const getMetadata = memoize(async (imagePath) => {
 export {
   getAspectRatio,
   getCropImageOptions,
+  getCropMaxWidth,
   getMetadata,
   getSharp,
   sanitizeCropWidths,

--- a/src/_lib/media/image-pipeline.js
+++ b/src/_lib/media/image-pipeline.js
@@ -22,6 +22,7 @@ import { parseHtml } from "#utils/dom-builder.js";
  * @param {string} path - Image path or URL
  * @param {Object} baseOptions - Base options (outputDir, filenameFormat, etc.)
  * @param {(number | string)[]} webpWidths - Widths for webp format (includes "auto" for original)
+ * @param {(number | string)[]} [jpegWidths] - Widths for the JPEG fallback
  * @returns {Promise<Object>} Combined webp + jpeg image metadata
  */
 export const processFormats = async (
@@ -29,13 +30,14 @@ export const processFormats = async (
   path,
   baseOptions,
   webpWidths,
+  jpegWidths = [JPEG_FALLBACK_WIDTH],
 ) => {
   const [webpMetadata, jpegMetadata] = await Promise.all([
     imageFn(path, { ...baseOptions, formats: ["webp"], widths: webpWidths }),
     imageFn(path, {
       ...baseOptions,
       formats: ["jpeg"],
-      widths: [JPEG_FALLBACK_WIDTH],
+      widths: jpegWidths,
     }),
   ]);
   return { ...webpMetadata, ...jpegMetadata };

--- a/src/_lib/media/image-utils.js
+++ b/src/_lib/media/image-utils.js
@@ -176,11 +176,15 @@ export const getPathAwareBasename = (src) => {
  * @param {string} src - Source path
  * @param {number} width - Output width
  * @param {string} format - Output format
+ * @param {{manualCacheKey?: string | number}} [options] - Eleventy Image options
  * @returns {string} Generated filename
  */
-export const filenameFormat = (_id, src, width, format) => {
+export const filenameFormat = (_id, src, width, format, options = {}) => {
   const basename = getPathAwareBasename(src);
-  return `${basename}-${width}.${format}`;
+  const cropSuffix = options.manualCacheKey
+    ? `-crop-${String(options.manualCacheKey).replaceAll("/", "x")}`
+    : "";
+  return `${basename}${cropSuffix}-${width}.${format}`;
 };
 
 // JPEG fallback width - only generate one JPEG size since nearly all browsers support webp

--- a/src/_lib/media/image-utils.js
+++ b/src/_lib/media/image-utils.js
@@ -181,8 +181,9 @@ export const getPathAwareBasename = (src) => {
  */
 export const filenameFormat = (_id, src, width, format, options = {}) => {
   const basename = getPathAwareBasename(src);
+  const extension = src.slice(src.lastIndexOf(".") + 1).toLowerCase();
   const cropSuffix = options.manualCacheKey
-    ? `-crop-${String(options.manualCacheKey).replaceAll("/", "x")}`
+    ? `-${extension}-crop-${String(options.manualCacheKey).replaceAll("/", "x")}`
     : "";
   return `${basename}${cropSuffix}-${width}.${format}`;
 };

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -18,7 +18,12 @@ import fs from "node:fs";
 /** @typedef {import("#lib/types").ImageProps} ImageProps */
 /** @typedef {import("#lib/types").ComputeImageProps} ComputeImageProps */
 import { PLACEHOLDER_MODE } from "#build/build-mode.js";
-import { cropImage, getAspectRatio, getMetadata } from "#media/image-crop.js";
+import {
+  getAspectRatio,
+  getCropImageOptions,
+  getMetadata,
+  sanitizeCropWidths,
+} from "#media/image-crop.js";
 import { processExternalImage } from "#media/image-external.js";
 import {
   getEleventyImg,
@@ -36,6 +41,7 @@ import {
   buildWrapperStyles,
   filenameFormat,
   isExternalUrl,
+  JPEG_FALLBACK_WIDTH,
   normalizeImagePath,
   normalizeImageUrl,
   parseWidths,
@@ -73,25 +79,39 @@ const processImageData = dedupeAsync(
   }) => {
     const imagePath = normalizeImagePath(imageName);
     const metadata = await getMetadata(imagePath);
-    const finalPath = await cropImage(aspectRatio, imagePath, metadata);
 
     const { default: Image } = await getEleventyImg();
 
     // Check if LQIP should be generated (skip for SVGs, transparent images, small files, or if noLqip is set)
     const generateLqip =
-      !noLqip && (await shouldGenerateLqip(finalPath, metadata));
+      !noLqip && (await shouldGenerateLqip(imagePath, metadata));
 
     // Include LQIP width in the webp widths for single-pass processing
     const requestedWidths = parseWidths(widths);
-    const webpWidths = generateLqip
+    const requestedWebpWidths = generateLqip
       ? [LQIP_WIDTH, ...requestedWidths]
       : requestedWidths;
+    const webpWidths = sanitizeCropWidths(
+      requestedWebpWidths,
+      aspectRatio,
+      metadata,
+    );
+    const jpegWidths = sanitizeCropWidths(
+      [JPEG_FALLBACK_WIDTH],
+      aspectRatio,
+      metadata,
+    );
 
     const imageMetadata = await processFormats(
       Image,
-      finalPath,
-      { ...DEFAULT_OPTIONS, fixOrientation: true },
+      imagePath,
+      {
+        ...DEFAULT_OPTIONS,
+        fixOrientation: true,
+        ...getCropImageOptions(aspectRatio),
+      },
       webpWidths,
+      jpegWidths,
     );
 
     const { bgImage, htmlMetadata } = await prepareLqipMetadata(

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -21,6 +21,7 @@ import { PLACEHOLDER_MODE } from "#build/build-mode.js";
 import {
   getAspectRatio,
   getCropImageOptions,
+  getCropMaxWidth,
   getMetadata,
   sanitizeCropWidths,
 } from "#media/image-crop.js";
@@ -122,7 +123,7 @@ const processImageData = dedupeAsync(
     const style = buildWrapperStyles(
       bgImage,
       aspectRatio,
-      metadata,
+      { ...metadata, width: getCropMaxWidth(aspectRatio, metadata) },
       getAspectRatio,
       skipMaxWidth,
     );

--- a/test/integration/build/image-crop.test.js
+++ b/test/integration/build/image-crop.test.js
@@ -1,68 +1,68 @@
 import { describe, expect, test } from "bun:test";
-import fs from "node:fs";
 import path from "node:path";
-import { ROOT_DIR } from "#lib/paths.js";
-import { cropImage, getAspectRatio, getMetadata } from "#media/image-crop.js";
+import {
+  getCropImageOptions,
+  getMetadata,
+  sanitizeCropWidths,
+} from "#media/image-crop.js";
 import { cleanupTempDir, createTempDir } from "#test/test-utils.js";
 
 describe("image-crop", () => {
-  // The crop helpers operate directly on a file path and its metadata; they
-  // do not need a built Eleventy site. Copy the fixture image into a temp dir
-  // and compute metadata — far cheaper than spawning a full build.
-  const withImageContext = async (testFn) => {
-    const tempDir = createTempDir("image-crop");
-    try {
-      const imagePath = path.join(tempDir, "party.jpg");
-      fs.copyFileSync(path.join(ROOT_DIR, "src/images/party.jpg"), imagePath);
-      const metadata = await getMetadata(imagePath);
-      return await testFn({ imagePath, metadata });
-    } finally {
-      cleanupTempDir(tempDir);
-    }
-  };
-
-  test(
-    "Crops image to aspect ratio and caches result",
-    () =>
-      withImageContext(async ({ imagePath, metadata }) => {
-        const croppedPath = await cropImage("16/9", imagePath, metadata);
-        expect(fs.existsSync(croppedPath)).toBe(true);
-
-        const croppedMeta = await getMetadata(croppedPath);
-        const expectedHeight = Math.round(metadata.width / (16 / 9));
-        expect(croppedMeta.height).toBe(expectedHeight);
+  test("clamps and deduplicates crop widths", () => {
+    expect(
+      sanitizeCropWidths([32, 240, 480, "auto"], "1/1", {
+        width: 600,
+        height: 200,
       }),
-    30_000,
-  );
+    ).toEqual([32, 200]);
+  });
 
-  test(
-    "Returns original path when aspect ratio is null",
-    () =>
-      withImageContext(async ({ imagePath, metadata }) => {
-        const result = await cropImage(null, imagePath, metadata);
-        expect(result).toBe(imagePath);
+  test("preserves source width when the crop fits without upscaling", () => {
+    expect(
+      sanitizeCropWidths([240, "auto"], "16/9", {
+        width: 600,
+        height: 600,
       }),
-    30_000,
-  );
+    ).toEqual([240, 600]);
+  });
 
-  test(
-    "Calculates aspect ratio from image dimensions",
-    () =>
-      withImageContext(async ({ metadata }) => {
-        const ratio = getAspectRatio(null, metadata);
-        expect(ratio).toMatch(/^\d+\/\d+$/);
-      }),
-    30_000,
-  );
+  test("leaves uncropped widths unchanged", () => {
+    const widths = [32, 240, "auto"];
+    expect(sanitizeCropWidths(widths, null, { width: 600, height: 200 })).toBe(
+      widths,
+    );
+  });
 
-  test("Applies EXIF rotation when cropping", async () => {
+  test("uses the aspect ratio as the manual cache key", () => {
+    expect(getCropImageOptions("16/9").manualCacheKey).toBe("16/9");
+    expect(getCropImageOptions(null)).toEqual({});
+  });
+
+  test("transforms each target width to the crop ratio", async () => {
+    const { default: sharp } = await import("sharp");
+    const transform = getCropImageOptions("16/9").transform;
+    const image = sharp({
+      create: {
+        width: 600,
+        height: 600,
+        channels: 3,
+        background: { r: 255, g: 0, b: 0 },
+      },
+    }).png();
+
+    transform(image, { width: 320 });
+    const buffer = await image.toBuffer();
+    const metadata = await sharp(buffer).metadata();
+
+    expect(metadata.width).toBe(320);
+    expect(metadata.height).toBe(180);
+  });
+
+  test("applies EXIF rotation when transforming a crop", async () => {
     const { default: sharp } = await import("sharp");
     const tempDir = createTempDir("exif-crop");
 
     try {
-      // Create a 600x200 image: left half red, right half green.
-      // EXIF orientation 6 (90° CW to display correctly).
-      // After rotation: 200x600, top 300 rows red, bottom 300 rows green.
       const greenOverlay = await sharp({
         create: {
           width: 300,
@@ -89,25 +89,17 @@ describe("image-crop", () => {
         .toFile(imagePath);
 
       const metadata = await getMetadata(imagePath);
-      // getMetadata swaps dimensions for orientation 6
       expect(metadata.width).toBe(200);
       expect(metadata.height).toBe(600);
 
-      // Crop to 16/9. cropHeight = round(200 / (16/9)) = 113.
-      // Center crop from rotated 200x600: rows ~244-356.
-      // Row 300 is the red/green boundary, so bottom of crop is in the green zone.
-      // Without .rotate(), sharp crops from raw 600x200 — center columns are all red.
-      const croppedPath = await cropImage("16/9", imagePath, metadata);
-      const expectedHeight = Math.round(200 / (16 / 9));
-
-      // Extract pixel near the bottom of the crop: should be green if rotated.
-      const { data } = await sharp(croppedPath)
-        .extract({ left: 100, top: expectedHeight - 1, width: 1, height: 1 })
+      const image = sharp(imagePath);
+      getCropImageOptions("16/9").transform(image, { width: 200 });
+      const buffer = await image.rotate().jpeg().toBuffer();
+      const { data } = await sharp(buffer)
+        .extract({ left: 100, top: 111, width: 1, height: 1 })
         .raw()
         .toBuffer({ resolveWithObject: true });
 
-      // Green channel should dominate (rotation placed the green half at the bottom).
-      // Without rotation this pixel would be red.
       expect(data[1]).toBeGreaterThan(100);
       expect(data[0]).toBeLessThan(100);
     } finally {

--- a/test/integration/build/image.test.js
+++ b/test/integration/build/image.test.js
@@ -5,6 +5,7 @@ import {
   imageShortcode,
   processAndWrapImage,
 } from "#media/image.js";
+import { getCropMaxWidth, getMetadata } from "#media/image-crop.js";
 import { useSharedSite } from "#test/test-site-factory.js";
 import { createMockEleventyConfig, wrapHtml } from "#test/test-utils.js";
 import { map } from "#toolkit/fp/array.js";
@@ -153,6 +154,21 @@ describe("image", () => {
         "(max-width: 600px) 100vw",
         "aspect-ratio: 16/9",
       ]);
+    });
+
+    test("Caps cropped wrapper width at the largest generated crop", async () => {
+      const metadata = await getMetadata("./src/images/party.jpg");
+      const maxWidth = getCropMaxWidth("1/1", metadata);
+      const result = await imageShortcode(
+        "party.jpg",
+        "Square party",
+        "240,2000",
+        null,
+        null,
+        "1/1",
+      );
+
+      expect(result).toContain(`max-width: min(${maxWidth}px, 100%)`);
     });
   });
 

--- a/test/precommit/steps.js
+++ b/test/precommit/steps.js
@@ -12,6 +12,7 @@ import {
   extractSlowTests,
   extractTestTotal,
 } from "#test/precommit/output.js";
+import { getNonCodeQualityTestFiles } from "#test/test-runner-utils.js";
 
 const CACHE_DIR = join(ROOT_DIR, ".cache");
 const TEST_COUNT_CACHE = join(CACHE_DIR, "precommit-test-count");
@@ -108,12 +109,12 @@ export const getSteps = () => {
       cmd: [
         "bun",
         "test",
+        ...getNonCodeQualityTestFiles("test/**/*.test.js"),
         "--dots",
         "--reporter=junit",
         `--reporter-outfile=${TEST_REPORT_FILE}`,
         "--timeout",
         "1500",
-        "--path-ignore-patterns=test/unit/code-quality/**",
       ],
       preRun: resetTestReport,
       progress: createDotsProgress(

--- a/test/precommit/steps.js
+++ b/test/precommit/steps.js
@@ -83,6 +83,17 @@ export const getSteps = () => {
       name: "generate-types",
       cmd: ["bun", "scripts/generate-pages-cms-types.js"],
     },
+    {
+      name: "tests:code-quality",
+      cmd: [
+        "bun",
+        "test",
+        "test/unit/code-quality",
+        "--concurrent",
+        "--timeout",
+        "1500",
+      ],
+    },
     { name: "lint", cmd: ["bun", "run", "lint"] },
     { name: "lint:scss", cmd: ["bun", "run", "lint:scss"] },
     { name: "knip", cmd: ["bun", "run", "knip"] },
@@ -102,6 +113,7 @@ export const getSteps = () => {
         `--reporter-outfile=${TEST_REPORT_FILE}`,
         "--timeout",
         "1500",
+        "--path-ignore-patterns=test/unit/code-quality/**",
       ],
       preRun: resetTestReport,
       progress: createDotsProgress(

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -15,6 +15,7 @@
 
 import {
   COMMON_STEPS,
+  codeQualityTestsStep,
   integrationTestsStep,
   isMainModule,
   runLanes,
@@ -22,7 +23,7 @@ import {
   verbose,
 } from "#test/test-runner-utils.js";
 
-const lanes = [
+const mainLanes = [
   [COMMON_STEPS.lint],
   [COMMON_STEPS.lintScss],
   [COMMON_STEPS.knip],
@@ -39,5 +40,10 @@ if (isMainModule(import.meta.url)) {
     verbose ? "Running full test suite (verbose)...\n" : "Running tests...",
   );
 
-  await runLanes({ lanes, verbose, title: "TEST SUMMARY" });
+  await runLanes({
+    lanes: [[codeQualityTestsStep]],
+    verbose,
+    title: "CODE QUALITY TEST SUMMARY",
+  });
+  await runLanes({ lanes: mainLanes, verbose, title: "TEST SUMMARY" });
 }

--- a/test/test-runner-utils.js
+++ b/test/test-runner-utils.js
@@ -274,6 +274,7 @@ export const unitTestsStep = (verbose) => ({
   args: [
     "test",
     "test/unit",
+    "--path-ignore-patterns=test/unit/code-quality/**",
     "--coverage",
     "--coverage-reporter=lcov",
     "--coverage-reporter=text",
@@ -283,6 +284,12 @@ export const unitTestsStep = (verbose) => ({
     ...(verbose ? ["--verbose"] : []),
   ],
 });
+
+export const codeQualityTestsStep = {
+  name: "tests:code-quality",
+  cmd: "bun",
+  args: ["test", "test/unit/code-quality", "--concurrent", "--timeout", "1500"],
+};
 
 /**
  * Integration tests step (no coverage - see unitTestsStep).

--- a/test/test-runner-utils.js
+++ b/test/test-runner-utils.js
@@ -274,7 +274,6 @@ export const unitTestsStep = (verbose) => ({
   args: [
     "test",
     "test/unit",
-    "--path-ignore-patterns=test/unit/code-quality/**",
     "--coverage",
     "--coverage-reporter=lcov",
     "--coverage-reporter=text",
@@ -284,6 +283,11 @@ export const unitTestsStep = (verbose) => ({
     ...(verbose ? ["--verbose"] : []),
   ],
 });
+
+export const getNonCodeQualityTestFiles = (pattern) =>
+  [...new Bun.Glob(pattern).scanSync(rootDir)].filter(
+    (file) => !file.startsWith("test/unit/code-quality/"),
+  );
 
 export const codeQualityTestsStep = {
   name: "tests:code-quality",

--- a/test/unit/media/image-utils.test.js
+++ b/test/unit/media/image-utils.test.js
@@ -415,7 +415,7 @@ describe("image-utils", () => {
         filenameFormat("id", "./src/images/photo.jpg", 240, "webp", {
           manualCacheKey: "16/9",
         }),
-      ).toBe("photo-crop-16x9-240.webp");
+      ).toBe("photo-jpg-crop-16x9-240.webp");
     });
 
     test("different crop ratios produce different filenames", () => {
@@ -435,6 +435,17 @@ describe("image-utils", () => {
       );
 
       expect(square).not.toBe(widescreen);
+    });
+
+    test("different source extensions produce different crop filenames", () => {
+      const jpeg = filenameFormat("id", "./src/images/photo.jpg", 240, "webp", {
+        manualCacheKey: "16/9",
+      });
+      const png = filenameFormat("id", "./src/images/photo.png", 240, "webp", {
+        manualCacheKey: "16/9",
+      });
+
+      expect(jpeg).not.toBe(png);
     });
   });
 });

--- a/test/unit/media/image-utils.test.js
+++ b/test/unit/media/image-utils.test.js
@@ -409,5 +409,32 @@ describe("image-utils", () => {
         ),
       ).toBe("photo-crop-abc123-240.webp");
     });
+
+    test("includes a readable crop ratio in transformed image filenames", () => {
+      expect(
+        filenameFormat("id", "./src/images/photo.jpg", 240, "webp", {
+          manualCacheKey: "16/9",
+        }),
+      ).toBe("photo-crop-16x9-240.webp");
+    });
+
+    test("different crop ratios produce different filenames", () => {
+      const square = filenameFormat(
+        "id",
+        "./src/images/photo.jpg",
+        240,
+        "webp",
+        { manualCacheKey: "1/1" },
+      );
+      const widescreen = filenameFormat(
+        "id",
+        "./src/images/photo.jpg",
+        240,
+        "webp",
+        { manualCacheKey: "16/9" },
+      );
+
+      expect(square).not.toBe(widescreen);
+    });
   });
 });

--- a/test/unit/scripts/build-metrics.test.js
+++ b/test/unit/scripts/build-metrics.test.js
@@ -56,4 +56,8 @@ describe("build metrics", () => {
       ),
     ).toThrow("invalid CPU time delta");
   });
+
+  test("rejects snapshots when no logical CPUs are reported", () => {
+    expect(() => getCpuSnapshot([])).toThrow("no logical CPUs were reported");
+  });
 });

--- a/test/unit/scripts/build-metrics.test.js
+++ b/test/unit/scripts/build-metrics.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  calculateAverageCpuUsage,
+  formatAverageCpuUsage,
+  getCpuSnapshot,
+} from "#scripts/build-metrics.js";
+
+const cpu = (times) => ({
+  model: "test",
+  speed: 1000,
+  times,
+});
+
+describe("build metrics", () => {
+  test("aggregates cumulative times across logical CPUs", () => {
+    const snapshot = getCpuSnapshot([
+      cpu({ user: 100, nice: 10, sys: 20, idle: 300, irq: 5 }),
+      cpu({ user: 200, nice: 20, sys: 40, idle: 400, irq: 10 }),
+    ]);
+
+    expect(snapshot).toEqual({
+      idle: 700,
+      total: 1105,
+      logicalCpuCount: 2,
+    });
+  });
+
+  test("calculates average utilization over the snapshot interval", () => {
+    const usage = calculateAverageCpuUsage(
+      { idle: 600, total: 1000, logicalCpuCount: 2 },
+      { idle: 700, total: 1400, logicalCpuCount: 2 },
+    );
+
+    expect(usage).toEqual({
+      percentage: 75,
+      busyCores: 1.5,
+      logicalCpuCount: 2,
+    });
+  });
+
+  test("formats utilization as percentage and equivalent busy cores", () => {
+    expect(
+      formatAverageCpuUsage({
+        percentage: 37.54,
+        busyCores: 3.0032,
+        logicalCpuCount: 8,
+      }),
+    ).toBe("Average system CPU usage: 37.5% (3.0 of 8 logical CPUs)");
+  });
+
+  test("rejects snapshots without elapsed CPU time", () => {
+    expect(() =>
+      calculateAverageCpuUsage(
+        { idle: 100, total: 200, logicalCpuCount: 2 },
+        { idle: 100, total: 200, logicalCpuCount: 2 },
+      ),
+    ).toThrow("invalid CPU time delta");
+  });
+});


### PR DESCRIPTION
## Summary
- upgrade Eleventy to 4.0.0-alpha.9 and Eleventy Image to 7.0.0
- replace intermediate JPEG crops with ratio-keyed transforms, clamp generated widths and wrappers to avoid upscaling, and keep readable crop filenames unique across source extensions
- report average system CPU utilization after builds and run code-quality tests before the remaining suite

## Verification
- full precommit suite passes
- build and internal-link check pass
- 20 generated crop assets compared against the preserved baseline; framing is unchanged and placeholder crops are pixel-identical
- CPU metric reports percentage and equivalent busy logical CPUs (95.0%, 15.2/16 on the verification build)