### PR TITLE
Improve CI build efficiency and resource metrics

### DIFF
--- a/scripts/build-metrics.js
+++ b/scripts/build-metrics.js
@@ -1,40 +1,87 @@
 import os from "node:os";
 
-const sumTimes = (times) =>
-  times.user + times.nice + times.sys + times.idle + times.irq;
+const linuxMaxRssToBytes = (maxRss, platform) =>
+  platform === "linux" ? maxRss * 1024 : maxRss;
 
-const getCpuSnapshot = (cpus = os.cpus()) => {
-  if (cpus.length === 0) {
-    throw new Error("CPU usage is unavailable: no logical CPUs were reported");
-  }
+const deriveMetrics = ({
+  logicalCpuCount,
+  maxRssBytes,
+  name,
+  systemCpuMs,
+  userCpuMs,
+  wallMs,
+}) => {
+  const totalCpuMs = userCpuMs + systemCpuMs;
+  const effectiveCores = wallMs > 0 ? totalCpuMs / wallMs : 0;
 
-  return cpus.reduce(
-    (snapshot, cpu) => {
-      snapshot.idle += cpu.times.idle;
-      snapshot.total += sumTimes(cpu.times);
-      return snapshot;
-    },
-    { idle: 0, total: 0, logicalCpuCount: cpus.length },
-  );
-};
-
-const calculateAverageCpuUsage = (start, end) => {
-  const idle = end.idle - start.idle;
-  const total = end.total - start.total;
-  if (total <= 0 || idle < 0 || idle > total) {
-    throw new Error("CPU usage is unavailable: invalid CPU time delta");
-  }
-
-  const percentage = ((total - idle) / total) * 100;
   return {
-    percentage,
-    busyCores: (percentage / 100) * end.logicalCpuCount,
-    logicalCpuCount: end.logicalCpuCount,
+    cpuUtilization: (effectiveCores / logicalCpuCount) * 100,
+    effectiveCores,
+    logicalCpuCount,
+    maxRssBytes,
+    name,
+    systemCpuMs,
+    totalCpuMs,
+    userCpuMs,
+    wallMs,
   };
 };
 
-const formatAverageCpuUsage = ({ percentage, busyCores, logicalCpuCount }) =>
-  `Average system CPU usage: ${percentage.toFixed(1)}% ` +
-  `(${busyCores.toFixed(1)} of ${logicalCpuCount} logical CPUs)`;
+const createPhaseMetrics = ({
+  logicalCpuCount = os.availableParallelism(),
+  name,
+  platform = process.platform,
+  resourceUsage,
+  wallMs,
+}) => {
+  if (!resourceUsage) {
+    throw new Error(`Resource usage is unavailable for ${name}`);
+  }
+  if (logicalCpuCount < 1) {
+    throw new Error("Resource usage is unavailable: no logical CPUs reported");
+  }
 
-export { calculateAverageCpuUsage, formatAverageCpuUsage, getCpuSnapshot };
+  return deriveMetrics({
+    logicalCpuCount,
+    maxRssBytes: linuxMaxRssToBytes(resourceUsage.maxRSS, platform),
+    name,
+    systemCpuMs: Number(resourceUsage.cpuTime.system) / 1000,
+    userCpuMs: Number(resourceUsage.cpuTime.user) / 1000,
+    wallMs,
+  });
+};
+
+const combinePhaseMetrics = (name, phases) => {
+  if (phases.length === 0) {
+    throw new Error("Cannot combine an empty set of build phases");
+  }
+
+  return deriveMetrics({
+    logicalCpuCount: phases[0].logicalCpuCount,
+    maxRssBytes: Math.max(...phases.map(({ maxRssBytes }) => maxRssBytes)),
+    name,
+    systemCpuMs: phases.reduce(
+      (total, { systemCpuMs }) => total + systemCpuMs,
+      0,
+    ),
+    userCpuMs: phases.reduce((total, { userCpuMs }) => total + userCpuMs, 0),
+    wallMs: phases.reduce((total, { wallMs }) => total + wallMs, 0),
+  });
+};
+
+const formatBytes = (bytes) => {
+  const gibibyte = 1024 ** 3;
+  if (bytes >= gibibyte) return `${(bytes / gibibyte).toFixed(2)} GiB`;
+  return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
+};
+
+const formatPhaseMetrics = (metrics) =>
+  `${metrics.name} resources: ${(metrics.wallMs / 1000).toFixed(2)}s wall, ` +
+  `${(metrics.totalCpuMs / 1000).toFixed(2)}s CPU ` +
+  `(${(metrics.userCpuMs / 1000).toFixed(2)}s user + ` +
+  `${(metrics.systemCpuMs / 1000).toFixed(2)}s sys, ` +
+  `${metrics.effectiveCores.toFixed(2)} effective cores, ` +
+  `${metrics.cpuUtilization.toFixed(1)}% of ${metrics.logicalCpuCount}), ` +
+  `${formatBytes(metrics.maxRssBytes)} peak RSS`;
+
+export { combinePhaseMetrics, createPhaseMetrics, formatPhaseMetrics };

--- a/scripts/eleventy-build.js
+++ b/scripts/eleventy-build.js
@@ -3,18 +3,14 @@
  * Fail-fast Eleventy build wrapper.
  *
  * By default, Eleventy continues processing other templates after an error,
- * and async image processing continues in the background. This makes it hard
- * to identify errors in CI logs (they get buried under thousands of lines).
- *
- * This wrapper monitors the build output and immediately terminates on error,
- * ensuring errors are visible at the end of the log output.
+ * and async image processing continues in the background. This wrapper
+ * terminates the build when one of Eleventy's fatal error markers appears.
  */
-import { spawn, spawnSync } from "node:child_process";
 import { parseArgs } from "node:util";
 import {
-  calculateAverageCpuUsage,
-  formatAverageCpuUsage,
-  getCpuSnapshot,
+  combinePhaseMetrics,
+  createPhaseMetrics,
+  formatPhaseMetrics,
 } from "#scripts/build-metrics.js";
 
 const ERROR_PATTERNS = [
@@ -39,19 +35,6 @@ if (values.serve) args.push("--serve");
 if (values.incremental) args.push("--incremental");
 args.push(...positionals);
 
-const cpuStart = getCpuSnapshot();
-
-const eleventy = spawn(
-  "bun",
-  ["./node_modules/@11ty/eleventy/cmd.cjs", ...args],
-  {
-    stdio: ["inherit", "pipe", "pipe"],
-    env: process.env,
-  },
-);
-
-let errorDetected = false;
-
 const containsError = (text) =>
   ERROR_PATTERNS.some((pattern) => text.includes(pattern));
 
@@ -68,84 +51,170 @@ const printFailureBanner = () => {
   console.error("Fix the issue and rebuild.\n");
 };
 
-const triggerFailFast = () => {
-  errorDetected = true;
-  setTimeout(() => {
-    printFailureBanner();
-    eleventy.kill("SIGTERM");
-  }, 100);
-};
-
-const writeErrorOutput = (data, text) => {
-  if (!isImageProcessingNoise(text)) {
-    process.stderr.write(data);
-  }
-};
-
-const writeNormalOutput = (data, isStderr) => {
-  const target = isStderr ? process.stderr : process.stdout;
-  target.write(data);
+const reportProcessFailure = (message, error) => {
+  console.error(message, error.message);
+  process.exitCode = 1;
+  return null;
 };
 
 const runPagefind = () => {
   console.log("\nRunning Pagefind indexer...");
-  const result = spawnSync(
-    "bun",
-    ["./node_modules/.bin/pagefind", "--site", "_site"],
-    { stdio: "inherit", env: process.env },
+  const startedAt = performance.now();
+  const result = Bun.spawnSync(
+    [process.execPath, "./node_modules/.bin/pagefind", "--site", "_site"],
+    {
+      env: process.env,
+      stderr: "inherit",
+      stdin: "inherit",
+      stdout: "inherit",
+    },
   );
-  if (result.status !== 0) {
+  const metrics = createPhaseMetrics({
+    name: "Pagefind",
+    resourceUsage: result.resourceUsage,
+    wallMs: performance.now() - startedAt,
+  });
+
+  console.log(formatPhaseMetrics(metrics));
+  if (result.exitCode !== 0) {
     console.error("Pagefind indexing failed");
-    return false;
+    return { metrics, succeeded: false };
   }
   console.log("Pagefind indexing complete\n");
-  return true;
+  return { metrics, succeeded: true };
 };
 
-let pagefindRanForServe = false;
+const spawnEleventy = () => {
+  try {
+    return Bun.spawn(
+      [process.execPath, "./node_modules/@11ty/eleventy/cmd.cjs", ...args],
+      {
+        env: process.env,
+        stderr: "pipe",
+        stdin: "inherit",
+        stdout: "pipe",
+      },
+    );
+  } catch (error) {
+    return reportProcessFailure("Failed to start Eleventy:", error);
+  }
+};
 
-const processChunk = (data, isStderr) => {
-  const text = data.toString();
-  if (errorDetected) {
-    writeErrorOutput(data, text);
+const pumpOutput = async (stream, processChunk, isStderr) => {
+  const reader = stream.getReader();
+  try {
+    let chunk = await reader.read();
+    while (!chunk.done) {
+      processChunk(Buffer.from(chunk.value), isStderr);
+      chunk = await reader.read();
+    }
+  } finally {
+    reader.releaseLock();
+  }
+};
+
+const waitForEleventy = async (eleventy, output) => {
+  try {
+    const exitCode = await eleventy.exited;
+    await output;
+    return exitCode;
+  } catch (error) {
+    return reportProcessFailure("Eleventy process failed:", error);
+  }
+};
+
+const createOutputProcessor = (eleventy) => {
+  let errorDetected = false;
+  let pagefindRanForServe = false;
+
+  const triggerFailFast = () => {
+    errorDetected = true;
+    setTimeout(() => {
+      printFailureBanner();
+      eleventy.kill("SIGTERM");
+    }, 100);
+  };
+
+  const shouldRunPagefind = (text) =>
+    values.serve && !pagefindRanForServe && text.includes("[11ty] Watching");
+
+  const writeAfterError = (data, text) => {
+    if (!isImageProcessingNoise(text)) process.stderr.write(data);
+  };
+
+  const processNormalChunk = (data, text, isStderr) => {
+    const target = isStderr ? process.stderr : process.stdout;
+    target.write(data);
+    if (containsError(text)) triggerFailFast();
+    if (shouldRunPagefind(text)) {
+      pagefindRanForServe = true;
+      runPagefind();
+    }
+  };
+
+  const processChunk = (data, isStderr) => {
+    const text = data.toString();
+    if (errorDetected) {
+      writeAfterError(data, text);
+      return;
+    }
+    processNormalChunk(data, text, isStderr);
+  };
+
+  return {
+    failed: () => errorDetected,
+    processChunk,
+  };
+};
+
+const getEleventyMetrics = (eleventy, startedAt) => {
+  const usage = eleventy.resourceUsage();
+  return usage
+    ? createPhaseMetrics({
+        name: "Eleventy",
+        resourceUsage: usage,
+        wallMs: performance.now() - startedAt,
+      })
+    : null;
+};
+
+const runPostBuild = (eleventyMetrics) => {
+  const pagefind = runPagefind();
+  if (!pagefind.succeeded) {
+    process.exitCode = 1;
     return;
   }
-  writeNormalOutput(data, isStderr);
-  if (containsError(text)) {
-    triggerFailFast();
-  }
-  if (
-    values.serve &&
-    !pagefindRanForServe &&
-    text.includes("[11ty] Watching")
-  ) {
-    pagefindRanForServe = true;
-    runPagefind();
+  if (eleventyMetrics) {
+    console.log(
+      formatPhaseMetrics(
+        combinePhaseMetrics("Total build", [eleventyMetrics, pagefind.metrics]),
+      ),
+    );
   }
 };
 
-const handleOutput = (stream, isStderr) => {
-  stream.on("data", (data) => processChunk(data, isStderr));
+const main = async () => {
+  const startedAt = performance.now();
+  const eleventy = spawnEleventy();
+  if (!eleventy) return;
+  const outputProcessor = createOutputProcessor(eleventy);
+
+  const output = Promise.all([
+    pumpOutput(eleventy.stdout, outputProcessor.processChunk, false),
+    pumpOutput(eleventy.stderr, outputProcessor.processChunk, true),
+  ]);
+  const exitCode = await waitForEleventy(eleventy, output);
+  if (exitCode === null) return;
+
+  const eleventyMetrics = getEleventyMetrics(eleventy, startedAt);
+  if (eleventyMetrics) console.log(formatPhaseMetrics(eleventyMetrics));
+
+  if (outputProcessor.failed() || exitCode !== 0) {
+    process.exitCode = exitCode || 1;
+    return;
+  }
+  if (values.serve) return;
+  runPostBuild(eleventyMetrics);
 };
 
-handleOutput(eleventy.stdout, false);
-handleOutput(eleventy.stderr, true);
-
-eleventy.on("close", (code) => {
-  if (errorDetected || code !== 0) {
-    process.exit(code || 1);
-  }
-  if (!values.serve) {
-    if (!runPagefind()) {
-      process.exit(1);
-    }
-    const cpuUsage = calculateAverageCpuUsage(cpuStart, getCpuSnapshot());
-    console.log(formatAverageCpuUsage(cpuUsage));
-  }
-  process.exit(0);
-});
-
-eleventy.on("error", (err) => {
-  console.error("Failed to start Eleventy:", err.message);
-  process.exit(1);
-});
+await main();

--- a/scripts/strict-typecheck-ratchet.js
+++ b/scripts/strict-typecheck-ratchet.js
@@ -14,7 +14,7 @@ import { spawnSync } from "node:child_process";
 import { ROOT_DIR } from "#lib/paths.js";
 
 // Current baseline - lower this as you fix errors
-const CURRENT_ERROR_COUNT = 364;
+const CURRENT_ERROR_COUNT = 353;
 
 // Files that currently pass strict mode (must not regress)
 const STRICT_CLEAN_FILES = [
@@ -63,6 +63,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/eleventy/canonical-url.js",
   "src/_lib/eleventy/file-info.js",
   "src/_lib/eleventy/format-price.js",
+  "src/_lib/eleventy/git-dates.js",
   "src/_lib/eleventy/ical.js",
   "src/_lib/eleventy/js-config.js",
   "src/_lib/eleventy/layout-aliases.js",
@@ -71,6 +72,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/eleventy/video.js",
   "src/_lib/filters/filter-core.js",
   "src/_lib/filters/spec-filters.js",
+  "src/_lib/media/image-cache-output.js",
   "src/_lib/media/image-crop.js",
   "src/_lib/media/image-frontmatter.js",
   "src/_lib/media/image-placeholder.js",
@@ -84,6 +86,7 @@ const STRICT_CLEAN_FILES = [
   "src/_lib/utils/dietary-utils.js",
   "src/_lib/utils/dom-builder.js",
   "src/_lib/utils/format-price.js",
+  "src/_lib/utils/git-dates.js",
   "src/_lib/utils/lazy-dom.js",
   "src/_lib/utils/linkable-content.js",
   "src/_lib/utils/liquid-render.js",

--- a/src/_lib/eleventy/git-dates.js
+++ b/src/_lib/eleventy/git-dates.js
@@ -1,8 +1,34 @@
-import { datesFor, formatHuman, formatIso } from "#utils/git-dates.js";
+import { log } from "#utils/console.js";
+import {
+  createGitDateLookup,
+  formatHuman,
+  formatIso,
+} from "#utils/git-dates.js";
 
 /** @param {*} eleventyConfig */
 export const configureGitDates = (eleventyConfig) => {
-  eleventyConfig.addFilter("gitDates", datesFor);
+  let lookup = null;
+  const getLookup = () => (lookup ||= createGitDateLookup());
+
+  eleventyConfig.on("eleventy.before", () => {
+    lookup = createGitDateLookup();
+    const { durationMs, paths, repositories } = lookup.stats;
+    log(
+      `Git date index: ${(durationMs / 1000).toFixed(2)}s wall, ` +
+        `${paths.toLocaleString("en-GB")} paths across ${repositories} ` +
+        `${repositories === 1 ? "repository" : "repositories"}`,
+    );
+  });
+  eleventyConfig.addFilter(
+    "gitDates",
+    /** @param {string | null | undefined} inputPath */ (inputPath) =>
+      getLookup().datesFor(inputPath),
+  );
+  eleventyConfig.addFilter(
+    "gitUpdated",
+    /** @param {string | null | undefined} inputPath */ (inputPath) =>
+      getLookup().updatedFor(inputPath),
+  );
   eleventyConfig.addFilter("humanDate", formatHuman);
   eleventyConfig.addFilter("isoDate", formatIso);
 };

--- a/src/_lib/media/image-cache-output.js
+++ b/src/_lib/media/image-cache-output.js
@@ -1,0 +1,64 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/** @typedef {{ countFiles: (directory: string) => number, linkTree: (source: string, destination: string) => boolean, resetDestination: (destination: string) => void }} CacheOutputHelpers */
+/** @typedef {{ source?: string, destination?: string, useHardLinks?: boolean, linkTree?: (source: string, destination: string) => boolean }} ImageCacheOutputOptions */
+/** @typedef {{ copied: number, durationMs: number, linked: number, total: number }} ImageCacheOutputResult */
+
+/** @type {CacheOutputHelpers} */
+const cacheOutput = Object.freeze({
+  countFiles(directory) {
+    return fs
+      .readdirSync(directory, { withFileTypes: true })
+      .reduce((total, entry) => {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          return total + cacheOutput.countFiles(entryPath);
+        }
+        return entry.isFile() ? total + 1 : total;
+      }, 0);
+  },
+
+  linkTree(source, destination) {
+    const sourceContents = `${source}${path.sep}.`;
+    return (
+      spawnSync("cp", ["-al", sourceContents, destination], {
+        stdio: "ignore",
+      }).status === 0
+    );
+  },
+
+  resetDestination(destination) {
+    fs.rmSync(destination, { recursive: true, force: true });
+  },
+});
+
+/**
+ * @param {ImageCacheOutputOptions} [options]
+ * @returns {ImageCacheOutputResult}
+ */
+export const materializeImageCache = ({
+  source = ".image-cache",
+  destination = "_site/img",
+  useHardLinks = process.env.GITHUB_ACTIONS === "true",
+  linkTree = cacheOutput.linkTree,
+} = {}) => {
+  const startedAt = performance.now();
+  const total = cacheOutput.countFiles(source);
+  cacheOutput.resetDestination(destination);
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+
+  const linked = Boolean(useHardLinks && linkTree(source, destination));
+  if (!linked) {
+    cacheOutput.resetDestination(destination);
+    fs.cpSync(source, destination, { recursive: true });
+  }
+
+  return {
+    copied: linked ? 0 : total,
+    durationMs: performance.now() - startedAt,
+    linked: linked ? total : 0,
+    total,
+  };
+};

--- a/src/_lib/media/image.js
+++ b/src/_lib/media/image.js
@@ -11,13 +11,14 @@
  * - computeWrappedImageHtml(): Generates wrapped picture element with LQIP
  *
  * PLACEHOLDER_MODE (env PLACEHOLDER_IMAGES=1): Skip processing for faster builds.
- * Image cache is copied to _site/img/ after Eleventy build completes.
+ * Image cache is materialized in _site/img/ after Eleventy build completes.
  */
 import fs from "node:fs";
 
 /** @typedef {import("#lib/types").ImageProps} ImageProps */
 /** @typedef {import("#lib/types").ComputeImageProps} ComputeImageProps */
 import { PLACEHOLDER_MODE } from "#build/build-mode.js";
+import { materializeImageCache } from "#media/image-cache-output.js";
 import {
   getAspectRatio,
   getCropImageOptions,
@@ -50,6 +51,7 @@ import {
 } from "#media/image-utils.js";
 import { dedupeAsync } from "#toolkit/fp/memoize.js";
 import { frozenObject } from "#toolkit/fp/object.js";
+import { log } from "#utils/console.js";
 
 const DEFAULT_OPTIONS = frozenObject({
   outputDir: ".image-cache",
@@ -258,7 +260,13 @@ const configureImages = async (eleventyConfig) => {
   );
   eleventyConfig.on("eleventy.after", () => {
     if (fs.existsSync(".image-cache/")) {
-      fs.cpSync(".image-cache/", "_site/img/", { recursive: true });
+      const { copied, durationMs, linked, total } = materializeImageCache();
+      log(
+        `Image cache output: ${(durationMs / 1000).toFixed(2)}s wall, ` +
+          `${total.toLocaleString("en-GB")} files ` +
+          `(${linked.toLocaleString("en-GB")} linked, ` +
+          `${copied.toLocaleString("en-GB")} copied)`,
+      );
     }
   });
 };

--- a/src/_lib/utils/git-dates.js
+++ b/src/_lib/utils/git-dates.js
@@ -1,77 +1,265 @@
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
-const runGit = (repo, args) => {
-  const result = execFileSync("git", ["-C", repo, ...args], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: 5000,
-  });
-  const trimmed = result.trim();
-  return trimmed === "" ? undefined : trimmed;
-};
+const HISTORY_TIMEOUT_MS = 120_000;
+const HISTORY_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+const TEMPLATE_PATHS = ["*.html", "*.liquid", "*.md"];
 
-export const datesFor = (inputPath) => {
-  if (!inputPath) return null;
+/** @typedef {import("node:child_process").SpawnSyncReturns<string>} GitResult */
+/** @typedef {{ published: string, updated: string, blob: string }} IndexedGitDates */
+/** @typedef {{ published: string, updated: string }} GitDates */
+/** @typedef {{ blob: string, status: string }} RawChange */
+/** @typedef {{ change: RawChange | null, firstPath: string | null, remaining: number }} ParseState */
+/** @typedef {Map<string, IndexedGitDates>} GitDateIndex */
+/** @typedef {{ repo: string, dates: GitDateIndex }} GitRepoIndex */
+/** @typedef {{ durationMs: number, paths: number, repositories: number }} GitDateStats */
+/** @typedef {{ datesFor: (inputPath: string | null | undefined) => GitDates | null, updatedFor: (inputPath: string | null | undefined) => string | null, stats: GitDateStats }} GitDateLookup */
+/** @typedef {{ cwd?: string, configuredRepo?: string | null }} GitDateLookupOptions */
+/**
+ * @typedef {object} GitHistory
+ * @property {(repo: string, args: string[], allowFailure?: boolean) => string | undefined} gitOutput
+ * @property {(result: GitResult) => void} assertGitSuccess
+ * @property {(inputPath: string) => string[]} pathCandidates
+ * @property {(cwd: string, configuredRepo: string | null | undefined) => string[]} candidateRepos
+ * @property {(date: string, blob: string) => IndexedGitDates} initialDates
+ * @property {(index: GitDateIndex, path: string, date: string, blob: string) => IndexedGitDates} datesAt
+ * @property {(dates: IndexedGitDates, date: string, blob: string) => void} updateDates
+ * @property {(index: GitDateIndex, status: string, path: string, date: string, blob: string) => void} applyPathChange
+ * @property {(index: GitDateIndex, oldPath: string, newPath: string, date: string, blob: string, status: string) => void} applyTransfer
+ * @property {(rawChange: string | undefined) => RawChange | null} parseRawChange
+ * @property {(change: RawChange) => number} pathsConsumedBy
+ * @property {(index: GitDateIndex, change: RawChange, paths: string[], date: string) => void} applyHistoryChange
+ * @property {() => ParseState} initialState
+ * @property {(state: ParseState, token: string) => ParseState} startChange
+ * @property {(state: ParseState, token: string, index: GitDateIndex, date: string) => ParseState} consumePath
+ * @property {(state: ParseState, token: string, index: GitDateIndex, date: string) => ParseState} parseHistoryToken
+ * @property {(record: string, index: GitDateIndex) => void} parseHistoryRecord
+ * @property {(repo: string) => GitDateIndex} buildRepoIndex
+ * @property {(indexes: GitRepoIndex[], inputPath: string) => IndexedGitDates | undefined} findDates
+ * @property {(indexes: GitRepoIndex[], inputPath: string | null | undefined) => GitDates | null} datesFor
+ * @property {(indexes: GitRepoIndex[], startedAt: number) => GitDateLookup} createLookup
+ */
 
-  const pathCandidates = (path) => {
-    const rel = path.replace(/^\.\//, "");
-    return rel.startsWith("src/") ? [rel, rel.slice(4)] : [rel];
-  };
+/** @type {GitHistory} */
+const history = Object.freeze({
+  gitOutput(repo, args, allowFailure = false) {
+    const result = spawnSync("git", ["-C", repo, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: HISTORY_TIMEOUT_MS,
+      maxBuffer: HISTORY_MAX_BUFFER_BYTES,
+    });
+    const failed = Boolean(result.error || result.status !== 0);
+    if (allowFailure && failed) return undefined;
+    history.assertGitSuccess(result);
+    const output = result.stdout.trim();
+    return output === "" ? undefined : output;
+  },
 
-  const candidateRepos = () => {
-    const repos = [
-      process.env.GIT_DATES_REPO,
-      process.cwd(),
-      resolve(process.cwd(), "..", "source"),
-    ]
-      .filter(Boolean)
-      .filter((repo) => existsSync(resolve(repo)));
+  assertGitSuccess(result) {
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      const stderr = result.stderr.trim();
+      throw new Error(stderr === "" ? `git exited ${result.status}` : stderr);
+    }
+  },
 
-    const roots = repos
-      .filter((repo) => existsSync(resolve(repo, ".git")))
-      .map((repo) => runGit(resolve(repo), ["rev-parse", "--show-toplevel"]))
-      .filter(Boolean);
+  pathCandidates(inputPath) {
+    const relative = inputPath.replace(/^\.\//, "");
+    return relative.startsWith("src/")
+      ? [relative, relative.slice(4)]
+      : [relative];
+  },
 
+  candidateRepos(cwd, configuredRepo) {
+    const candidates = [configuredRepo, cwd, resolve(dirname(cwd), "source")]
+      .filter((repo) => typeof repo === "string")
+      .map((repo) => resolve(repo))
+      .filter((repo) => existsSync(repo) && existsSync(resolve(repo, ".git")));
+    const roots = candidates
+      .map((repo) =>
+        history.gitOutput(repo, ["rev-parse", "--show-toplevel"], true),
+      )
+      .filter((root) => typeof root === "string");
     return [...new Set(roots)];
-  };
+  },
 
-  const datesForPath = (repo, rel) => {
-    const created = runGit(repo, [
+  initialDates(date, blob) {
+    return { published: date, updated: date, blob };
+  },
+
+  datesAt(index, path, date, blob) {
+    const existing = index.get(path);
+    return existing ? existing : history.initialDates(date, blob);
+  },
+
+  updateDates(dates, date, blob) {
+    if (dates.blob !== blob) dates.updated = date;
+    dates.blob = blob;
+  },
+
+  applyPathChange(index, status, path, date, blob) {
+    if (status === "D") {
+      const dates = history.datesAt(index, path, date, blob);
+      history.updateDates(dates, date, blob);
+      index.set(path, dates);
+      return;
+    }
+    const dates = index.get(path);
+    if (!dates) {
+      index.set(path, history.initialDates(date, blob));
+      return;
+    }
+    history.updateDates(dates, date, blob);
+  },
+
+  applyTransfer(index, oldPath, newPath, date, blob, status) {
+    const dates = history.datesAt(index, oldPath, date, blob);
+    if (status === "R") {
+      history.updateDates(dates, date, "0");
+      index.set(oldPath, dates);
+    }
+    index.set(newPath, { ...dates, updated: date, blob });
+  },
+
+  parseRawChange(rawChange) {
+    const match = rawChange
+      ?.trim()
+      .match(/^:\d+ \d+ [0-9a-f]+ ([0-9a-f]+) ([A-Z])(\d+)?$/);
+    return match ? { blob: match[1], status: match[2] } : null;
+  },
+
+  pathsConsumedBy({ status }) {
+    return status === "R" || status === "C" ? 2 : 1;
+  },
+
+  applyHistoryChange(index, { blob, status }, paths, date) {
+    if (status === "R" || status === "C") {
+      history.applyTransfer(index, paths[0], paths[1], date, blob, status);
+      return;
+    }
+    const path = paths[0];
+    if (path) history.applyPathChange(index, status, path, date, blob);
+  },
+
+  initialState() {
+    return { change: null, firstPath: null, remaining: 0 };
+  },
+
+  startChange(state, token) {
+    const change = history.parseRawChange(token);
+    return change
+      ? {
+          change,
+          firstPath: null,
+          remaining: history.pathsConsumedBy(change),
+        }
+      : state;
+  },
+
+  consumePath(state, token, index, date) {
+    if (state.remaining === 1 && state.change) {
+      const paths = state.firstPath ? [state.firstPath, token] : [token];
+      history.applyHistoryChange(index, state.change, paths, date);
+      return { change: null, firstPath: null, remaining: 0 };
+    }
+    return {
+      change: state.change,
+      firstPath: token,
+      remaining: state.remaining - 1,
+    };
+  },
+
+  parseHistoryToken(state, token, index, date) {
+    return state.remaining === 0
+      ? history.startChange(state, token)
+      : history.consumePath(state, token, index, date);
+  },
+
+  parseHistoryRecord(record, index) {
+    const [rawDate, ...tokens] = record.split("\0");
+    const date = rawDate.trim();
+    if (!date) return;
+    tokens.reduce(
+      (state, token) => history.parseHistoryToken(state, token, index, date),
+      history.initialState(),
+    );
+  },
+
+  buildRepoIndex(repo) {
+    const output = history.gitOutput(repo, [
       "log",
-      "--follow",
-      "--diff-filter=A",
-      "--format=%aI",
+      "--reverse",
+      "--format=%x1e%aI",
+      "--raw",
+      "--no-abbrev",
+      "--find-renames",
+      "--find-copies-harder",
+      "-z",
       "--",
-      rel,
-    ])
-      ?.split("\n")
-      .filter(Boolean)
-      .pop();
+      ...TEMPLATE_PATHS,
+    ]);
+    const records = output ? output.split("\x1e") : [];
+    return records.reduce((index, record) => {
+      history.parseHistoryRecord(record, index);
+      return index;
+    }, new Map());
+  },
 
-    const modified = runGit(repo, ["log", "-1", "--format=%aI", "--", rel]);
+  findDates(indexes, inputPath) {
+    return indexes
+      .flatMap(({ dates }) =>
+        history
+          .pathCandidates(inputPath)
+          .map((candidate) => dates.get(candidate)),
+      )
+      .find(Boolean);
+  },
 
-    if (!created && !modified) return null;
+  datesFor(indexes, inputPath) {
+    if (!inputPath) return null;
+    const result = history.findDates(indexes, inputPath);
+    return result
+      ? { published: result.published, updated: result.updated }
+      : null;
+  },
 
-    const published = created || modified;
-    const updated = modified || created;
+  createLookup(indexes, startedAt) {
+    return {
+      datesFor: (inputPath) => history.datesFor(indexes, inputPath),
+      updatedFor: (inputPath) => {
+        const dates = history.datesFor(indexes, inputPath);
+        return dates ? dates.updated : null;
+      },
+      stats: {
+        durationMs: performance.now() - startedAt,
+        paths: indexes.reduce((total, { dates }) => total + dates.size, 0),
+        repositories: indexes.length,
+      },
+    };
+  },
+});
 
-    return { published, updated };
-  };
-
-  const pairs = candidateRepos().flatMap((repo) =>
-    pathCandidates(inputPath).map((rel) => [repo, rel]),
-  );
-
-  for (const [repo, rel] of pairs) {
-    const result = datesForPath(repo, rel);
-    if (result) return result;
-  }
-
-  return null;
+/**
+ * @param {GitDateLookupOptions} [options]
+ * @returns {GitDateLookup}
+ */
+export const createGitDateLookup = (options = {}) => {
+  const startedAt = performance.now();
+  const cwd = options.cwd === undefined ? process.cwd() : options.cwd;
+  const configuredRepo =
+    options.configuredRepo === undefined
+      ? process.env.GIT_DATES_REPO
+      : options.configuredRepo;
+  const indexes = history.candidateRepos(cwd, configuredRepo).map((repo) => ({
+    repo,
+    dates: history.buildRepoIndex(repo),
+  }));
+  return history.createLookup(indexes, startedAt);
 };
 
+/** @param {string | null | undefined} iso */
 export const formatHuman = (iso) => {
   if (!iso) return "";
   const d = new Date(iso);
@@ -82,6 +270,7 @@ export const formatHuman = (iso) => {
   });
 };
 
+/** @param {string | null | undefined} iso */
 export const formatIso = (iso) => {
   if (!iso) return "";
   return new Date(iso).toISOString().slice(0, 10);

--- a/src/utils/sitemap.html
+++ b/src/utils/sitemap.html
@@ -8,10 +8,10 @@ eleventyExcludeFromCollections: true
   {%- for page in collections.all -%}
     {%- if page.data.no_index != true and page.url -%}
       {%- unless page.url contains "." -%}
-        {%- assign dates = page.inputPath | gitDates -%}
+        {%- assign updated = page.inputPath | gitUpdated -%}
         <url>
           <loc>{{ page.url | canonicalUrl | escape }}</loc>
-          {%- if dates %}<lastmod>{{ dates.updated | isoDate }}</lastmod>{% endif -%}
+          {%- if updated %}<lastmod>{{ updated | isoDate }}</lastmod>{% endif -%}
         </url>
       {%- endunless -%}
     {%- endif -%}

--- a/test/unit/eleventy/git-dates.test.js
+++ b/test/unit/eleventy/git-dates.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { configureGitDates } from "#eleventy/git-dates.js";
+import { createMockEleventyConfig } from "#test/test-utils.js";
+
+describe("git date filters", () => {
+  test("registers build refresh and public filters", () => {
+    const config = createMockEleventyConfig();
+    configureGitDates(config);
+
+    expect(typeof config.eventHandlers["eleventy.before"]).toBe("function");
+    expect(typeof config.filters.gitDates).toBe("function");
+    expect(typeof config.filters.gitUpdated).toBe("function");
+    expect(typeof config.filters.humanDate).toBe("function");
+    expect(typeof config.filters.isoDate).toBe("function");
+  });
+});

--- a/test/unit/media/image-cache-output.test.js
+++ b/test/unit/media/image-cache-output.test.js
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { materializeImageCache } from "#media/image-cache-output.js";
+import { withTempDirAsync } from "#test/test-utils.js";
+
+const originalGithubActions = process.env.GITHUB_ACTIONS;
+
+afterEach(() => {
+  if (originalGithubActions === undefined) {
+    delete process.env.GITHUB_ACTIONS;
+  } else {
+    process.env.GITHUB_ACTIONS = originalGithubActions;
+  }
+});
+
+const withCache = (name, testFn) =>
+  withTempDirAsync(name, async (tempDir) => {
+    const source = path.join(tempDir, "cache");
+    const destination = path.join(tempDir, "output");
+    const nested = path.join(source, "nested");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(source, "one.webp"), "one");
+    fs.writeFileSync(path.join(nested, "two.jpg"), "two");
+    await testFn({ destination, source });
+  });
+
+const inode = (filePath) => fs.statSync(filePath).ino;
+
+describe("image cache output", () => {
+  test("copies files outside GitHub Actions", () =>
+    withCache("image-cache-copy", ({ destination, source }) => {
+      delete process.env.GITHUB_ACTIONS;
+
+      const result = materializeImageCache({ destination, source });
+
+      expect(result).toMatchObject({ copied: 2, linked: 0, total: 2 });
+      expect(inode(path.join(destination, "one.webp"))).not.toBe(
+        inode(path.join(source, "one.webp")),
+      );
+      expect(
+        fs.readFileSync(path.join(destination, "nested/two.jpg"), "utf8"),
+      ).toBe("two");
+    }));
+
+  test("hard links files in GitHub Actions", () =>
+    withCache("image-cache-link", ({ destination, source }) => {
+      process.env.GITHUB_ACTIONS = "true";
+
+      const result = materializeImageCache({ destination, source });
+
+      expect(result).toMatchObject({ copied: 0, linked: 2, total: 2 });
+      expect(inode(path.join(destination, "nested/two.jpg"))).toBe(
+        inode(path.join(source, "nested/two.jpg")),
+      );
+    }));
+
+  test("falls back to copying when a hard link fails", () =>
+    withCache("image-cache-fallback", ({ destination, source }) => {
+      const result = materializeImageCache({
+        destination,
+        linkTree: () => false,
+        source,
+        useHardLinks: true,
+      });
+
+      expect(result).toMatchObject({ copied: 2, linked: 0, total: 2 });
+      const sourceStat = fs.statSync(path.join(source, "one.webp"));
+      const copiedStat = fs.statSync(path.join(destination, "one.webp"));
+      expect(copiedStat.ino).not.toBe(sourceStat.ino);
+    }));
+});

--- a/test/unit/scripts/build-metrics.test.js
+++ b/test/unit/scripts/build-metrics.test.js
@@ -1,63 +1,121 @@
 import { describe, expect, test } from "bun:test";
 import {
-  calculateAverageCpuUsage,
-  formatAverageCpuUsage,
-  getCpuSnapshot,
+  combinePhaseMetrics,
+  createPhaseMetrics,
+  formatPhaseMetrics,
 } from "#scripts/build-metrics.js";
 
-const cpu = (times) => ({
-  model: "test",
-  speed: 1000,
-  times,
+const usage = ({
+  maxRSS = 1024,
+  system = 500_000n,
+  user = 1_500_000n,
+} = {}) => ({
+  cpuTime: { system, user },
+  maxRSS,
 });
 
 describe("build metrics", () => {
-  test("aggregates cumulative times across logical CPUs", () => {
-    const snapshot = getCpuSnapshot([
-      cpu({ user: 100, nice: 10, sys: 20, idle: 300, irq: 5 }),
-      cpu({ user: 200, nice: 20, sys: 40, idle: 400, irq: 10 }),
-    ]);
-
-    expect(snapshot).toEqual({
-      idle: 700,
-      total: 1105,
-      logicalCpuCount: 2,
+  test("derives CPU utilization and Linux RSS for one phase", () => {
+    expect(
+      createPhaseMetrics({
+        logicalCpuCount: 4,
+        name: "Eleventy",
+        platform: "linux",
+        resourceUsage: usage(),
+        wallMs: 2000,
+      }),
+    ).toEqual({
+      cpuUtilization: 25,
+      effectiveCores: 1,
+      logicalCpuCount: 4,
+      maxRssBytes: 1024 ** 2,
+      name: "Eleventy",
+      systemCpuMs: 500,
+      totalCpuMs: 2000,
+      userCpuMs: 1500,
+      wallMs: 2000,
     });
   });
 
-  test("calculates average utilization over the snapshot interval", () => {
-    const usage = calculateAverageCpuUsage(
-      { idle: 600, total: 1000, logicalCpuCount: 2 },
-      { idle: 700, total: 1400, logicalCpuCount: 2 },
+  test("does not scale RSS on platforms where it is already bytes", () => {
+    expect(
+      createPhaseMetrics({
+        logicalCpuCount: 2,
+        name: "Pagefind",
+        platform: "darwin",
+        resourceUsage: usage({ maxRSS: 12_345 }),
+        wallMs: 1000,
+      }).maxRssBytes,
+    ).toBe(12_345);
+  });
+
+  test("combines sequential phase time and peak memory", () => {
+    const first = createPhaseMetrics({
+      logicalCpuCount: 4,
+      name: "Eleventy",
+      platform: "linux",
+      resourceUsage: usage({ maxRSS: 2048 }),
+      wallMs: 2000,
+    });
+    const second = createPhaseMetrics({
+      logicalCpuCount: 4,
+      name: "Pagefind",
+      platform: "linux",
+      resourceUsage: usage({ maxRSS: 1024, system: 0n, user: 500_000n }),
+      wallMs: 1000,
+    });
+
+    expect(combinePhaseMetrics("Total build", [first, second])).toMatchObject({
+      effectiveCores: 2.5 / 3,
+      maxRssBytes: 2 * 1024 ** 2,
+      name: "Total build",
+      systemCpuMs: 500,
+      totalCpuMs: 2500,
+      userCpuMs: 2000,
+      wallMs: 3000,
+    });
+  });
+
+  test("formats phase metrics with effective cores and normalized CPU", () => {
+    const metrics = createPhaseMetrics({
+      logicalCpuCount: 8,
+      name: "Eleventy",
+      platform: "linux",
+      resourceUsage: usage({ maxRSS: 1_572_864 }),
+      wallMs: 2000,
+    });
+
+    expect(formatPhaseMetrics(metrics)).toBe(
+      "Eleventy resources: 2.00s wall, 2.00s CPU " +
+        "(1.50s user + 0.50s sys, 1.00 effective cores, 12.5% of 8), " +
+        "1.50 GiB peak RSS",
     );
 
-    expect(usage).toEqual({
-      percentage: 75,
-      busyCores: 1.5,
-      logicalCpuCount: 2,
-    });
-  });
-
-  test("formats utilization as percentage and equivalent busy cores", () => {
     expect(
-      formatAverageCpuUsage({
-        percentage: 37.54,
-        busyCores: 3.0032,
-        logicalCpuCount: 8,
-      }),
-    ).toBe("Average system CPU usage: 37.5% (3.0 of 8 logical CPUs)");
-  });
-
-  test("rejects snapshots without elapsed CPU time", () => {
-    expect(() =>
-      calculateAverageCpuUsage(
-        { idle: 100, total: 200, logicalCpuCount: 2 },
-        { idle: 100, total: 200, logicalCpuCount: 2 },
+      formatPhaseMetrics(
+        createPhaseMetrics({
+          logicalCpuCount: 8,
+          name: "Pagefind",
+          platform: "linux",
+          resourceUsage: usage(),
+          wallMs: 2000,
+        }),
       ),
-    ).toThrow("invalid CPU time delta");
+    ).toEndWith("1.0 MiB peak RSS");
   });
 
-  test("rejects snapshots when no logical CPUs are reported", () => {
-    expect(() => getCpuSnapshot([])).toThrow("no logical CPUs were reported");
+  test("rejects missing resource data and empty phase sets", () => {
+    expect(() =>
+      createPhaseMetrics({
+        logicalCpuCount: 0,
+        name: "Eleventy",
+        resourceUsage: usage(),
+        wallMs: 1,
+      }),
+    ).toThrow("no logical CPUs");
+    expect(() =>
+      createPhaseMetrics({ name: "Eleventy", resourceUsage: null, wallMs: 1 }),
+    ).toThrow("Resource usage is unavailable");
+    expect(() => combinePhaseMetrics("Total build", [])).toThrow("empty set");
   });
 });

--- a/test/unit/utils/git-dates.test.js
+++ b/test/unit/utils/git-dates.test.js
@@ -3,13 +3,18 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { withTempDirAsync } from "#test/test-utils.js";
-import { datesFor, formatHuman, formatIso } from "#utils/git-dates.js";
+import {
+  createGitDateLookup,
+  formatHuman,
+  formatIso,
+} from "#utils/git-dates.js";
 
-const runGitInDir = (args, cwd) =>
+const runGitInDir = (args, cwd, env = {}) =>
   execFileSync("git", args, {
     cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
+    env: { ...process.env, ...env },
   }).trim();
 
 const initGitRepo = (dir) => {
@@ -18,10 +23,16 @@ const initGitRepo = (dir) => {
   runGitInDir(["config", "user.name", "Test"], dir);
 };
 
-const gitCommit = (dir, message) => {
+const gitCommit = (dir, message, date = "2025-01-01T10:00:00Z") => {
   runGitInDir(["add", "-A"], dir);
-  runGitInDir(["commit", "-m", message, "--allow-empty"], dir);
+  runGitInDir(["commit", "-m", message, "--allow-empty"], dir, {
+    GIT_AUTHOR_DATE: date,
+    GIT_COMMITTER_DATE: date,
+  });
 };
+
+const createLookup = (cwd) =>
+  createGitDateLookup({ cwd, configuredRepo: null });
 
 const withGitRepo =
   (testName, { fileName = "page.md", content = "content" } = {}) =>
@@ -29,16 +40,10 @@ const withGitRepo =
     withTempDirAsync(testName, async (tempDir) => {
       initGitRepo(tempDir);
       const filePath = path.join(tempDir, fileName);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
       fs.writeFileSync(filePath, content);
       gitCommit(tempDir, "add page");
-
-      const originalCwd = process.cwd();
-      try {
-        process.chdir(tempDir);
-        await testFn({ tempDir, filePath });
-      } finally {
-        process.chdir(originalCwd);
-      }
+      await testFn({ tempDir, filePath });
     });
 
 describe("git-dates", () => {
@@ -67,62 +72,129 @@ describe("git-dates", () => {
   });
 
   describe("datesFor", () => {
-    test("returns null for null/undefined input", () => {
-      expect(datesFor(null)).toBe(null);
-      expect(datesFor(undefined)).toBe(null);
-    });
+    test("returns null for null/undefined input", () =>
+      withGitRepo("git-dates-empty-input")(({ tempDir }) => {
+        const lookup = createLookup(tempDir);
+        expect(lookup.datesFor(null)).toBe(null);
+        expect(lookup.datesFor(undefined)).toBe(null);
+      }));
 
     test("returns null for untracked file", async () => {
       await withTempDirAsync("git-dates-untracked", async (tempDir) => {
         initGitRepo(tempDir);
         gitCommit(tempDir, "initial");
         fs.writeFileSync(path.join(tempDir, "untracked.md"), "content");
+        expect(createLookup(tempDir).datesFor("untracked.md")).toBe(null);
+      });
+    });
 
-        const originalCwd = process.cwd();
-        try {
-          process.chdir(tempDir);
-          expect(datesFor("untracked.md")).toBe(null);
-        } finally {
-          process.chdir(originalCwd);
-        }
+    test("ignores a candidate whose .git directory is invalid", async () => {
+      await withTempDirAsync("git-dates-invalid-repo", async (tempDir) => {
+        fs.mkdirSync(path.join(tempDir, ".git"));
+        expect(createLookup(tempDir).datesFor("page.md")).toBe(null);
       });
     });
 
     test("returns published and updated dates for committed file", () =>
-      withGitRepo("git-dates-committed", { fileName: "committed.md" })(() => {
-        const result = datesFor("committed.md");
-        expect(result).not.toBe(null);
-        expect(result.published).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-        expect(result.updated).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-      }));
+      withGitRepo("git-dates-committed", { fileName: "committed.md" })(
+        ({ tempDir }) => {
+          const result = createLookup(tempDir).datesFor("committed.md");
+          expect(result).not.toBe(null);
+          expect(result.published).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+          expect(result.updated).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        },
+      ));
 
     test("updated date changes after modification", () =>
       withGitRepo("git-dates-modified", { fileName: "modified.md" })(
         ({ tempDir, filePath }) => {
-          const before = datesFor("modified.md");
+          const before = createLookup(tempDir).datesFor("modified.md");
 
           fs.writeFileSync(filePath, "modified content");
-          gitCommit(tempDir, "modify page");
+          gitCommit(tempDir, "modify page", "2025-02-01T10:00:00Z");
 
-          const after = datesFor("modified.md");
+          const after = createLookup(tempDir).datesFor("modified.md");
           expect(after.published).toBe(before.published);
-          expect(new Date(after.updated).getTime()).toBeGreaterThanOrEqual(
+          expect(new Date(after.updated).getTime()).toBeGreaterThan(
             new Date(before.updated).getTime(),
           );
         },
       ));
 
     test("returns consistent results for same path", () =>
-      withGitRepo("git-dates-consistent", { fileName: "cached.md" })(() => {
-        const first = datesFor("cached.md");
-        const second = datesFor("cached.md");
-        expect(first.published).toBe(second.published);
-        expect(first.updated).toBe(second.updated);
-      }));
+      withGitRepo("git-dates-consistent", { fileName: "cached.md" })(
+        ({ tempDir }) => {
+          const lookup = createLookup(tempDir);
+          const first = lookup.datesFor("cached.md");
+          const second = lookup.datesFor("cached.md");
+          expect(first.published).toBe(second.published);
+          expect(first.updated).toBe(second.updated);
+          expect(lookup.updatedFor("cached.md")).toBe(first.updated);
+        },
+      ));
 
     test("strips leading ./ from path", () =>
-      withGitRepo("git-dates-dot-slash", { fileName: "dotpath.md" })(() => {
-        expect(datesFor("./dotpath.md")).not.toBe(null);
+      withGitRepo("git-dates-dot-slash", { fileName: "dotpath.md" })(
+        ({ tempDir }) => {
+          expect(createLookup(tempDir).datesFor("./dotpath.md")).not.toBe(null);
+        },
+      ));
+
+    test("follows renames without changing the published date", () =>
+      withGitRepo("git-dates-rename", { fileName: "old.md" })(
+        ({ tempDir, filePath }) => {
+          const renamedPath = path.join(tempDir, "new.md");
+          fs.renameSync(filePath, renamedPath);
+          gitCommit(tempDir, "rename page", "2025-02-01T10:00:00Z");
+
+          const lookup = createLookup(tempDir);
+          expect(lookup.datesFor("old.md")).toEqual({
+            published: "2025-01-01T10:00:00Z",
+            updated: "2025-02-01T10:00:00Z",
+          });
+          expect(lookup.datesFor("new.md")).toEqual({
+            published: "2025-01-01T10:00:00Z",
+            updated: "2025-02-01T10:00:00Z",
+          });
+          expect(lookup.updatedFor("new.md")).toBe("2025-02-01T10:00:00Z");
+        },
+      ));
+
+    test("follows copied template history", () =>
+      withGitRepo("git-dates-copy", { fileName: "source.md" })(
+        ({ tempDir, filePath }) => {
+          fs.copyFileSync(filePath, path.join(tempDir, "copy.md"));
+          gitCommit(tempDir, "copy page", "2025-02-01T10:00:00Z");
+
+          expect(createLookup(tempDir).datesFor("copy.md")).toEqual({
+            published: "2025-01-01T10:00:00Z",
+            updated: "2025-02-01T10:00:00Z",
+          });
+        },
+      ));
+
+    test("preserves the first published date when a file is re-added", () =>
+      withGitRepo("git-dates-readded", { fileName: "page.md" })(
+        ({ tempDir, filePath }) => {
+          fs.rmSync(filePath);
+          gitCommit(tempDir, "delete page", "2025-02-01T10:00:00Z");
+          fs.writeFileSync(filePath, "replacement");
+          gitCommit(tempDir, "re-add page", "2025-03-01T10:00:00Z");
+
+          expect(createLookup(tempDir).datesFor("page.md")).toEqual({
+            published: "2025-01-01T10:00:00Z",
+            updated: "2025-03-01T10:00:00Z",
+          });
+        },
+      ));
+
+    test("falls back from merged src paths to source repository paths", () =>
+      withGitRepo("git-dates-src-fallback", {
+        fileName: "products/page.md",
+      })(({ tempDir }) => {
+        expect(createLookup(tempDir).datesFor("src/products/page.md")).not.toBe(
+          null,
+        );
       }));
   });
 });


### PR DESCRIPTION
## Summary

- replace per-template Git date subprocesses with one indexed history scan per repository
- add the `gitUpdated` Liquid filter and use it for sitemap `lastmod` values
- hard-link the Eleventy image cache into build output on GitHub Actions, with a normal copy fallback
- report wall time, CPU time, effective cores, normalized CPU use, and peak RSS for Eleventy, Pagefind, and the total build
- add focused unit and integration coverage and protect the new modules with the strict-type ratchet

## Why

The existing `gitDates` filter runs Git commands for each rendered template, and large sites copy tens of thousands of cached image files into the output directory. The single host-wide CPU summary also hides which build phase is underutilizing the available runner capacity.

This change removes the repeated Git process overhead, avoids duplicate image data on GitHub Actions runners, and makes resource use attributable to individual build phases.

## Impact

Local builds retain normal image copies. GitHub Actions builds use hard links when the filesystem supports them and automatically fall back to copying otherwise. Published and updated dates retain the legacy behavior for modifications, renames, copies, deletions, and re-added files.

The new phase metrics measure the build subprocesses directly instead of sampling unrelated host activity.

## Benchmark

Using `../exhibition-game-hire` as the representative large site:

- indexed dates matched the legacy implementation for all 481 tracked Markdown, HTML, and Liquid files
- one index pass took 1.08s versus 6.38s for the legacy per-file Git commands
- 22,209 cached images were hard-linked in 0.14s with zero copies
- an 8-CPU placeholder-image build completed in 8.25s total
- Eleventy used 1.57 effective cores over 7.88s; Pagefind used 2.56 effective cores over 0.37s

The full Exhibition benchmark used `PLACEHOLDER_IMAGES=1` because the local Bun/GLib image stack crashes while decoding an SVG before the output hook. The content graph, Git history, cache materialization, and search phases were still exercised.

## Validation

- `env CI=1 bun run precommit --ci`
- `bun run build`
- `env GITHUB_ACTIONS=true bun run build`
- hard-link inode verification for template and Exhibition cache output
- exact Git-date comparison against the legacy per-file commands
