### PR TITLE
Tag guide pages with a property, keep property guides off the site-wide guide

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1815,6 +1815,14 @@ content:
           search: fields.name
           value: "{path}"
           label: "{fields.name}"
+      - name: property
+        label: Property
+        type: reference
+        options:
+          collection: properties
+          search: fields.name
+          value: "{path}"
+          label: "{fields.name}"
       - { name: order, type: number, label: Order }
       - { name: body, type: rich-text, label: Body }
       - { name: permalink, type: string, label: Permalink }

--- a/BLOCKS_LAYOUT.md
+++ b/BLOCKS_LAYOUT.md
@@ -1028,12 +1028,12 @@ Define FAQs inline via `items`, or omit to fall back to the page-level `faqs` ar
 
 ### `guide-categories`
 
-Displays guide categories collection.
+Displays the site-wide guide categories.
 
 **Component:** `block_guide_categories`
 **Template:** `src/_includes/design-system/blocks/guide-categories.html`
 
-No block-level parameters. Uses the global `collections.guide-categories`.
+No block-level parameters. Uses the global `collections.guide-categories`, minus any category with a `property` — those belong to a single property's guide and are listed by the `property-guides` block on the property page instead.
 
 ---
 
@@ -1066,7 +1066,7 @@ Lists the guide pages that belong to the current guide category (filtered via `g
 **Component:** `block_guide_pages_list`
 **Template:** `src/_includes/design-system/blocks/guide-pages-list.html`
 
-Guide-category-only block. No parameters. Renders nothing when there are no pages in the category.
+Guide-category-only block. No parameters. A guide page with a `property` is only listed when the category carries the same `property`. Renders nothing when there are no pages left to show.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"#utils/*": "./src/_lib/utils/*",
 		"#public/*": "./src/_lib/public/*",
 		"#menus/*": "./src/menus/*",
+		"#guide-categories/*": "./src/guide-categories/*",
 		"#test/*": "./test/*",
 		"#scripts/*": "./scripts/*",
 		"#bin/*": "./bin/*",

--- a/scripts/customise-cms/item-builders.js
+++ b/scripts/customise-cms/item-builders.js
@@ -201,6 +201,8 @@ export const buildGuidePagesFields = (config, fields) =>
         "guide-categories",
         false,
       ),
+    enabled("properties") &&
+      createReferenceField("property", "Property", "properties", false),
     COMMON_FIELDS.order,
     fields.body,
   ])(config);

--- a/src/_includes/design-system/blocks/guide-categories.html
+++ b/src/_includes/design-system/blocks/guide-categories.html
@@ -1,6 +1,16 @@
-{%- if collections.guide-categories.size > 0 -%}
+{%- comment -%}
+Guide-categories block - lists the guide categories that apply to the whole
+site. Categories tied to a single property are left out: they belong in that
+property's own guide, listed by the `property-guides` block on the property
+page. Renders nothing when every category belongs to a property.
+
+No block-level parameters.
+{%- endcomment -%}
+
+{%- assign general_categories = collections.guide-categories | generalGuides -%}
+{%- if general_categories.size > 0 -%}
 <ul class="guide-categories-list">
-  {%- for category in collections.guide-categories -%}
+  {%- for category in general_categories -%}
     <li>
       {%- if category.data.icon -%}
         <div class="guide-category-icon">{{ category.data.icon | renderIcon }}</div>

--- a/src/_includes/design-system/blocks/guide-pages-list.html
+++ b/src/_includes/design-system/blocks/guide-pages-list.html
@@ -1,12 +1,15 @@
 {%- comment -%}
 Guide-pages-list block - lists the guide pages that belong to the current
-guide category (filtered via `guidesByCategory`). Renders nothing when
-there are no pages in the category.
+guide category (filtered via `guidesByCategory`). Pages tagged with a property
+are only listed when the category belongs to that same property, so a general
+category never picks up one property's guides. Renders nothing when there are
+no pages left to show.
 
 Guide-category-only block. No block-level parameters.
 {%- endcomment -%}
 
-{%- assign guide_pages = collections.guide-pages | guidesByCategory: page.fileSlug -%}
+{%- assign category_pages = collections.guide-pages | guidesByCategory: page.fileSlug -%}
+{%- assign guide_pages = category_pages | guidesForProperty: property -%}
 {%- if guide_pages.size > 0 -%}
 <div class="container">
   <ul class="guide-list">

--- a/src/_lib/collections/guides.js
+++ b/src/_lib/collections/guides.js
@@ -25,20 +25,14 @@ const guideCategoriesByProperty = (guideCategories, propertySlug) =>
   indexByProperty(guideCategories)[propertySlug] ?? [];
 
 /**
- * Does this guide category or page apply to every property?
- * @param {import("#lib/types").EleventyCollectionItem} guide
- * @returns {boolean}
- */
-const isGeneralGuide = (guide) => !guide.data.property;
-
-/**
  * Guide categories or pages with no property of their own, i.e. the ones that
  * belong in a site-wide guide listing rather than a single property's guide.
  *
  * @param {import("#lib/types").EleventyCollectionItem[]} guides
  * @returns {import("#lib/types").EleventyCollectionItem[]}
  */
-const generalGuides = (guides) => guides.filter(isGeneralGuide);
+const generalGuides = (guides) =>
+  guides.filter((guide) => !guide.data.property);
 
 /**
  * Guide categories or pages to show within one property's guide: the ones
@@ -54,8 +48,8 @@ const guidesForProperty = (guides, propertySlug) => {
   if (!propertySlug) return generalGuides(guides);
   const slug = normaliseSlug(propertySlug);
   return guides.filter((guide) => {
-    const guideProperty = guide.data.property;
-    return !guideProperty || normaliseSlug(guideProperty) === slug;
+    const { property } = guide.data;
+    return !property || normaliseSlug(property) === slug;
   });
 };
 

--- a/src/_lib/collections/guides.js
+++ b/src/_lib/collections/guides.js
@@ -53,10 +53,10 @@ const generalGuides = (guides) => guides.filter(isGeneralGuide);
 const guidesForProperty = (guides, propertySlug) => {
   if (!propertySlug) return generalGuides(guides);
   const slug = normaliseSlug(propertySlug);
-  return guides.filter(
-    (guide) =>
-      isGeneralGuide(guide) || normaliseSlug(guide.data.property) === slug,
-  );
+  return guides.filter((guide) => {
+    const guideProperty = guide.data.property;
+    return !guideProperty || normaliseSlug(guideProperty) === slug;
+  });
 };
 
 /** @param {*} eleventyConfig */

--- a/src/_lib/collections/guides.js
+++ b/src/_lib/collections/guides.js
@@ -1,5 +1,6 @@
 import { addDataFilter } from "#eleventy/add-data-filter.js";
 import { createFieldIndexer } from "#utils/collection-utils.js";
+import { normaliseSlug } from "#utils/slug-utils.js";
 
 /** Index guides by category for O(1) lookups, cached per guides array */
 const indexByGuideCategory = createFieldIndexer("guide-category");
@@ -23,6 +24,41 @@ const guidesByCategory = (guidePages, categorySlug) =>
 const guideCategoriesByProperty = (guideCategories, propertySlug) =>
   indexByProperty(guideCategories)[propertySlug] ?? [];
 
+/**
+ * Does this guide category or page apply to every property?
+ * @param {import("#lib/types").EleventyCollectionItem} guide
+ * @returns {boolean}
+ */
+const isGeneralGuide = (guide) => !guide.data.property;
+
+/**
+ * Guide categories or pages with no property of their own, i.e. the ones that
+ * belong in a site-wide guide listing rather than a single property's guide.
+ *
+ * @param {import("#lib/types").EleventyCollectionItem[]} guides
+ * @returns {import("#lib/types").EleventyCollectionItem[]}
+ */
+const generalGuides = (guides) => guides.filter(isGeneralGuide);
+
+/**
+ * Guide categories or pages to show within one property's guide: the ones
+ * tagged with that property, plus the general ones that apply everywhere.
+ * With no property slug (a category that isn't tied to a property) only the
+ * general ones are left.
+ *
+ * @param {import("#lib/types").EleventyCollectionItem[]} guides
+ * @param {string | undefined | null} propertySlug
+ * @returns {import("#lib/types").EleventyCollectionItem[]}
+ */
+const guidesForProperty = (guides, propertySlug) => {
+  if (!propertySlug) return generalGuides(guides);
+  const slug = normaliseSlug(propertySlug);
+  return guides.filter(
+    (guide) =>
+      isGeneralGuide(guide) || normaliseSlug(guide.data.property) === slug,
+  );
+};
+
 /** @param {*} eleventyConfig */
 const configureGuides = (eleventyConfig) => {
   eleventyConfig.addFilter("guidesByCategory", guidesByCategory);
@@ -31,6 +67,14 @@ const configureGuides = (eleventyConfig) => {
     "guideCategoriesByProperty",
     guideCategoriesByProperty,
   );
+  addDataFilter(eleventyConfig, "generalGuides", generalGuides);
+  addDataFilter(eleventyConfig, "guidesForProperty", guidesForProperty);
 };
 
-export { configureGuides, guideCategoriesByProperty, guidesByCategory };
+export {
+  configureGuides,
+  generalGuides,
+  guideCategoriesByProperty,
+  guidesByCategory,
+  guidesForProperty,
+};

--- a/src/_lib/utils/block-schema/guide-categories.js
+++ b/src/_lib/utils/block-schema/guide-categories.js
@@ -3,7 +3,7 @@ export const type = "guide-categories";
 export const fields = {};
 
 export const docs = {
-  summary: "Displays guide categories collection.",
+  summary: "Displays the site-wide guide categories.",
   notes:
-    "No block-level parameters. Uses the global `collections.guide-categories`.",
+    "No block-level parameters. Uses the global `collections.guide-categories`, minus any category with a `property` — those belong to a single property's guide and are listed by the `property-guides` block on the property page instead.",
 };

--- a/src/_lib/utils/block-schema/guide-pages-list.js
+++ b/src/_lib/utils/block-schema/guide-pages-list.js
@@ -12,5 +12,5 @@ export const docs = {
   summary:
     "Lists the guide pages that belong to the current guide category (filtered via `guidesByCategory`).",
   notes:
-    "Guide-category-only block. No parameters. Renders nothing when there are no pages in the category.",
+    "Guide-category-only block. No parameters. A guide page with a `property` is only listed when the category carries the same `property`. Renders nothing when there are no pages left to show.",
 };

--- a/src/guide-categories/guide-categories.11tydata.js
+++ b/src/guide-categories/guide-categories.11tydata.js
@@ -1,18 +1,22 @@
 import { linkableContent } from "#utils/linkable-content.js";
-import { withNavigationAnchor } from "#utils/navigation-utils.js";
+import {
+  buildNavigation,
+  withNavigationAnchor,
+} from "#utils/navigation-utils.js";
 import { normaliseSlug } from "#utils/slug-utils.js";
 
 export default linkableContent("guide", {
   property: (data) =>
     data.property ? normaliseSlug(data.property) : undefined,
-  eleventyNavigation: (data) => {
-    if (data.eleventyNavigation) {
-      return withNavigationAnchor(data, data.eleventyNavigation);
-    }
-    return withNavigationAnchor(data, {
-      key: data.name,
-      parent: data.strings.guide_name,
-      order: data.link_order || 0,
-    });
-  },
+  eleventyNavigation: (data) =>
+    buildNavigation(data, (d) => {
+      // A category tied to one property belongs in that property's guide,
+      // reached from the property page, not in the site-wide navigation.
+      if (d.property) return false;
+      return withNavigationAnchor(d, {
+        key: d.name,
+        parent: d.strings.guide_name,
+        order: d.link_order || 0,
+      });
+    }),
 });

--- a/src/guide-pages/guide-pages.11tydata.js
+++ b/src/guide-pages/guide-pages.11tydata.js
@@ -7,6 +7,8 @@ export default linkableContent("guide", {
     data["guide-category"] ? normaliseSlug(data["guide-category"]) : undefined,
   parentGuideCategory: (data) =>
     data["guide-category"] ? normaliseSlug(data["guide-category"]) : undefined,
+  property: (data) =>
+    data.property ? normaliseSlug(data.property) : undefined,
   permalink: (data) => {
     if (data.permalink) return normalisePermalink(data.permalink);
     const category = data["guide-category"]

--- a/test/unit/collections/guides.test.js
+++ b/test/unit/collections/guides.test.js
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
   configureGuides,
+  generalGuides,
   guideCategoriesByProperty,
   guidesByCategory,
+  guidesForProperty,
 } from "#collections/guides.js";
 import {
   createMockEleventyConfig,
@@ -21,6 +23,15 @@ const guides = (pairs) =>
 /** Create a guide category with name and optional property */
 const guideCategory = (name, property) => ({
   data: { name, ...(property && { property }) },
+});
+
+/** Create a guide page inside a category, optionally tied to a property */
+const categorisedGuide = (name, property) => ({
+  data: {
+    name,
+    "guide-category": "about-the-accommodation",
+    ...(property && { property }),
+  },
 });
 
 describe("guides", () => {
@@ -122,6 +133,99 @@ describe("guides", () => {
     expect(mockConfig.filters.guideCategoriesByProperty).toBe(
       guideCategoriesByProperty,
     );
+  });
+
+  test("Adds generalGuides filter", () => {
+    const mockConfig = createMockEleventyConfig();
+
+    configureGuides(mockConfig);
+
+    expect(mockConfig.filters.generalGuides).toBe(generalGuides);
+  });
+
+  test("Adds guidesForProperty filter", () => {
+    const mockConfig = createMockEleventyConfig();
+
+    configureGuides(mockConfig);
+
+    expect(mockConfig.filters.guidesForProperty).toBe(guidesForProperty);
+  });
+});
+
+describe("generalGuides", () => {
+  test("Keeps only guides with no property of their own", () => {
+    const categories = [
+      guideCategory("Getting Started"),
+      guideCategory("Lighting the Fire", "seaside-cottage"),
+      guideCategory("Local Area"),
+    ];
+
+    expectResultTitles(generalGuides(categories), [
+      "Getting Started",
+      "Local Area",
+    ]);
+  });
+
+  test("Returns empty array when every guide belongs to a property", () => {
+    const categories = [
+      guideCategory("Getting Started", "seaside-cottage"),
+      guideCategory("Advanced", "mountain-lodge"),
+    ];
+
+    expect(generalGuides(categories)).toEqual([]);
+  });
+
+  test("Handles empty guides array", () => {
+    expect(generalGuides([])).toEqual([]);
+  });
+});
+
+describe("guidesForProperty", () => {
+  test("Keeps the property's own guides alongside the general ones", () => {
+    const guidePages = [
+      categorisedGuide("Lighting the Fire", "seaside-cottage"),
+      categorisedGuide("Hot Water", "mountain-lodge"),
+      categorisedGuide("Local Walks"),
+    ];
+
+    expectResultTitles(guidesForProperty(guidePages, "seaside-cottage"), [
+      "Lighting the Fire",
+      "Local Walks",
+    ]);
+  });
+
+  test("Matches a property reference written as a CMS path", () => {
+    const guidePages = [
+      categorisedGuide("Lighting the Fire", "properties/seaside-cottage.md"),
+      categorisedGuide("Hot Water", "mountain-lodge"),
+    ];
+
+    expectResultTitles(guidesForProperty(guidePages, "seaside-cottage"), [
+      "Lighting the Fire",
+    ]);
+  });
+
+  test("Drops every property-specific guide when there is no property", () => {
+    const guidePages = [
+      categorisedGuide("Lighting the Fire", "seaside-cottage"),
+      categorisedGuide("Local Walks"),
+    ];
+
+    expectResultTitles(guidesForProperty(guidePages, undefined), [
+      "Local Walks",
+    ]);
+  });
+
+  test("Does not modify the input array", () => {
+    const originalPages = [
+      categorisedGuide("Lighting the Fire", "seaside-cottage"),
+      categorisedGuide("Local Walks"),
+    ];
+    const pagesCopy = structuredClone(originalPages);
+
+    guidesForProperty(pagesCopy, "seaside-cottage");
+
+    expect(pagesCopy).toEqual(originalPages);
   });
 });
 

--- a/test/unit/guide-categories/guide-categories.11tydata.test.js
+++ b/test/unit/guide-categories/guide-categories.11tydata.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import guideCategoriesData from "#guide-categories/guide-categories.11tydata.js";
+
+const { eleventyComputed } = guideCategoriesData;
+
+const categoryData = (overrides = {}) => ({
+  name: "About the Accommodation",
+  page: { fileSlug: "about-the-accommodation", url: "/guide/about/" },
+  strings: { guide_name: "Guide" },
+  ...overrides,
+});
+
+describe("guide categories property", () => {
+  test("Normalises a CMS property reference to a slug", () => {
+    const data = categoryData({ property: "properties/roger-pot.md" });
+
+    expect(eleventyComputed.property(data)).toBe("roger-pot");
+  });
+
+  test("Leaves the property unset when the category has none", () => {
+    expect(eleventyComputed.property(categoryData())).toBeUndefined();
+  });
+});
+
+describe("guide categories eleventyNavigation", () => {
+  test("Builds a Guide navigation entry for a general category", () => {
+    expect(eleventyComputed.eleventyNavigation(categoryData())).toEqual({
+      key: "About the Accommodation",
+      parent: "Guide",
+      order: 0,
+    });
+  });
+
+  test("Suppresses navigation for a category tied to a property", () => {
+    const data = categoryData({ property: "roger-pot" });
+
+    expect(eleventyComputed.eleventyNavigation(data)).toBe(false);
+  });
+
+  test("Uses an explicit eleventyNavigation even with a property set", () => {
+    const eleventyNavigation = { key: "Guest Guide", parent: "Guide" };
+    const data = categoryData({ property: "roger-pot", eleventyNavigation });
+
+    expect(eleventyComputed.eleventyNavigation(data)).toEqual(
+      eleventyNavigation,
+    );
+  });
+});


### PR DESCRIPTION
## What

Guide categories could already be tied to a property, but nothing acted on it outside the `property-guides` block:

- the `guide-categories` block listed **every** category, property-specific or not, so one property's guest guide showed up as general site content on `/guide/`
- those categories also added themselves to the site-wide "Guide" navigation dropdown
- individual guide pages had no way to say which property they belonged to at all

On a multi-property site that means "Lighting a fire", "Hot water" and "Bottled water" for one cottage are listed as if they applied to all of them.

## Changes

- **Guide pages take a `property` reference**, the same one guide categories already take. Normalised to a slug in `guide-pages.11tydata.js`, and added to the guide-pages CMS collection.
- **`guide-categories` block** lists only categories with no property. Property-tied categories are reached from the property page via the existing `property-guides` block.
- **`guide-pages-list` block** shows a page tagged with a property only when the category carries the same property, so a general category never picks up one property's guides. A page with no property still shows everywhere.
- **A category tied to a property no longer adds itself to the navigation** (returns `false` from `eleventyNavigation`, same pattern as child categories in `categories.11tydata.js`), matching where its links now live.
- Two new filters in `#collections/guides.js`: `generalGuides` (drop anything with a property) and `guidesForProperty` (a property's own guides plus the general ones).

`.pages.yml`, `BLOCKS_LAYOUT.md` and the generated CMS types were regenerated from the changed schema/docs.

## Behaviour change

Sites that have property-tied guide categories **and** expected them in the global `/guide/` listing or the header navigation will see them drop out of both. That is the point of the change - the categories were already declaring which property they belong to. Sites with no `property` on any guide category are unaffected: every category is general, so both listings render exactly as before.

## Testing

- `bun test` - 3343 pass, 0 fail
- `bun run lint` - clean (only the pre-existing biome schema-version notice)
- New unit tests cover `generalGuides`, `guidesForProperty` (including a CMS-path reference like `properties/seaside-cottage.md`), the two new filter registrations, and the guide-category `property` computation and navigation suppression
- Built the garsdale-cottages client site against this branch: the Roger Pot guide categories leave `/guide/` and the header nav, the category pages still list their guides for guests, and the internal link check passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fn9PkWHBLNcKbxKxqfyiWQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guide pages can now be linked to specific properties.
  * Property-linked guides are filtered by matching property and category.
  * General guide categories and navigation are shown separately from property-specific content.
* **Documentation**
  * Updated guidance for property-specific categories and guide listings.
* **Tests**
  * Added coverage for property filtering, navigation behavior, slug matching, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->